### PR TITLE
Fix ordering on feature index page

### DIFF
--- a/linkerd.io/content/2/features/_index.md
+++ b/linkerd.io/content/2/features/_index.md
@@ -1,10 +1,10 @@
 +++
 date = "2018-09-10T12:00:00-07:00"
-title = "Features"
+title = "Overview"
 [menu.l5d2docs]
   name = "Features"
+  identifier = "features"
   weight = 3
 +++
 
 {{% sectiontoc "cli" %}}
-

--- a/linkerd.io/content/2/features/automatic-tls.md
+++ b/linkerd.io/content/2/features/automatic-tls.md
@@ -1,9 +1,10 @@
 +++
 date = "2018-07-31T12:00:00-07:00"
 title = "Experimental: Automatic TLS"
+weight = 11
 [menu.l5d2docs]
   name = "Experimental: Automatic TLS"
-  parent = "Features"
+  parent = "features"
 aliases = [
   "/2/automatic-tls/"
 ]

--- a/linkerd.io/content/2/features/automatic-tls.md
+++ b/linkerd.io/content/2/features/automatic-tls.md
@@ -1,6 +1,7 @@
 +++
 date = "2018-07-31T12:00:00-07:00"
 title = "Experimental: Automatic TLS"
+description = "Linkerd can be configured to automatically negotiate Transport Layer Security (TLS) for application communication."
 weight = 11
 [menu.l5d2docs]
   name = "Experimental: Automatic TLS"

--- a/linkerd.io/content/2/features/cni.md
+++ b/linkerd.io/content/2/features/cni.md
@@ -1,12 +1,13 @@
 +++
 date = "2018-07-31T12:00:00-07:00"
 title = "Experimental: CNI Plugin"
+weight = 12
+[menu.l5d2docs]
+  name = "Experimental: CNI Plugin"
+  parent = "features"
 aliases = [
   "/2/cni-plugin/"
 ]
-[menu.l5d2docs]
-  name = "Experimental: CNI Plugin"
-  parent = "Features"
 +++
 
 Linkerd installs can be configured to run a

--- a/linkerd.io/content/2/features/cni.md
+++ b/linkerd.io/content/2/features/cni.md
@@ -1,6 +1,7 @@
 +++
 date = "2018-07-31T12:00:00-07:00"
 title = "Experimental: CNI Plugin"
+description = "Linkerd can be configured to run a CNI plugin that rewrites each pod's iptables rules automatically."
 weight = 12
 [menu.l5d2docs]
   name = "Experimental: CNI Plugin"

--- a/linkerd.io/content/2/features/dashboard.md
+++ b/linkerd.io/content/2/features/dashboard.md
@@ -1,9 +1,10 @@
 +++
 date = "2018-11-19T12:00:00-07:00"
 title = "Dashboard and Grafana"
+weight = 9
 [menu.l5d2docs]
   name = "Dashboard and Grafana"
-  parent = "Features"
+  parent = "features"
 +++
 
 In addition to its [command-line interface](../../cli), Linkerd provides a web
@@ -38,5 +39,3 @@ The dashboards that are provided out of the box include:
 {{< gallery-item src="/images/screenshots/grafana-health.png" title="Linkerd Health" >}}
 
 {{< /gallery >}}
-
-

--- a/linkerd.io/content/2/features/dashboard.md
+++ b/linkerd.io/content/2/features/dashboard.md
@@ -1,6 +1,7 @@
 +++
 date = "2018-11-19T12:00:00-07:00"
 title = "Dashboard and Grafana"
+description = "Linkerd provides a web dashboard, as well as pre-configured Grafana dashboards."
 weight = 9
 [menu.l5d2docs]
   name = "Dashboard and Grafana"

--- a/linkerd.io/content/2/features/ha.md
+++ b/linkerd.io/content/2/features/ha.md
@@ -1,9 +1,10 @@
 +++
 date = "2018-09-10T12:00:00-07:00"
 title = "Experimental: High Availability"
+weight = 10
 [menu.l5d2docs]
   name = "Experimental: High Availability"
-  parent = "Features"
+  parent = "features"
 aliases = [
   "/2/ha/"
 ]

--- a/linkerd.io/content/2/features/ha.md
+++ b/linkerd.io/content/2/features/ha.md
@@ -1,6 +1,7 @@
 +++
 date = "2018-09-10T12:00:00-07:00"
 title = "Experimental: High Availability"
+description = "Linkerd can be configured to run its control plane in High Availability (HA) mode."
 weight = 10
 [menu.l5d2docs]
   name = "Experimental: High Availability"

--- a/linkerd.io/content/2/features/http-grpc.md
+++ b/linkerd.io/content/2/features/http-grpc.md
@@ -1,6 +1,7 @@
 +++
 date = "2018-07-31T12:00:00-07:00"
 title = "HTTP, HTTP/2, and gRPC Proxying"
+description = "Linkerd will automatically enable advanced features (including metrics, load balancing, retries, and more) for HTTP, HTTP/2, and gRPC connections."
 weight = 1
 [menu.l5d2docs]
   name = "HTTP, HTTP/2, and gRPC Proxying"

--- a/linkerd.io/content/2/features/http-grpc.md
+++ b/linkerd.io/content/2/features/http-grpc.md
@@ -1,10 +1,10 @@
 +++
 date = "2018-07-31T12:00:00-07:00"
 title = "HTTP, HTTP/2, and gRPC Proxying"
+weight = 1
 [menu.l5d2docs]
   name = "HTTP, HTTP/2, and gRPC Proxying"
-  parent = "Features"
-  weight = "1"
+  parent = "features"
 +++
 
 Linkerd can proxy all TCP connections, and will automatically enable advanced

--- a/linkerd.io/content/2/features/ingress.md
+++ b/linkerd.io/content/2/features/ingress.md
@@ -1,6 +1,7 @@
 +++
 date = "2018-11-19T12:00:00-07:00"
 title = "Ingress"
+description = "Linkerd can work alongside your ingress controller of choice."
 weight = 6
 [menu.l5d2docs]
   name = "Ingress"

--- a/linkerd.io/content/2/features/ingress.md
+++ b/linkerd.io/content/2/features/ingress.md
@@ -1,10 +1,10 @@
 +++
 date = "2018-11-19T12:00:00-07:00"
 title = "Ingress"
+weight = 6
 [menu.l5d2docs]
   name = "Ingress"
-  parent = "Features"
-  weight = "6"
+  parent = "features"
 aliases = [
   "/2/ingress/"
 ]

--- a/linkerd.io/content/2/features/load-balancing.md
+++ b/linkerd.io/content/2/features/load-balancing.md
@@ -1,9 +1,10 @@
 +++
 date = "2018-11-19T12:00:00-07:00"
-title = "Load balancing"
+title = "Load Balancing"
+description = "Linkerd automatically load balances requests across all destination endpoints on HTTP, HTTP/2, and gRPC connections."
 weight = 8
 [menu.l5d2docs]
-  name = "Load balancing"
+  name = "Load Balancing"
   parent = "features"
 +++
 

--- a/linkerd.io/content/2/features/load-balancing.md
+++ b/linkerd.io/content/2/features/load-balancing.md
@@ -1,10 +1,10 @@
 +++
 date = "2018-11-19T12:00:00-07:00"
 title = "Load balancing"
+weight = 8
 [menu.l5d2docs]
   name = "Load balancing"
-  parent = "Features"
-  weight = "8"
+  parent = "features"
 +++
 
 For HTTP, HTTP/2, and gRPC connections, Linkerd automatically load balances
@@ -28,5 +28,3 @@ exposed as a headless service, Linkerd will balance requests properly.
 Linkerd's load balancing is particularly useful for gRPC (or HTTP/2) services
 in Kubernetes, for which [Kubernetes's default load balancing is not
 effective](https://kubernetes.io/blog/2018/11/07/grpc-load-balancing-on-kubernetes-without-tears/).
-
-

--- a/linkerd.io/content/2/features/protocol-detection.md
+++ b/linkerd.io/content/2/features/protocol-detection.md
@@ -1,6 +1,7 @@
 +++
 date = "2018-07-31T12:00:00-07:00"
 title = "TCP Proxying and Protocol Detection"
+description = "Linkerd is capable of proxying all TCP traffic, including TLS'd connections, WebSockets, and HTTP tunneling."
 weight = 2
 [menu.l5d2docs]
   name = "TCP Proxying and Protocol Detection"

--- a/linkerd.io/content/2/features/protocol-detection.md
+++ b/linkerd.io/content/2/features/protocol-detection.md
@@ -1,17 +1,17 @@
 +++
 date = "2018-07-31T12:00:00-07:00"
 title = "TCP Proxying and Protocol Detection"
+weight = 2
 [menu.l5d2docs]
   name = "TCP Proxying and Protocol Detection"
-  parent = "Features"
-  weight = "2"
+  parent = "features"
 aliases = [
   "/2/supported-protocols/"
 ]
 +++
 
 Linkerd is capable of proxying all TCP traffic, including TLS'd connections,
-WebSockets, and HTTP tunneling. 
+WebSockets, and HTTP tunneling.
 
 Linkerd performs *protocol detection* to determine whether traffic is HTTP or
 HTTP/2 (including gRPC). If Linkerd detects that a connection is using HTTP or
@@ -70,4 +70,3 @@ their default ports (3306 and 25, respectively), then Linkerd will currently
 identify these protocols based on the port, and will not attempt to perform
 protocol detection. Thus, no extra configuration is necessary for plaintext
 MySQL and SMTP connections.
-

--- a/linkerd.io/content/2/features/proxy-injection.md
+++ b/linkerd.io/content/2/features/proxy-injection.md
@@ -1,10 +1,10 @@
 +++
 date = "2018-09-10T12:00:00-07:00"
 title = "Automatic Proxy Injection"
+weight = 4
 [menu.l5d2docs]
   name = "Automatic Proxy Injection"
-  parent = "Features"
-  weight = "4"
+  parent = "features"
 aliases = [
   "/2/proxy-injection/"
 ]

--- a/linkerd.io/content/2/features/proxy-injection.md
+++ b/linkerd.io/content/2/features/proxy-injection.md
@@ -1,6 +1,7 @@
 +++
 date = "2018-09-10T12:00:00-07:00"
 title = "Automatic Proxy Injection"
+description = "Linkerd can be configured to automatically inject the data plane proxy into your service."
 weight = 4
 [menu.l5d2docs]
   name = "Automatic Proxy Injection"

--- a/linkerd.io/content/2/features/retries-and-timeouts.md
+++ b/linkerd.io/content/2/features/retries-and-timeouts.md
@@ -1,10 +1,10 @@
 +++
 date = "2019-02-06T13:23:37-08:00"
 title = "Retries and Timeouts"
+weight = 3
 [menu.l5d2docs]
   name = "Retries and Timeouts"
-  parent = "Features"
-  weight = "3"
+  parent = "features"
 +++
 
 A [service profile](/2/features/service-profiles) may define certain routes as

--- a/linkerd.io/content/2/features/retries-and-timeouts.md
+++ b/linkerd.io/content/2/features/retries-and-timeouts.md
@@ -1,6 +1,7 @@
 +++
 date = "2019-02-06T13:23:37-08:00"
 title = "Retries and Timeouts"
+description = "Linkerd can be configured to perform service-specific retries and timeouts."
 weight = 3
 [menu.l5d2docs]
   name = "Retries and Timeouts"

--- a/linkerd.io/content/2/features/service-profiles.md
+++ b/linkerd.io/content/2/features/service-profiles.md
@@ -1,6 +1,7 @@
 +++
 date = "2018-10-16T12:00:21-07:00"
 title = "Service Profiles"
+description = "Linkerd supports defining service profiles that enable per-route metrics and features such as retries and timeouts."
 weight = 5
 [menu.l5d2docs]
   name = "Service Profiles"

--- a/linkerd.io/content/2/features/service-profiles.md
+++ b/linkerd.io/content/2/features/service-profiles.md
@@ -1,10 +1,10 @@
 +++
 date = "2018-10-16T12:00:21-07:00"
 title = "Service Profiles"
+weight = 5
 [menu.l5d2docs]
   name = "Service Profiles"
-  parent = "Features"
-  weight = "5"
+  parent = "features"
 aliases = [
   "/2/service-profiles/"
 ]

--- a/linkerd.io/content/2/features/telemetry.md
+++ b/linkerd.io/content/2/features/telemetry.md
@@ -1,10 +1,10 @@
 +++
 date = "2018-11-19T12:00:00-07:00"
 title = "Telemetry and monitoring"
+weight = 7
 [menu.l5d2docs]
   name = "Telemetry and monitoring"
-  parent = "Features"
-  weight = "7"
+  parent = "features"
 +++
 
 Linkerd automatically collects metrics from all services that send traffic

--- a/linkerd.io/content/2/features/telemetry.md
+++ b/linkerd.io/content/2/features/telemetry.md
@@ -1,9 +1,10 @@
 +++
 date = "2018-11-19T12:00:00-07:00"
-title = "Telemetry and monitoring"
+title = "Telemetry and Monitoring"
+description = "Linkerd automatically collects metrics from all services that send traffic through it."
 weight = 7
 [menu.l5d2docs]
-  name = "Telemetry and monitoring"
+  name = "Telemetry and Monitoring"
   parent = "features"
 +++
 


### PR DESCRIPTION
This is a follow-up to #145, which setup a new features index page. The index page wasn't really using the `sectiontoc` shortcode correctly, so items were showing up out of order, and the features index page itself was being included in the list of features. This should fix it. Adding a `description` tag on each of the feature pages would also make the index page a lot prettier. I can add that as part of this branch if nobody else is working on it.

Before this branch, on current master, the feature index page looks like this:

![screen shot 2019-02-11 at 1 18 13 pm](https://user-images.githubusercontent.com/9226/52594410-5310d300-2e00-11e9-97a1-8c0760d675f6.png)

And after this branch, it looks like this:

![screen shot 2019-02-11 at 1 19 50 pm](https://user-images.githubusercontent.com/9226/52594426-5d32d180-2e00-11e9-80fd-6cb97fbd5bec.png)
