### PR TITLE
Added some documentation for --ha flag to Linkerd2

### DIFF
--- a/linkerd.io/content/2/cli/inject.mmark
+++ b/linkerd.io/content/2/cli/inject.mmark
@@ -34,6 +34,8 @@ information as the table below:
 | `--proxy-image` | The linkerd proxy container image name (default "gcr.io/linkerd-io/proxy"). If you have modified (or made private) the Linkerd Proxy Init Container, you will adjust that here.  | `--proxy-image="quay.io/org/imagename"` |
 | `--proxy-log-level` | The log level for the proxy (default "warn,linkerd2_proxy=info"). The first value is the log level for the Init Container, and the second is the level for the Proxy Container. | `--proxy-log-level="info,linkerd2_proxy=debug"` |
 | `--proxy-uid` | Run the proxy under this user ID (default 2102) | `--proxy-uid=123` |
+| `--proxy-cpu` | Set the amount of CPU units that the sidecar requests | `--proxy-cpu=10m` |
+| `--proxy-memory` | Set the amount of Memory units that the sidecar requests | `--proxy-memory=50Mi` |
 | `--registry` | Docker registry to pull images from (default "gcr.io/linkerd-io") | `--registry="quay.io/ygrene` |
 | `--skip-inbound-ports` | Ports that should skip the proxy and send directly to the application (default []). IMPORTANT! If there is a port you do not want Linkerd proxying (for example SMTP port 25) you will _need_ to put it in this list.  | `--skip-inbound-ports=25,26,27` |
 | `--skip-outbound-ports` | Outbound ports that should skip the proxy (default []). Similarly to the above, if there are outbound ports you don't want leaving the pod from the `--outbound-port` (such as MySQL,) they need to be listed here. | `--skip-outbound-ports=25,3306,5432` |

--- a/linkerd.io/content/2/ha/_index.md
+++ b/linkerd.io/content/2/ha/_index.md
@@ -1,0 +1,31 @@
++++
+date = "2018-09-10T12:00:00-07:00"
+title = "Experimental: High Availabilty"
+[menu.l5d2docs]
+  name = "Experimental: High Availability"
+  weight = 13
++++
+
+Linkerd can be ran in High Availability or HA mode.
+
+This feature is **experimental** and it's only available in the [_edge_ release](../edge/).
+
+Here's a short description of what `--ha` does to the `linkerd` install.
+
+* Defaults the controller replicas to `3`
+* Set's sane `cpu` + `memory` requests to the linkerd control plane components.
+* Defaults to a sensible requests for the sidecar containers for the control plane + [_auto proxy injection_](../proxy-injection/).
+
+
+### Setup
+Because it's the control plane that requires the `ha` config, you'll need to use the `install` command with the `ha` flag.
+
+```bash
+linkerd install --ha | kubectl apply -f
+```
+
+You can also override the amount of controller replicas that you wish to run by passing in the `--controller-replicas` flag
+
+```bash
+linkerd install --ha --controller-replicas=2 | kubectl apply -f
+```


### PR DESCRIPTION
Started to add some basic HA for a new experimental flag to enable multiple controller replicas and sensible requests to the k8s deployments.

Pending on merge of https://github.com/linkerd/linkerd2/pull/1852.

Also not sure if this the right way to do documentation - I just didn't think it was fair that someone else had to document a feature that they maybe didn't build, so thought I should at least start it 👍 

Signed-off-by: Blam <ben@blam.sh>