### PR TITLE
Remove legacy `version` release channel.

### DIFF
--- a/versioncheck.linkerd.io/public/version.json
+++ b/versioncheck.linkerd.io/public/version.json
@@ -1,1 +1,1 @@
-{"version":"L5D2_STABLE_VERSION","stable":"L5D2_STABLE_VERSION","edge":"L5D2_EDGE_VERSION"}
+{"stable":"L5D2_STABLE_VERSION","edge":"L5D2_EDGE_VERSION"}


### PR DESCRIPTION
The `version` release channel supported pre-2.0 releases. It was also
unique in that the channel name was not part of the version string,
which prevented some helpful assumptions about the structure of release
channel versions in Linkerd.

Remove the `version` release channel. Going forward all channel versions
should be of the form:

```
{ "channel": "channel-version" }
```

Relates to linkerd/linkerd2#2130

Signed-off-by: Andrew Seigner <siggy@buoyant.io>