### PR TITLE
Make all links relative

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,4 +93,4 @@ Describe the modifications you've made.
 [discourse]: https://discourse.linkerd.io/
 [issue]: https://github.com/linkerd/linkerd/issues/new
 [members]: https://github.com/orgs/linkerd/people
-[slack]: http://slack.linkerd.io/
+[slack]: https://slack.linkerd.io/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Source code for the linkerd.io website.
     brew install hugo
     ```
 
+1. Build site:
+
+    ```bash
+    ./build
+    ```
+
 1. Run Hugo in development mode:
 
     ```bash

--- a/linkerd.io/config.toml
+++ b/linkerd.io/config.toml
@@ -33,7 +33,7 @@ sectionPagesMenu = "main"
   name = "Blog"
   identifier = "blog"
   weight = 3
-  url = "http://blog.linkerd.io/"
+  url = "https://blog.linkerd.io/"
 
 [[menu.top]]
   name = "Enterprise"

--- a/linkerd.io/layouts/alias.html
+++ b/linkerd.io/layouts/alias.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><title>{{ .Page.RelPermalink }}</title><link rel="canonical" href="{{ .Page.RelPermalink }}"/><meta name="robots" content="noindex"><meta charset="utf-8" /><meta http-equiv="refresh" content="0; url={{ .Page.RelPermalink }}" /></head></html>

--- a/linkerd.io/layouts/index.html
+++ b/linkerd.io/layouts/index.html
@@ -6,7 +6,7 @@
           <h1>Ultralight service mesh for Kubernetes and beyond</h1>
           <p>Linkerd gives you observability, reliabilty, and security for your<br/> microservices &mdash; with no code change required.</p>
           <div class="header-button-group pb-3">
-            <a href="{{ ref . "/choose-your-platform.md" }}" class="btn btn-primary">Get started</a>
+            <a href="{{ relref . "/choose-your-platform.md" }}" class="btn btn-primary">Get started</a>
           </div>
           <div class="github-stat-buttons">
             <a class="github-button" href="https://github.com/linkerd/linkerd2" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star linkerd/linkerd2 on GitHub">Star</a>

--- a/linkerd.io/layouts/partials/cyp.html
+++ b/linkerd.io/layouts/partials/cyp.html
@@ -8,7 +8,7 @@
 
 <h4> Linkerd 2.x </h4>
 <div class="row justify-content-center">
-  <a href='{{ ref . "/2/getting-started/_index.md" }}' class="col-md-6">
+  <a href='{{ relref . "/2/getting-started/_index.md" }}' class="col-md-6">
     <img class="w-100" src="/images/get_started_kubernetes_rect@2x.png">
   </a>
 </div>
@@ -16,25 +16,25 @@
 <h4> Linkerd 1.x </h4>
 
 <div class="row">
-  <a href='{{ ref . "/1/getting-started/k8s.md" }}' class="col">
+  <a href='{{ relref . "/1/getting-started/k8s.md" }}' class="col">
     <img class="w-100" src="/images/get_started_kubernetes_rect@2x.png">
   </a>
 
-  <a href='{{ ref . "/1/getting-started/ecs.md" }}' class="col">
+  <a href='{{ relref . "/1/getting-started/ecs.md" }}' class="col">
     <img class="w-100" src="/images/get_started_ecs_rect@2x.png">
   </a>
 
   <div class="w-100"></div>
 
-  <a href='{{ ref . "/1/getting-started/dcos.md" }}' class="col">
+  <a href='{{ relref . "/1/getting-started/dcos.md" }}' class="col">
     <img class="w-100" src="/images/get_started_dcos_rect@2x.png">
   </a>
 
-  <a href='{{ ref . "/1/getting-started/docker.md" }}' class="col">
+  <a href='{{ relref . "/1/getting-started/docker.md" }}' class="col">
     <img class="w-100" src="/images/get_started_docker_rect@2x.png">
   </a>
 
-  <a href='{{ ref . "/1/getting-started/locally.md" }}' class="col">
+  <a href='{{ relref . "/1/getting-started/locally.md" }}' class="col">
     <img class="w-100" src="/images/get_started_local_rect@2x.png">
   </a>
 </div>

--- a/linkerd.io/layouts/partials/footer.html
+++ b/linkerd.io/layouts/partials/footer.html
@@ -5,7 +5,7 @@
 	<a href="https://github.com/linkerd/website">(edit this site)</a>
         <!-- <ul class="list-unstyled">
           <li>
-            <a href="{{ ref . "/2/getting-started/_index.md" }}"
+            <a href="{{ relref . "/2/getting-started/_index.md" }}"
               class="btn btn-outline-primary">
               Get Started
             </a>

--- a/linkerd.io/layouts/partials/get-started.html
+++ b/linkerd.io/layouts/partials/get-started.html
@@ -14,25 +14,25 @@
 </div>
 
 <div class="row pt-5">
-  <a href='{{ ref . "/1/getting-started/locally.md" }}' class="col">
+  <a href='{{ relref . "/1/getting-started/locally.md" }}' class="col">
     <img class="w-100" src="/images/get_started_local_rect@2x.png">
   </a>
 
-  <a href='{{ ref . "/1/getting-started/k8s.md" }}' class="col">
+  <a href='{{ relref . "/1/getting-started/k8s.md" }}' class="col">
     <img class="w-100" src="/images/get_started_kubernetes_rect@2x.png">
   </a>
 
-  <a href='{{ ref . "/1/getting-started/dcos.md" }}' class="col">
+  <a href='{{ relref . "/1/getting-started/dcos.md" }}' class="col">
     <img class="w-100" src="/images/get_started_dcos_rect@2x.png">
   </a>
 
   <div class="w-100"></div>
 
-  <a href='{{ ref . "/1/getting-started/docker.md" }}' class="col">
+  <a href='{{ relref . "/1/getting-started/docker.md" }}' class="col">
     <img class="w-100" src="/images/get_started_docker_rect@2x.png">
   </a>
 
-  <a href='{{ ref . "/1/getting-started/ecs.md" }}' class="col">
+  <a href='{{ relref . "/1/getting-started/ecs.md" }}' class="col">
     <img class="w-100" src="/images/get_started_ecs_rect@2x.png">
   </a>
 

--- a/linkerd.io/layouts/partials/nav.html
+++ b/linkerd.io/layouts/partials/nav.html
@@ -22,7 +22,7 @@
         </li>
         {{ end }}
         <li>
-          <a href="{{ ref . "/choose-your-platform.md" }}" class="btn btn-outline-light">Get Started</a>
+          <a href="{{ relref . "/choose-your-platform.md" }}" class="btn btn-outline-light">Get Started</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
Hugo's `ref` produces HTML with absolute links, causing many links
rendered via `make serve-linkerd.io` to point to linkerd.io rather than
localhost.

Replace `ref` with `relref`, also introduce an Alias partial, to override
default alias behavior with relative links.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>