### PR TITLE
Fix missing label in booksapp config

### DIFF
--- a/run.linkerd.io/public/booksapp.yml
+++ b/run.linkerd.io/public/booksapp.yml
@@ -160,6 +160,7 @@ spec:
     metadata:
       labels:
         app: traffic
+        project: booksapp
     spec:
       dnsPolicy: ClusterFirst
       containers:


### PR DESCRIPTION
This is a follow-up to #110, which adds a project=booksapp label to the traffic pod, since I noticed it was missing. Relates to BuoyantIO/booksapp#13.