### PR TITLE
Add note for 2.1.0 upgrade regarding the CLI

### DIFF
--- a/linkerd.io/content/2/upgrade/_index.md
+++ b/linkerd.io/content/2/upgrade/_index.md
@@ -32,7 +32,7 @@ upgrade. Perform the upgrade in the following order:
       --ignore-not-found
     ```
 
-1. [Upgrade the CLI](#upgrade-the-cli)
+1. [Upgrade the CLI](#upgrade-the-cli). Note that right after upgrading the CLI, most of its commands will fail. You can only rely on the `linkerd install` command to complete the following steps, and only after doing so will the CLI be fully usable again.
 
 1. [Upgrade the control plane](#upgrade-the-control-plane)
 


### PR DESCRIPTION
Fixes #104 

Not only won't `linkerd version` work after upgrading the CLI (before upgrading the CP), but also `check`, `dashboard`, `stats`, etc.