### PR TITLE
Modify Prometheus docs to use Federation

### DIFF
--- a/linkerd.io/content/2/observability/prometheus.md
+++ b/linkerd.io/content/2/observability/prometheus.md
@@ -76,7 +76,8 @@ curl -G --data-urlencode 'match[]={job="linkerd-proxy"}' --data-urlencode 'match
 
 ### Prometheus JSON API
 
-Similar to the `/federate` API, Prometheus provides a JSON API to retrieve all metrics:
+Similar to the `/federate` API, Prometheus provides a JSON API to retrieve all
+metrics:
 
 ```bash
 curl http://prometheus.linkerd.svc.cluster.local:9090/api/v1/query?query=request_total
@@ -84,11 +85,15 @@ curl http://prometheus.linkerd.svc.cluster.local:9090/api/v1/query?query=request
 
 ## Querying Linkerd's `/metrics` endpoint
 
-If you want to query a Linkerd proxy directly, you can use its `/metrics` endpoint.
+If you want to query a Linkerd proxy directly, you can use its `/metrics`
+endpoint.
 
-Each Linkerd proxy, injected as a sidecar with your application, provides application-level metrics for all requests transiting through your application's pod.
+Each Linkerd proxy, injected as a sidecar with your application, provides
+application-level metrics for all requests transiting through your application's
+pod.
 
-For example, to view `/metrics` from a single Linkerd proxy, running in the `linkerd` namespace:
+For example, to view `/metrics` from a single Linkerd proxy, running in the
+`linkerd` namespace:
 
 ```bash
 kubectl port-forward -n linkerd $(kubectl -n linkerd get pods -l linkerd.io/control-plane-ns=linkerd -o jsonpath='{.items[0].metadata.name}') 4191:4191


### PR DESCRIPTION
The existing Prometheus docs instructed users to collect from Linkerd
proxies directly.

Instead provides instructions for using Prometheus federation, a simpler
and more robust approach.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

![screen shot 2018-11-29 at 2 03 28 pm](https://user-images.githubusercontent.com/236915/49254987-994cbd80-f3df-11e8-872a-2d53916f2e05.png)

![screen shot 2018-11-29 at 2 03 38 pm](https://user-images.githubusercontent.com/236915/49254994-9c47ae00-f3df-11e8-8bb5-72f033009879.png)
