### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.*.swp
+.DS_Store
+tmp


### PR DESCRIPTION
Looks like we missed this file when porting from the old repo.