### PR TITLE
Update auto-inject docs for new opt-in behavior

### DIFF
--- a/linkerd.io/content/2/automatic-tls/_index.md
+++ b/linkerd.io/content/2/automatic-tls/_index.md
@@ -3,7 +3,7 @@ date = "2018-07-31T12:00:00-07:00"
 title = "Experimental: Automatic TLS"
 [menu.l5d2docs]
   name = "Experimental: Automatic TLS"
-  weight = 12
+  weight = 14
 +++
 
 Linkerd can be configured to automatically negotiate Transport Layer Security

--- a/linkerd.io/content/2/cli/_index.md
+++ b/linkerd.io/content/2/cli/_index.md
@@ -6,7 +6,7 @@ title = "Overview"
 [menu.l5d2docs]
   name = "CLI"
   identifier = "cli"
-  weight = 7
+  weight = 8
 +++
 
 The Linkerd CLI is the primary way to interact with Linkerd. It can install the

--- a/linkerd.io/content/2/cni/_index.md
+++ b/linkerd.io/content/2/cni/_index.md
@@ -6,7 +6,7 @@ aliases = [
 ]
 [menu.l5d2docs]
   name = "Experimental: CNI Plugin"
-  weight = 14
+  weight = 16
 +++
 
 Linkerd installs can be configured to run a

--- a/linkerd.io/content/2/debugging/_index.md
+++ b/linkerd.io/content/2/debugging/_index.md
@@ -6,7 +6,7 @@ aliases = [
 ]
 [menu.l5d2docs]
   name = "Debugging"
-  weight = 9
+  weight = 10
 +++
 
 This section assumes you've followed the steps in the

--- a/linkerd.io/content/2/edge/_index.md
+++ b/linkerd.io/content/2/edge/_index.md
@@ -3,7 +3,7 @@ date = "2018-07-31T12:00:00-07:00"
 title = "Release Channels"
 [menu.l5d2docs]
   name = "Release Channels"
-  weight = 15
+  weight = 17
 +++
 
 Linkerd 2.x publishes releases into multiple channels. This provides the option to

--- a/linkerd.io/content/2/faq/_index.md
+++ b/linkerd.io/content/2/faq/_index.md
@@ -6,7 +6,7 @@ title = "Frequently Asked Questions"
 [menu.l5d2docs]
   name = "Frequently Asked Questions"
   identifier = "faq"
-  weight = 8
+  weight = 9
 +++
 
 ## Setting up access to a Google Kubernetes Engine (GKE) cluster {#gke}

--- a/linkerd.io/content/2/get-involved/_index.md
+++ b/linkerd.io/content/2/get-involved/_index.md
@@ -3,7 +3,7 @@ date = "2018-07-31T12:00:00-07:00"
 title = "Get Involved"
 [menu.l5d2docs]
   name = "Get Involved"
-  weight = 16
+  weight = 18
 +++
 
 We're really excited to welcome Contributors to [Linkerd](https://github.com/linkerd/linkerd2)!

--- a/linkerd.io/content/2/ingress/_index.md
+++ b/linkerd.io/content/2/ingress/_index.md
@@ -3,7 +3,7 @@ date = "2018-11-19T12:00:00-07:00"
 title = "Ingress"
 [menu.l5d2docs]
   name = "Ingress"
-  weight = 11
+  weight = 12
 +++
 
 While Linkerd does not handle ingress itself, it does work alongside your

--- a/linkerd.io/content/2/observability/_index.md
+++ b/linkerd.io/content/2/observability/_index.md
@@ -1,13 +1,12 @@
 +++
 date = "2018-09-17T08:00:00-07:00"
 title = "Overview"
-weight = 1
 [sitemap]
   priority = 1.0
 [menu.l5d2docs]
   name = "Observability"
   identifier = "observability"
-  weight = 10
+  weight = 11
 +++
 
 Linkerd provides extensive observability functionality. It automatically

--- a/linkerd.io/content/2/proxy-injection/_index.md
+++ b/linkerd.io/content/2/proxy-injection/_index.md
@@ -6,301 +6,159 @@ title = "Experimental: Automatic Proxy Injection"
   weight = 13
 +++
 
-Linkerd can be configured to automatically inject the data plane proxy into your service.
+Linkerd can be configured to automatically inject the data plane proxy into your
+service. This is an alternative to needing to run the
+[`linkerd inject`](../cli/inject/) command.
 
-This feature is **experimental** and it's only available in the [_edge_ release](../edge/).
-
-Here are some feature highlights:
-
-* Integrate with the Linkerd CA to let Linkerd manage the secure, private connection between the Kubernetes API Server and the proxy injector webhook.
-* All required permissions are defined in the new `linkerd-linkerd-proxy-injector` cluster role, separated from the cluster role of the control plane.
-* When a new deployment is created, the Linkerd proxy will be automatically injected if:
-  * the namespace has the `linkerd.io/auto-inject: enabled` label or
-  * the namespace isn't labeled with the `linkerd.io/auto-inject` label.
-* Namespaces that are labeled with the `linkerd.io/auto-inject: disabled` are ignored.
-* Within "enabled" namespaces, deployments with pods that are labeled with `linkerd.io/auto-inject: disabled` or `linkerd.io/auto-inject: completed` are ignored.
-
-The feature has the following limitations:
-
-* Currently, the auto-proxy injection only works with deployment workload. It doesn't work with other workload like StatefulSet, DaemonSet, Pod etc.
+This feature is **experimental**, since it only supports Deployment-type
+workloads. It will be removed from experimental once all workloads are supported
+([tracked here](https://github.com/linkerd/linkerd2/issues/1751)).
 
 ## Installation
-The automatic proxy injection is implemented with an [admission webhook](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#admission-webhooks), which requires Kubernetes 1.9 or later. To get started, verify that your kube-apiserver has the `admission-control` flag and the admissionregistration API enabled.
+
+Automatic proxy injection is implemented with an
+[admission webhook](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#admission-webhooks),
+which requires your cluster to have the `admissionregistration.k8s.io/v1beta1`
+API enabled. To verify, run:
 
 ```bash
-kubectl api-versions | grep admissionregistration
+$ kubectl api-versions | grep admissionregistration
 admissionregistration.k8s.io/v1beta1
 ```
 
-The proxy auto-injection feature is disabled by default. To enable it, you must install Linkerd with the `--tls=optional` and `--proxy-auto-inject` flags.
+Automatic proxy injection is disabled by default when installing the Linkerd
+control plane. To enable it, set the `--proxy-auto-inject` flag, as follows:
+
 ```bash
-$ linkerd install --tls=optional --proxy-auto-inject | kubectl apply -f -
+$ linkerd install --proxy-auto-inject | kubectl apply -f -
 ```
 
-Run `check` to make sure everything is ready.
-```bash
-$ linkerd check
-kubernetes-api: can initialize the client..................................[ok]
-kubernetes-api: can query the Kubernetes API...............................[ok]
-kubernetes-api: is running the minimum Kubernetes API version..............[ok]
-linkerd-api: control plane namespace exists................................[ok]
-linkerd-api: control plane pods are ready..................................[ok]
-linkerd-api: can initialize the client.....................................[ok]
-linkerd-api: can query the control plane API...............................[ok]
-linkerd-api[kubernetes]: control plane can talk to Kubernetes..............[ok]
-linkerd-api[prometheus]: control plane can talk to Prometheus..............[ok]
-linkerd-version: can determine the latest version..........................[ok]
-linkerd-version: cli is up-to-date.........................................[ok]
-linkerd-version: control plane is up-to-date...............................[ok]
+This will add a new `linkerd-proxy-injector` service and deployment to the
+control plane, to serve the admission webhook.
 
-Status check results are [ok]
+```bash
+$ kubectl -n linkerd get deploy/linkerd-proxy-injector svc/linkerd-proxy-injector
+NAME                                           DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+deployment.extensions/linkerd-proxy-injector   1         1         1            1           3m
+
+NAME                             TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)   AGE
+service/linkerd-proxy-injector   ClusterIP   10.100.40.55   <none>        443/TCP   3m
 ```
 
-A new proxy-injector deployment are added to the control plane.
-```bash
-$ kubectl -n linkerd get deploy
-NAME             DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-ca               1         1         1            1           4m
-controller       1         1         1            1           4m
-grafana          1         1         1            1           4m
-prometheus       1         1         1            1           4m
-proxy-injector   1         1         1            1           4m
-web              1         1         1            1           4m
+## Configuration
 
-$ kubectl -n linkerd get po
-NAME                              READY     STATUS    RESTARTS   AGE
-ca-54d574c7b5-gr4kw               2/2       Running   0          4m
-controller-5858d6df74-d652q       5/5       Running   0          4m
-grafana-757cdf976-wt88x           2/2       Running   0          4m
-prometheus-6bc8f55ff8-qgjlc       2/2       Running   0          4m
-proxy-injector-55dd8f7bd7-srnps   2/2       Running   1          4m
-web-6584749d68-c6nnj              2/2       Running   0          4m
+Automatic proxy injection  will only be performed on pods with the
+`linkerd.io/inject: enabled` annotation, or on pods in namespaces with the
+`linkerd.io/inject: enabled` annotation. If a namespace has been configured to
+use auto-injection, it's also possible to disabled injection for a given pod in
+that namespace using the `linkerd.io/inject: disabled` annotation.
+
+For example, to add automatic proxy injection for all all pods in the
+`sample-inject-enabled-ns` namespace, setup the namespace to include the
+`linkerd.io/inject: enabled` annotation, as follows:
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sample-inject-enabled-ns
+  annotations:
+    linkerd.io/inject: enabled
 ```
 
-## Injection
-### Namespace
+After applying that namespace configuration to your cluster, you can test automatic
+proxy injection by creating a new deployment in that namespace, by running:
 
-Namespaces that are labeled `linkerd.io/auto-inject: disabled` are ignored.
 ```bash
-$ kubectl create ns disabled
-namespace "disabled" created
-
-$ kubectl label ns disabled linkerd.io/auto-inject=disabled
-namespace "disabled" labeled
-
-$ kubectl -n disabled run nginx --image=nginx --port=80
-deployment.apps "nginx" created
-
-$ kubectl -n disabled get deploy
-NAME      DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-nginx     1         1         1            1           6s
-
-$ kubectl -n disabled get po
-NAME                     READY     STATUS    RESTARTS   AGE
-nginx-666865b5dd-zcgsc   1/1       Running   0          8s
+$ kubectl -n sample-inject-enabled-ns run helloworld --image=buoyantio/helloworld
+deployment.apps "helloworld" created
 ```
 
-The proxy sidecar container will be auto-injected into namespaces that are either **not** labeled with `linkerd.io/auto-inject` or labeled with `linkerd.io/auto-inject: enabled`.
+Verify that the deployment's pod includes a `linkerd-proxy` container:
+
 ```bash
-$ kubectl create ns enabled
-namespace "enabled" created
-
-$ kubectl label ns enabled linkerd.io/auto-inject=enabled
-namespace "enabled" labeled
-
-$ kubectl -n enabled run nginx --image=nginx --port=80
-deployment.apps "nginx" created
-
-$ kubectl -n enabled get deploy
-NAME      DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-nginx     1         1         1            0           6s
-
-$ kubectl -n enabled get po
-NAME                     READY     STATUS    RESTARTS   AGE
-nginx-7fdb79d8db-n2qjs   2/2       Running   0          7s
-
-$ kubectl -n enabled logs nginx-7fdb79d8db-n2qjs linkerd-proxy
-INFO linkerd2_proxy using controller at Some(HostAndPort { host: DnsName(DnsName(DNSName("proxy-api.linkerd.svc.cluster.local"))), port: 8086 })
-INFO linkerd2_proxy routing on V4(127.0.0.1:4140)
-INFO linkerd2_proxy proxying on V4(0.0.0.0:4143) to None
-INFO linkerd2_proxy serving Prometheus metrics on V4(0.0.0.0:4191)
-INFO linkerd2_proxy protocol detection disabled for inbound ports {25, 3306}
-INFO linkerd2_proxy protocol detection disabled for outbound ports {25, 3306}
-INFO admin={bg=tls-config} linkerd2_proxy::transport::tls::config loaded TLS configuration.
-INFO admin={bg=resolver} linkerd2_proxy::transport::connect DNS resolved DnsName(DnsName(DNSName("proxy-api.linkerd.svc.cluster.local"))) to 10.96.77.89
-INFO admin={bg=tls-config} linkerd2_proxy::transport::tls::config loaded TLS configuration.
-INFO admin={bg=tls-config} linkerd2_proxy::transport::tls::config loaded TLS configuration.
-INFO admin={bg=resolver} linkerd2_proxy::transport::connect DNS resolved DnsName(DnsName(DNSName("proxy-api.linkerd.svc.cluster.local"))) to 10.96.77.89
-
-$ kubectl create ns unlabeled
-namespace "unlabeled" created
-
-$ kubectl -n unlabeled run nginx --image=nginx --port=80
-deployment.apps "nginx" created
-
-$ kubectl -n unlabeled get deploy
-NAME      DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-nginx     1         1         1            0           13s
-
-$ kubectl -n unlabeled get po
-NAME                     READY     STATUS    RESTARTS   AGE
-nginx-74cc99c95c-jvhk8   2/2       Running   0          21s
-
-$ kubectl -n unlabeled logs nginx-74cc99c95c-jvhk8 linkerd-proxy
-INFO linkerd2_proxy using controller at Some(HostAndPort { host: DnsName(DnsName(DNSName("proxy-api.linkerd.svc.cluster.local"))), port: 8086 })
-INFO linkerd2_proxy routing on V4(127.0.0.1:4140)
-INFO linkerd2_proxy proxying on V4(0.0.0.0:4143) to None
-INFO linkerd2_proxy serving Prometheus metrics on V4(0.0.0.0:4191)
-INFO linkerd2_proxy protocol detection disabled for inbound ports {25, 3306}
-INFO linkerd2_proxy protocol detection disabled for outbound ports {25, 3306}
-INFO admin={bg=tls-config} linkerd2_proxy::transport::tls::config loaded TLS configuration.
-INFO admin={bg=resolver} linkerd2_proxy::transport::connect DNS resolved DnsName(DnsName(DNSName("proxy-api.linkerd.svc.cluster.local"))) to 10.96.77.89
-INFO admin={bg=tls-config} linkerd2_proxy::transport::tls::config loaded TLS configuration.
-INFO admin={bg=tls-config} linkerd2_proxy::transport::tls::config loaded TLS configuration.
-INFO admin={bg=resolver} linkerd2_proxy::transport::connect DNS resolved DnsName(DnsName(DNSName("proxy-api.linkerd.svc.cluster.local"))) to 10.96.77.89
-INFO admin={bg=tls-config} linkerd2_proxy::transport::tls::config loaded TLS configuration.
-INFO admin={bg=tls-config} linkerd2_proxy::transport::tls::config loaded TLS configuration.
-INFO admin={bg=resolver} linkerd2_proxy::transport::connect DNS resolved DnsName(DnsName(DNSName("proxy-api.linkerd.svc.cluster.local"))) to 10.96.77.89
+$ kubectl -n sample-inject-enabled-ns get po -l run=helloworld \
+  -o jsonpath='{.items[0].spec.containers[*].name}'
+helloworld linkerd-proxy
 ```
 
-### Deployment
-Deployments with pods that are labeled `linkerd.io/auto-inject: disabled` and `linkerd.io/auto-inject: completed` are ignored. Note that these are the pod template labels i.e. `spec.template.metadata.labels`, not the deployment's labels.
+It's also possible to explicitly configure auto-injection for all pods in a
+deployment, even if that deployment is running in a namespace that has not been
+configured for auto-inject. To do this, add the `linkerd.io/inject: enabled`
+annotation to the deployment's pod spec. For example, create a new deployment in
+the `default` namespace, as follows:
 
-When the webhook receives a request to mutate a pod's specification, it also checks the pod's container specification to ensure no proxy sidecar has already been injected. If a pod already has the proxy sidecar container, it will be ignored.
-```bash
-$ kubectl -n unlabeled run nginx-disabled --image=nginx --port=80 --labels="linkerd.io/auto-inject=disabled"
-deployment.apps "nginx-disabled" created
-
-$ kubectl -n unlabeled run nginx-completed --image=nginx --port=80 --labels="linkerd.io/auto-inject=completed"
-deployment.apps "nginx-completed" created
-
-$ kubectl -n unlabeled get deploy
-NAME              DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-nginx-completed   1         1         1            1           2m
-nginx-disabled    1         1         1            1           3m
-
-$ kubectl -n unlabeled get po -L linkerd.io/auto-inject
-NAME                               READY     STATUS    RESTARTS   AGE       AUTO-INJECT
-nginx-completed-6cb5f6f6cf-fq5lk   1/1       Running   0          56s       completed
-nginx-disabled-776768bbc9-z8dcf    1/1       Running   0          1m        disabled
+```yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: helloworld-enabled
+  labels:
+    run: helloworld-enabled
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: helloworld-enabled
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: enabled
+      labels:
+        run: helloworld-enabled
+    spec:
+      containers:
+      - name: helloworld-enabled
+        image: buoyantio/helloworld
 ```
 
-Deployments with pods that are labeled `linkerd.io/auto-inject: enabled` or unlabeled will be auto-injected with the proxy init and sidecar containers.
+If you apply that configuration to your cluster, you can verify that the
+deployment's pod is injected with a `linkerd-proxy` container:
+
 ```bash
-$ kubectl -n unlabeled run nginx-enabled --image=nginx --port=80 --labels="linkerd.io/auto-inject=enabled"
-deployment.apps "nginx-enabled" created
-
-$ kubectl -n unlabeled run nginx-unlabeled --image=nginx --port=80
-deployment.apps "nginx-unlabeled" created
-
-$ kubectl -n unlabeled get deploy
-NAME               DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-nginx-enabled      1         1         1            1           15s
-nginx-unlabeled    1         1         1            0           11s
-
-$ kubectl -n unlabeled get po -L linkerd.io/auto-inject
-NAME                               READY     STATUS    RESTARTS   AGE       AUTO-INJECT
-nginx-completed-6cb5f6f6cf-fq5lk   1/1       Running   0          1m        completed
-nginx-disabled-776768bbc9-z8dcf    1/1       Running   0          2m        disabled
-nginx-enabled-6658556d5c-ljchj     2/2       Running   0          2m        enabled
-nginx-unlabeled-79f6ccb579-sss8k   2/2       Running   0          1m
+$ kubectl get po -l run=helloworld-enabled \
+  -o jsonpath='{.items[0].spec.containers[*].name}'
+helloworld-enabled linkerd-proxy
 ```
 
-## Validation
-The TLS secrets of the _enabled_ and _unlabeled_ deployments are created.
-```bash
-$ kubectl -n unlabeled get secret
-NAME                                         TYPE                                  DATA      AGE
-default-token-w75rf                          kubernetes.io/service-account-token   3         45m
-nginx-enabled-deployment-tls-linkerd-io      Opaque                                2         2m
-nginx-unlabeled-deployment-tls-linkerd-io    Opaque                                2         1m
+Additionally, it's possible to disable auto-injection for all pods in a
+deployment, even if that deployment is running in a namespace that has been
+configured for auto-inject. To do this, add the `linkerd.io/inject: disabled`
+annotation to the deployment's pod spec. For example, create a new deployment in
+the `sample-inject-enabled-ns` namespace that you created above, as follows:
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: helloworld-disabled
+  namespace: sample-inject-enabled-ns
+  labels:
+    run: helloworld-disabled
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: helloworld-disabled
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: disabled
+      labels:
+        run: helloworld-disabled
+    spec:
+      containers:
+      - name: helloworld-disabled
+        image: buoyantio/helloworld
 ```
 
-Check the proxy's logs of the newly created _enabled_ and _unlabeled_ pods.
-```bash
-$ kubectl -n unlabeled logs nginx-enabled-6658556d5c-ljchj linkerd-proxy
-INFO linkerd2_proxy using controller at Some(HostAndPort { host: DnsName(DnsName(DNSName("proxy-api.linkerd.svc.cluster.local"))), port: 8086 })
-INFO linkerd2_proxy routing on V4(127.0.0.1:4140)
-INFO linkerd2_proxy proxying on V4(0.0.0.0:4143) to None
-INFO linkerd2_proxy serving Prometheus metrics on V4(0.0.0.0:4191)
-INFO linkerd2_proxy protocol detection disabled for inbound ports {25, 3306}
-INFO linkerd2_proxy protocol detection disabled for outbound ports {25, 3306}
-INFO admin={bg=tls-config} linkerd2_proxy::transport::tls::config loaded TLS configuration.
-INFO admin={bg=resolver} linkerd2_proxy::transport::connect DNS resolved DnsName(DnsName(DNSName("proxy-api.linkerd.svc.cluster.local"))) to 10.99.83.97
-INFO admin={bg=tls-config} linkerd2_proxy::transport::tls::config loaded TLS configuration.
-INFO admin={bg=tls-config} linkerd2_proxy::transport::tls::config loaded TLS configuration.
-INFO admin={bg=resolver} linkerd2_proxy::transport::connect DNS resolved DnsName(DnsName(DNSName("proxy-api.linkerd.svc.cluster.local"))) to 10.99.83.97
-INFO admin={bg=tls-config} linkerd2_proxy::transport::tls::config loaded TLS configuration.
-INFO admin={bg=tls-config} linkerd2_proxy::transport::tls::config loaded TLS configuration.
-INFO admin={bg=resolver} linkerd2_proxy::transport::connect DNS resolved DnsName(DnsName(DNSName("proxy-api.linkerd.svc.cluster.local"))) to 10.99.83.97
+If you apply that configuration to your cluster, you can verify that the
+deployment's pod is not injected with a `linkerd-proxy` container, as follows:
 
-$ kubectl -n unlabeled logs nginx-unlabeled-79f6ccb579-sss8k linkerd-proxy
-INFO linkerd2_proxy using controller at Some(HostAndPort { host: DnsName(DnsName(DNSName("proxy-api.linkerd.svc.cluster.local"))), port: 8086 })
-INFO linkerd2_proxy routing on V4(127.0.0.1:4140)
-INFO linkerd2_proxy proxying on V4(0.0.0.0:4143) to None
-INFO linkerd2_proxy serving Prometheus metrics on V4(0.0.0.0:4191)
-INFO linkerd2_proxy protocol detection disabled for inbound ports {25, 3306}
-INFO linkerd2_proxy protocol detection disabled for outbound ports {25, 3306}
-INFO admin={bg=tls-config} linkerd2_proxy::transport::tls::config loaded TLS configuration.
-INFO admin={bg=resolver} linkerd2_proxy::transport::connect DNS resolved DnsName(DnsName(DNSName("proxy-api.linkerd.svc.cluster.local"))) to 10.99.83.97
-INFO admin={bg=tls-config} linkerd2_proxy::transport::tls::config loaded TLS configuration.
-INFO admin={bg=tls-config} linkerd2_proxy::transport::tls::config loaded TLS configuration.
-INFO admin={bg=resolver} linkerd2_proxy::transport::connect DNS resolved DnsName(DnsName(DNSName("proxy-api.linkerd.svc.cluster.local"))) to 10.99.83.97
-INFO admin={bg=tls-config} linkerd2_proxy::transport::tls::config loaded TLS configuration.
-INFO admin={bg=tls-config} linkerd2_proxy::transport::tls::config loaded TLS configuration.
-INFO admin={bg=resolver} linkerd2_proxy::transport::connect DNS resolved DnsName(DnsName(DNSName("proxy-api.linkerd.svc.cluster.local"))) to 10.99.83.97
-INFO admin={bg=tls-config} linkerd2_proxy::transport::tls::config loaded TLS configuration.
-INFO admin={bg=tls-config} linkerd2_proxy::transport::tls::config loaded TLS configuration.
-INFO admin={bg=resolver} linkerd2_proxy::transport::connect DNS resolved DnsName(DnsName(DNSName("proxy-api.linkerd.svc.cluster.local"))) to 10.99.83.97
+```bash
+$ kubectl -n sample-inject-enabled-ns get po -l run=helloworld-disabled \
+  -o jsonpath='{.items[0].spec.containers[*].name}'
+helloworld-disabled
 ```
 
-Take a look at the stats and try generating some simple traffic.
-```bash
-$ linkerd stat deployments -n unlabeled
-NAME               MESHED   SUCCESS   RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   TLS
-nginx-completed      0/1         -     -             -             -             -     -
-nginx-disabled       0/1         -     -             -             -             -     -
-nginx-enabled        1/1   100.00%   0.1rps           0ms           0ms           0ms    0%
-nginx-unlabeled      1/1   100.00%   0.0rps           1ms           1ms           1ms    0%
-```
-
-Further testing...
-Delete the _enabled_ pod. The new pod should still have the proxy sidecar.
-```bash
-$ kubectl -n unlabeled delete po nginx-enabled-6658556d5c-ljchj
-pod "nginx-enabled-6658556d5c-ljchj" deleted
-
-$ kubectl -n unlabeled get po
-NAME                               READY     STATUS        RESTARTS   AGE
-nginx-completed-6cb5f6f6cf-fq5lk   1/1       Running       0          10m
-nginx-disabled-776768bbc9-z8dcf    1/1       Running       0          10m
-nginx-enabled-6658556d5c-8v6c4     2/2       Running       0          28s
-nginx-enabled-6658556d5c-ljchj     0/2       Terminating   0          10m
-nginx-unlabeled-79f6ccb579-sss8k   2/2       Running       0          10m
-```
-
-Set the image of the _enabled_ deployment to a different version.
-```bash
-$ kubectl -n unlabeled set image deployment nginx-enabled nginx-enabled=nginx:1.9.1
-deployment.apps "nginx" image updated
-
-$ kubectl -n unlabeled describe deploy nginx-enabled
-...
-   nginx-enabled:
-    Image:        nginx:1.9.1
-    Port:         80/TCP
-    Host Port:    0/TCP
-    Environment:  <none>
-    Mounts:       <none>
-
-$ kubectl -n unlabeled get po
-NAME                               READY     STATUS    RESTARTS   AGE
-...
-nginx-enabled-65f8d5c4fb-kh5rr     2/2       Running   0          1m
-```
-The new pod should still have the proxy sidecar.
-
-## Debugging
-If the proxy sidecar isn't automatically injected, take a look at the proxy-injector logs. If the proxy-injector emits a series of `remote error: tls: bad certificate` errors, then the CA bundle defind in the webhook's mutating webhook configuration has gone out-of-sync with the CA certificate generated by the CA controller. The easiest resolution is to delete the proxy-injector pod and let it recreate its mutating webhook configuration.
-
-Additionally, the proxy-injector container take the `-log-level` argument which can be set to generate more verbose logs output.
+Note that no `linkerd-proxy` container is present.

--- a/linkerd.io/content/2/proxy-injection/_index.md
+++ b/linkerd.io/content/2/proxy-injection/_index.md
@@ -1,8 +1,8 @@
 +++
 date = "2018-09-10T12:00:00-07:00"
-title = "Experimental: Automatic Proxy Injection"
+title = "Automatic Proxy Injection"
 [menu.l5d2docs]
-  name = "Experimental: Automatic Proxy Injection"
+  name = "Automatic Proxy Injection"
   weight = 13
 +++
 
@@ -14,10 +14,6 @@ plane is always present and configured correctly, regardless of how pods are
 deployed. Note that as of Linkerd 2.2, this feature is opt-in, and you must
 explicitly annotate namespaces or pods as described below to enable
 auto-injection.
-
-This feature is **experimental**, since it only supports Deployment-type
-workloads. It will be removed from experimental once all workloads are supported
-([tracked here](https://github.com/linkerd/linkerd2/issues/1751)).
 
 ## Installation
 

--- a/linkerd.io/content/2/proxy-injection/_index.md
+++ b/linkerd.io/content/2/proxy-injection/_index.md
@@ -8,7 +8,12 @@ title = "Experimental: Automatic Proxy Injection"
 
 Linkerd can be configured to automatically inject the data plane proxy into your
 service. This is an alternative to needing to run the
-[`linkerd inject`](../cli/inject/) command.
+[`linkerd inject`](../cli/inject/) command. Moving injection to the cluster
+side, rather than relying on client side behavior, can help ensure that the data
+plane is always present and configured correctly, regardless of how pods are
+deployed. Note that as of Linkerd 2.2, this feature is opt-in, and you must
+explicitly annotate namespaces or pods as described below to enable
+auto-injection.
 
 This feature is **experimental**, since it only supports Deployment-type
 workloads. It will be removed from experimental once all workloads are supported
@@ -50,10 +55,10 @@ service/linkerd-proxy-injector   ClusterIP   10.100.40.55   <none>        443/TC
 Automatic proxy injection  will only be performed on pods with the
 `linkerd.io/inject: enabled` annotation, or on pods in namespaces with the
 `linkerd.io/inject: enabled` annotation. If a namespace has been configured to
-use auto-injection, it's also possible to disabled injection for a given pod in
+use auto-injection, it's also possible to disable injection for a given pod in
 that namespace using the `linkerd.io/inject: disabled` annotation.
 
-For example, to add automatic proxy injection for all all pods in the
+For example, to add automatic proxy injection for all pods in the
 `sample-inject-enabled-ns` namespace, setup the namespace to include the
 `linkerd.io/inject: enabled` annotation, as follows:
 

--- a/linkerd.io/content/2/supported-protocols/_index.md
+++ b/linkerd.io/content/2/supported-protocols/_index.md
@@ -3,7 +3,7 @@ date = "2018-07-31T12:00:00-07:00"
 title = "Supported Protocols"
 [menu.l5d2docs]
   name = "Supported Protocols"
-  weight = 6
+  weight = 7
 +++
 
 Linkerd is capable of proxying all TCP traffic, including WebSockets and HTTP


### PR DESCRIPTION
This branch updates the proxy auto-inject doc to reflect the change in targeting behavior that's happening in linkerd/linkerd2#2209. As part of this change, I've trimmed down the content on the page a bit, to hopefully make it easier to follow.

Fixes #112.