### PR TITLE
Refreshing the ECS getting started guide with latest features

### DIFF
--- a/linkerd.io/content/1/getting-started/ecs.md
+++ b/linkerd.io/content/1/getting-started/ecs.md
@@ -39,6 +39,8 @@ The following components make up the system:
   provides a monitoring dashboard for all service traffic
 * `consul-server`: service discovery back-end, runs on a single EC2 instance
 
+{{< fig src="/images/ecs-linkerd-diagram.png" title="Linkerd in ECS" >}}
+
 ## Initial Setup
 
 First, launch a cluster of EC2 instances orchestrated by ECS. You can use a
@@ -168,6 +170,10 @@ Hello (172.31.20.160) World-V2 (172.31.19.35)!!
 By setting the `l5d-dtab` header, we instructed Linkerd to dynamically route all
 requests destined for `world` to `world-v2`.
 
+{{< fig src="/images/ecs-linkerd-routing.png" title="Linkerd request routing" >}} 
+ For more information, have a look at 
+[Dynamic Request Routing]({{% ref "/1/features/routing.md" %}}).
+
 ## linkerd-viz
 
 [`linkerd-viz`](https://github.com/linkerd/linkerd-viz) collects and displays
@@ -194,6 +200,10 @@ ssh -i "~/.ssh/$KEY_PAIR.pem" -L 127.0.0.1:3000:$VIZ_NODE:3000 ec2-user@$VIZ_NOD
 # view linkerd-viz (osx)
 open http://localhost:3000
 ```
+
+If everything worked correctly, we should see a dashboard like this:
+
+{{< fig src="/images/ecs-linkerd-viz.png" title="linkerd-viz in ECS" >}}
 
 ## Further reading
 

--- a/linkerd.io/content/1/getting-started/ecs.md
+++ b/linkerd.io/content/1/getting-started/ecs.md
@@ -41,153 +41,41 @@ The following components make up the system:
 
 {{< fig src="/images/ecs-linkerd-diagram.png" title="Linkerd in ECS" >}}
 
-Note that `linkerd`, `consul-agent`, and `consul-registrator` run on every ECS
-node. As of the writing of this guide, the ECS scheduler does not explicitly
-support this. Instead, we use an AWS Launch Configuration to bootstrap every ECS
-node with these three foundational services. We still boot these foundational
-services via an `aws ecs start-task` command, so they will be visible as running
-ECS containers.
-
 ## Initial Setup
 
-This guide assumes you have already configured AWS with the proper
-IAM, key pairs, and VPCs for an ECS cluster. For more information start here:
-http://docs.aws.amazon.com/AmazonECS/latest/developerguide/get-set-up-for-amazon-ecs.html
+First, launch a cluster of EC2 instances orchestrated by ECS. You can use a following CloudFormation template to create a VPC, security group, an autoscaling group for launching EC2 instances configured to connect to ECS. You can download or clone the [linkerd-examples repo](https://github.com/linkerd/linkerd-examples/tree/master/ecs) to get the template.
 
-Set a key pair you will use to access your instances, or omit the parameter to
-forego ssh access.
+You can open the CloudFormation console and deploy the `linkerd-ecs-cluster.yml` template or if you have the AWS CLI installed and configured run:
 
-```bash
-KEY_PAIR=<MY KEY PAIR NAME>
+```
+aws cloudformation deploy \
+  --stack-name linkerd-ecs-cluster \
+  --template-file linkerd-ecs-cluster.yml \
+  --capabilities CAPABILITY_IAM 
 ```
 
-Create a Security Group that allows outside access to the following:
+The next thing needed is a Consul server, and the `linkerd`, `consul-agent`, and `consul-registrator` daemons. These can be deployed using the `linkerd-daemons.yml` template. In order to launch this template you need to find your IP address, so that the template can configure the security group to allow you to access the Linkerd and Consul dashboard. The easiest way to do this is to type "what is my IP" into your search engine of choice.
 
-- ssh: 22
-- `linkerd` routing: 4140
-- `linkerd` admin UI: 9990
-- `linkerd-viz`: 3000
-- `consul-agent` and `consul-server` UI: 8500
-
-```bash
-GROUP_ID=$(aws ec2 create-security-group --group-name l5d-demo-sg --description "Linkerd Demo" | jq -r .GroupId)
-aws ec2 authorize-security-group-ingress --group-id $GROUP_ID \
-  --ip-permissions \
-  FromPort=22,IpProtocol=tcp,ToPort=22,IpRanges=[{CidrIp="0.0.0.0/0"}] \
-  FromPort=4140,IpProtocol=tcp,ToPort=4140,IpRanges=[{CidrIp="0.0.0.0/0"}] \
-  FromPort=9990,IpProtocol=tcp,ToPort=9990,IpRanges=[{CidrIp="0.0.0.0/0"}] \
-  FromPort=3000,IpProtocol=tcp,ToPort=3000,IpRanges=[{CidrIp="0.0.0.0/0"}] \
-  FromPort=8500,IpProtocol=tcp,ToPort=8500,IpRanges=[{CidrIp="0.0.0.0/0"}] \
-  IpProtocol=-1,UserIdGroupPairs=[{GroupId=$GROUP_ID}]
 ```
-
-The Security Group also opens every port between nodes. For a comprehensive list
-of all ports required for intra-node communication, reference the ECS Task
-Definition files, found in the
-[linkerd-examples repo](https://github.com/linkerd/linkerd-examples/tree/master/ecs)
-
-## Consul Server
-
-For demonstration purposes, we run a single Consul Server outside of the ECS
-cluster.
-
-```bash
-aws ec2 run-instances --image-id ami-7d664a1d \
-  --instance-type m4.xlarge \
-  --user-data file://consul-server-user-data.txt \
-  --placement AvailabilityZone=us-west-1a \
-  --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=l5d-demo-consul-server}]" \
-  --key-name $KEY_PAIR --security-group-ids $GROUP_ID
+aws cloudformation deploy \
+  --stack-name linkerd-daemons \
+  --parameter-overrides IPCidr=<your ip address>/32 \
+  --template-file linkerd-daemons.yml \
+  --capabilities CAPABILITY_IAM 
 ```
-
-We tag this instance with `l5d-demo-consul-server`. We will then reference this
-tag in the `consul-agent` config running on each ECS node. This enables the
-`consul-agent`'s to find `consul-server`.
-
-## ECS Cluster
-
-Create a new ECS cluster named `l5d-demo`
-
-```bash
-aws ecs create-cluster --cluster-name l5d-demo
-```
-
-We reference `l5d-demo` when bootstrapping our ECS nodes, to instruct them
-to join this ECS cluster we have just created.
-
-### Role Policy
-
-Create a Role Policy to allow ECS instances to start tasks and describe
-instances.
-
-```bash
-aws iam put-role-policy --role-name ecsInstanceRole --policy-name l5dDemoPolicy --policy-document file://ecs-role-policy.json
-```
-
-We require the `ecs:StartTask` ability because our Launch Configuration will
-start our three foundational tasks on each ECS node. We require the
-`ec2:DescribeInstances` ability because `consul-agent` will need to find
-`consul-server` via the `l5d-demo-consul-server` instance tag.
 
 ### Register Task Definitions
 
-These Task Definitions describe how we configure and boot all five applications.
-Note that `hello-world` describes three separate Docker containers, `hello`,
-`world`, and `world-v2`.
+Now we have an ECS cluster that is running all the daemons necessary for Linkerd to function. We can run a Linkerd enabled application in the cluster. First we need to register some task definitions that describe how to configure and boot the application.
 
 ```bash
-aws ecs register-task-definition --cli-input-json file://linkerd-task-definition.json
 aws ecs register-task-definition --cli-input-json file://linkerd-viz-task-definition.json
-aws ecs register-task-definition --cli-input-json file://consul-agent-task-definition.json
-aws ecs register-task-definition --cli-input-json file://consul-registrator-task-definition.json
 aws ecs register-task-definition --cli-input-json file://hello-world-task-definition.json
 ```
 
-### Create Launch Configuration
-
-This step defines a Launch Configuration. The
-[ecs-user-data.txt](https://github.com/linkerd/linkerd-examples/blob/master/ecs/ecs-user-data.txt)
-file instructs the Launch Configuration to configure and boot `linkerd`,
-`consul-agent`, and `consul-registrator` on each ECS node.
-
-```bash
-aws autoscaling create-launch-configuration \
-  --launch-configuration-name l5d-demo-lc \
-  --image-id ami-7d664a1d \
-  --instance-type m4.xlarge \
-  --user-data file://ecs-user-data.txt \
-  --iam-instance-profile ecsInstanceRole \
-  --security-groups $GROUP_ID \
-  --key-name $KEY_PAIR
-```
-
-Note the
-[ecs-user-data.txt](https://github.com/linkerd/linkerd-examples/blob/master/ecs/ecs-user-data.txt)
-file dynamically generated config files for each of `linkerd`, `consul-agent`,
-and `consul-registrator`, using data specific to the ECS Instance it is running
-on.
-
-### Create Auto Scaling Group
-
-This step actually creates the EC2 instances, based on the Launch Configuration
-defined above. Upon completion, we should have two ECS nodes, each running
-`linkerd`, `consul-agent`, and `consul-registrator`.
-
-```bash
-aws autoscaling create-auto-scaling-group \
-  --auto-scaling-group-name l5d-demo-asg \
-  --launch-configuration-name l5d-demo-lc \
-  --min-size 1 --max-size 3 --desired-capacity 2 \
-  --tags ResourceId=l5d-demo-asg,ResourceType=auto-scaling-group,Key=Name,Value=l5d-demo-ecs,PropagateAtLaunch=true \
-  --availability-zones us-west-1a
-```
-
-We name our instances `l5d-demo-ecs` so we can programmatically find them later
-on.
-
 ### Deploy hello-world
 
-Now that all our foundational services are deployed, we can deploy a sample app.
+Now that all our foundational services are deployed and the task definitions are available, we can deploy a sample app.
 The `hello-world` task is composed of a `hello` service, a `world` service, and
 a `world-v2` service. To demonstrate inter-service communication, we configure
 the `hello` service to call the `world` service, via `linkerd`.

--- a/linkerd.io/content/1/getting-started/ecs.md
+++ b/linkerd.io/content/1/getting-started/ecs.md
@@ -39,12 +39,10 @@ The following components make up the system:
   provides a monitoring dashboard for all service traffic
 * `consul-server`: service discovery back-end, runs on a single EC2 instance
 
-{{< fig src="/images/ecs-linkerd-diagram.png" title="Linkerd in ECS" >}}
-
 ## Initial Setup
 
 First, launch a cluster of EC2 instances orchestrated by ECS. You can use a
-CloudFormation template to create a VPC, security group, an autoscaling group
+CloudFormation template to create a VPC, security group, and autoscaling group
 for launching EC2 instances configured to connect to ECS. You can download or
 clone the [linkerd-examples repo](https://github.com/linkerd/linkerd-examples/tree/master/ecs)
 to get the template.
@@ -52,23 +50,25 @@ to get the template.
 Open the CloudFormation console and deploy the `linkerd-ecs-cluster.yml` template
 or if you have the AWS CLI installed and configured run:
 
-```
+```bash
+KEY_PAIR=<MY KEY PAIR NAME>
+
 aws cloudformation deploy \
   --stack-name linkerd-ecs-cluster \
   --template-file linkerd-ecs-cluster.yml \
-  --parameter-overrides KeyName=<your SSH key name> \
-  --capabilities CAPABILITY_IAM 
+  --parameter-overrides KeyName=$KEY_PAIR \
+  --capabilities CAPABILITY_IAM
 ```
 
 The next thing needed is a Consul server, and the `linkerd`, `consul-agent`,
 and `consul-registrator` daemons. These can be deployed using the
 `linkerd-daemons.yml` template:
 
-```
+```bash
 aws cloudformation deploy \
   --stack-name linkerd-daemons \
   --template-file linkerd-daemons.yml \
-  --capabilities CAPABILITY_IAM 
+  --capabilities CAPABILITY_IAM
 ```
 
 ### Register Task Definitions
@@ -100,19 +100,21 @@ Note that we have deployed two instances of `hello-world`, which results in two
 
 ## Test everything worked
 
-First we need to create an SSH tunnel to the cluster. The following commands will
-choose one of the EC2 hosts, and forward traffic on three local ports to three
-remote ports on the EC2 host:
+First we need to create an SSH tunnel to the cluster. The following commands
+will choose one of the EC2 hosts, and forward traffic on three local ports to
+three remote ports on the EC2 host:
 
-- Traffic to `localhost:9990` will go to the Linkerd dashboard on the remote host
-- Traffic to `localhost:8500` will go to the Consul admin dashboard on the remote host
-- Traffic to `localhost:4140` will go to the Linkerd HTTP proxy on the remote host
-- Traffic to `localhost:3000` will go to the Linkerd visualizer on the remote host (will launch this later)
+- Traffic to `localhost:9990` will go to the Linkerd dashboard on the remote
+  host
+- Traffic to `localhost:8500` will go to the Consul admin dashboard on the
+  remote host
+- Traffic to `localhost:4140` will go to the Linkerd HTTP proxy on the remote
+  host
 
 Note that if one of these four ports is already in use on your local machine
 you will either have to stop whatever software if using that port, or you can
-eliminate the port collision by replace the local port number with another unused
-port number in the SSH tunnel command as well as all subsequent commands.
+eliminate the port collision by replace the local port number with another
+unused port number in the SSH tunnel command as well as all subsequent commands.
 
 ```bash
 # Select an ECS node
@@ -123,33 +125,26 @@ ECS_NODE=$( \
     --output text \
 )
 
-ssh -f -i "~/.ssh/<your key name here>.pem" \
+ssh -i "~/.ssh/$KEY_PAIR.pem" \
     -L 127.0.0.1:4140:$ECS_NODE:4140 \
     -L 127.0.0.1:9990:$ECS_NODE:9990 \
-    -L 127.0.0.1:3000:$ECS_NODE:3000 \
     -L 127.0.0.1:8500:$ECS_NODE:8500 ec2-user@$ECS_NODE -N
 ```
 
-The SSH tunnel is now launched, and forked into the background. As long as it runs
-you will be able to access the remote Linkerd HTTP proxy, Linkerd Dashboard, and
-Consul dashboard as if they were on your local host:
+The SSH tunnel is now launched. As long as it runs you will be able to access
+the remote Linkerd HTTP proxy, Linkerd Dashboard, and Consul dashboard as if
+they were on your local host:
 
-```
+```bash
 # view Linkerd and Consul UIs (osx)
 open http://localhost:9990
 open http://localhost:8500
 ```
 
-You can kill this SSH tunnel process later using: 
+Lets use the tunnel to send some requests to the `helloworld` service via the
+Linkerd HTTP proxy:
 
 ```bash
-pkill -f ssh
-```
-
-For now though, lets use the tunnel to send some requests to the `helloworld`
-service via the Linkerd HTTP proxy:
-
-```
 # test routing via Linkerd
 http_proxy=localhost:4140 curl hello
 Hello (172.31.20.160) World (172.31.19.35)!!
@@ -173,11 +168,6 @@ Hello (172.31.20.160) World-V2 (172.31.19.35)!!
 By setting the `l5d-dtab` header, we instructed Linkerd to dynamically route all
 requests destined for `world` to `world-v2`.
 
-{{< fig src="/images/ecs-linkerd-routing.png" title="Linkerd request routing" >}}
-
-For more information, have a look at
-[Dynamic Request Routing]({{% ref "/1/features/routing.md" %}}).
-
 ## linkerd-viz
 
 [`linkerd-viz`](https://github.com/linkerd/linkerd-viz) collects and displays
@@ -197,15 +187,13 @@ aws ecs run-task --cluster l5d-demo --task-definition linkerd-viz --count 1
 TASK_ID=$(aws ecs list-tasks --cluster l5d-demo --family linkerd-viz --desired-status RUNNING --query taskArns[0] --output text)
 CONTAINER_INSTANCE=$(aws ecs describe-tasks --cluster l5d-demo --tasks $TASK_ID --query tasks[0].containerInstanceArn --output text)
 INSTANCE_ID=$(aws ecs describe-container-instances --cluster l5d-demo --container-instances $CONTAINER_INSTANCE --query containerInstances[0].ec2InstanceId --output text)
-ECS_NODE=$(aws ec2 describe-instances --instance-ids $INSTANCE_ID --query Reservations[*].Instances[0].PublicDnsName --output text)
+VIZ_NODE=$(aws ec2 describe-instances --instance-ids $INSTANCE_ID --query Reservations[*].Instances[0].PublicDnsName --output text)
+
+ssh -i "~/.ssh/$KEY_PAIR.pem" -L 127.0.0.1:3000:$VIZ_NODE:3000 ec2-user@$VIZ_NODE -N
 
 # view linkerd-viz (osx)
 open http://localhost:3000
 ```
-
-If everything worked correctly, we should see a dashboard like this:
-
-{{< fig src="/images/ecs-linkerd-viz.png" title="linkerd-viz in ECS" >}}
 
 ## Further reading
 

--- a/linkerd.io/content/1/getting-started/ecs.md
+++ b/linkerd.io/content/1/getting-started/ecs.md
@@ -113,7 +113,7 @@ three remote ports on the EC2 host:
 
 Note that if one of these four ports is already in use on your local machine
 you will either have to stop whatever software if using that port, or you can
-eliminate the port collision by replace the local port number with another
+eliminate the port collision by replacing the local port number with another
 unused port number in the SSH tunnel command as well as all subsequent commands.
 
 ```bash


### PR DESCRIPTION
This updates the ECS getting started guide to use CloudFormation templates for an easier LinkerD deploy experience, and simplifies and secures the deployment approach by using the latest daemon service support in ECS