### PR TITLE
Add static checks page to redirect anchor links

### DIFF
--- a/linkerd.io/content/2/cli/check.md
+++ b/linkerd.io/content/2/cli/check.md
@@ -32,7 +32,7 @@ linkerd check --proxy
 ```
 
 For resolutions to common `linkerd check` failures, have a look at
-[Frequently Asked Questions](/2/faq).
+[Resolutions for linkerd check failures](/2/installing/#check).
 
 ## Flags
 

--- a/linkerd.io/content/2/cli/routes.mmark
+++ b/linkerd.io/content/2/cli/routes.mmark
@@ -4,7 +4,7 @@ title = "Routes"
 description = "The routes command displays per-route service metrics."
 weight = 3
 [menu.l5d2docs]
-  name = "Routes"
+  name = "routes"
   parent = "cli"
 +++
 

--- a/linkerd.io/static/checks/index.html
+++ b/linkerd.io/static/checks/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=https://linkerd.io/2/installing/#check">
+    <script type="text/javascript">
+    window.onload = function() {
+      window.location.href = window.location.origin + "/2/installing/" + window.location.hash;
+    }
+    </script>
+    <title>Linkerd Check Redirection</title>
+  </head>
+  <body>
+    If you are not redirected automatically, follow this <a href='https://linkerd.io/2/installing/#check'>link</a>.
+  </body>
+</html>


### PR DESCRIPTION
The `linkerd check` command references linkerd.io URLs with anchors, for
example:
https://linkerd.io/2/faq/#pre-k8s

Moving the location of `/2/faq` breaks these URLs, and hugo does not
persist anchors across alias redirects.

This change introduces a static page, allowing us to maintan aliases for
`linkerd check` output that preserves anchors.

Example redirect:
https://linkerd.io/checks/#pre-k8s -> https://linkerd.io/2/faq/#pre-k8s

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

This change was motivated by #146.