### PR TITLE
Fix some typos in docs

### DIFF
--- a/linkerd.io/content/1/tutorials/part-nine.md
+++ b/linkerd.io/content/1/tutorials/part-nine.md
@@ -56,7 +56,7 @@ Also deploy Linkerd:
 kubectl apply -f https://raw.githubusercontent.com/BuoyantIO/linkerd-examples/master/k8s-daemonset/k8s/linkerd-grpc.yml
 ```
 
-Once Kubernetes provisions an external LoadBalancer IP for Linkerd, we can do some test requests! Note that the examples in these blog posts assume k8s is running on GKE (e.g. external loadbalancer IPs are availble, no CNI plugins are being used). Slight modifications may be needed for other environments—see our [Flavors of Kubernetes](https://discourse.linkerd.io/t/flavors-of-kubernetes/53) help page for environments like Minikube or CNI configurations with Calico/Weave.
+Once Kubernetes provisions an external LoadBalancer IP for Linkerd, we can do some test requests! Note that the examples in these blog posts assume k8s is running on GKE (e.g. external loadbalancer IPs are available, no CNI plugins are being used). Slight modifications may be needed for other environments—see our [Flavors of Kubernetes](https://discourse.linkerd.io/t/flavors-of-kubernetes/53) help page for environments like Minikube or CNI configurations with Calico/Weave.
 
 We’ll use the helloworld-client provided by the `hello world` [docker image](https://hub.docker.com/r/buoyantio/helloworld/) in order to send test gRPC requests to our `hello world` service:
 

--- a/linkerd.io/content/2/ha/_index.md
+++ b/linkerd.io/content/2/ha/_index.md
@@ -1,6 +1,6 @@
 +++
 date = "2018-09-10T12:00:00-07:00"
-title = "Experimental: High Availabilty"
+title = "Experimental: High Availability"
 [menu.l5d2docs]
   name = "Experimental: High Availability"
   weight = 14

--- a/linkerd.io/content/2/observability/proxy-metrics.md
+++ b/linkerd.io/content/2/observability/proxy-metrics.md
@@ -168,7 +168,7 @@ which have closed.
 currently open.
 * `tcp_write_bytes_total`: A counter of the total number of sent bytes. This is
 updated when the connection closes.
-* `tcp_read_bytes_total`: A counter of the total number of recieved bytes. This
+* `tcp_read_bytes_total`: A counter of the total number of received bytes. This
 is updated when the connection closes.
 * `tcp_connection_duration_ms`: A histogram of the duration of the lifetime of a
 connection, in milliseconds. This is updated when the connection closes.


### PR DESCRIPTION
1. "availble" to "available" in line 59.
2. "Availabilty" to "Availability" in line 3.
3. "recieved" to "received" in line 171.