### PR TITLE
Style, topography and small content updates

### DIFF
--- a/linkerd.io/assets/scss/custom.scss
+++ b/linkerd.io/assets/scss/custom.scss
@@ -2,10 +2,9 @@ $dark: #1d2322;
 
 $primary: #236Ad9;
 
-$font-family-sans-serif: lato,helvetica neue,sans-serif;
+$font-family-sans-serif: Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 $headings-font-weight: 300;
 
 $table-cell-min-width: 10em;
 
-$code-color: #343a40;
-$code-background: #e9ecef;
+$kbd-padding-y: 0.1rem;

--- a/linkerd.io/assets/scss/custom.scss
+++ b/linkerd.io/assets/scss/custom.scss
@@ -1,4 +1,3 @@
-
 $dark: #1d2322;
 
 $primary: #236Ad9;

--- a/linkerd.io/assets/scss/custom.scss
+++ b/linkerd.io/assets/scss/custom.scss
@@ -1,3 +1,4 @@
+
 $dark: #1d2322;
 
 $primary: #236Ad9;
@@ -8,3 +9,8 @@ $headings-font-weight: 300;
 $table-cell-min-width: 10em;
 
 $kbd-padding-y: 0.1rem;
+$kbd-padding-x: 0.2rem;
+
+$kbd-color: #212529; // $body-color
+$kbd-bg: #dee2e6; // $gray-300
+

--- a/linkerd.io/assets/scss/index.scss
+++ b/linkerd.io/assets/scss/index.scss
@@ -45,33 +45,43 @@ footer li {
 }
 
 .docs-content {
-  h1 {
-    margin-bottom: 1.75rem;
+  h1, h2 {
+    border-bottom: 1px solid $gray-500;
+    padding-bottom: .5rem;
   }
 
-  h2, h3 {
-    margin-top: 1rem;
-    padding-bottom: 1.75rem;
+  h1, h2, h3, h4 {
+    margin-top: 1.5rem;
+    margin-bottom: 1rem;
   }
 
   pre {
-    margin-bottom: 1.25rem;
+    margin-bottom: 1rem;
   }
 
   dt:first-child, dd:nth-child(2) {
     // This is because the border-top class is being used
     border-top: 0px !important;
   }
-}
 
-code {
-  $code-background: $code-background;
-}
+  .table td {
+    min-width: $table-cell-min-width;
 
-.table td {
-  min-width: $table-cell-min-width;
+    &.cli {
+      white-space: nowrap;
+    }
+  }
 
-  &.cli {
-    white-space: nowrap;
+  .table td,th {
+    border-top: 0px;
+  }
+
+  :not(pre) > code[class*="language-"] {
+    padding: $kbd-padding-y $kbd-padding-x;
+    font-size: $kbd-font-size;
+    color: $kbd-color;
+    background-color: $kbd-bg;
+    @include border-radius($border-radius-sm);
+    @include box-shadow($kbd-box-shadow);
   }
 }

--- a/linkerd.io/assets/scss/index.scss
+++ b/linkerd.io/assets/scss/index.scss
@@ -4,10 +4,6 @@
 @import "linkerd-coin.scss";
 @import "linkerd-demo.scss";
 
-
-$kbd-color: $body-color;
-$kbd-bg: $gray-300;
-
 .linkerd-bg {
   background: linear-gradient(#3F8B5A, #275B3A);
 }

--- a/linkerd.io/assets/scss/index.scss
+++ b/linkerd.io/assets/scss/index.scss
@@ -4,6 +4,10 @@
 @import "linkerd-coin.scss";
 @import "linkerd-demo.scss";
 
+
+$kbd-color: $body-color;
+$kbd-bg: $gray-300;
+
 .linkerd-bg {
   background: linear-gradient(#3F8B5A, #275B3A);
 }

--- a/linkerd.io/content/2/architecture/_index.md
+++ b/linkerd.io/content/2/architecture/_index.md
@@ -6,7 +6,22 @@ title = "Architecture"
   weight = 2
 +++
 
-## Control Plane
+At a high level, Linkerd consists of a *control plane* and a *data plane*.
+
+The *control plane* is a set of services that run in a dedicated
+namespace. These services accomplish various things---aggregating telemetry
+data, providing a user-facing API, providing control data to the data plane
+proxies, etc. Together, they drive the behavior of the data plane.
+
+The *data plane* consists of transparent proxies that are run next
+to each service instance. These proxies automatically handle all traffic to and
+from the service. Because they're transparent, these proxies act as highly
+instrumented out-of-process network stacks, sending telemetry to, and receiving
+control signals from, the control plane.
+
+{{< fig src="/images/architecture/control-plane.png" title="Architecture" >}}
+
+# Control Plane
 
 The Linkerd control plane is a set of services that run in a dedicated
 Kubernetes namespace (`linkerd` by default). These services accomplish various
@@ -34,9 +49,7 @@ The control plane is made up of four components:
   component is used to render and display these dashboards. You can reach these
   dashboards via links in the Linkerd dashboard itself.
 
-{{< fig src="/images/architecture/control-plane.png" title="Architecture" >}}
-
-## Data Plane
+# Data Plane
 
 The Linkerd data plane is comprised of lightweight proxies, which are deployed
 as sidecar containers alongside each instance of your service code. In order to
@@ -84,13 +97,13 @@ The proxy's features include:
 The proxy supports service discovery via DNS and the
 [destination gRPC API](https://github.com/linkerd/linkerd2-proxy-api).
 
-## CLI
+# CLI
 
 The Linkerd CLI is run locally on your machine and is used to interact with the
 control and data planes. It can be used to view statistics, debug production
 issues in real time and install/upgrade the control and data planes.
 
-## Dashboard
+# Dashboard
 
 The Linkerd dashboard provides a high level view of what is happening with your
 services in real time. It can be used to view the "golden" metrics (success
@@ -100,7 +113,7 @@ running `linkerd dashboard` from the command line.
 
 {{< fig src="/images/architecture/stat.png" title="Top Line Metrics">}}
 
-## Grafana
+# Grafana
 
 As a component of the control plane, Grafana provides actionable dashboards for
 your services out of the box. It is possible to see high level metrics and dig
@@ -120,7 +133,7 @@ The dashboards that are provided out of the box include:
 
 {{< /gallery >}}
 
-## Prometheus
+# Prometheus
 
 Prometheus is a cloud native monitoring solution that is used to collect
 and store all the Linkerd metrics. It is installed as part of the control plane

--- a/linkerd.io/content/2/cli/check.md
+++ b/linkerd.io/content/2/cli/check.md
@@ -34,13 +34,6 @@ linkerd check --proxy
 For resolutions to common `linkerd check` failures, have a look at
 [Resolutions for linkerd check failures](/2/installing/#check).
 
-## Flags
-
-{{< flags "check" >}}
-
-### Global flags
-
-{{< global-flags >}}
 
 # Example output
 
@@ -86,44 +79,6 @@ control-plane-version
 Status check results are √
 ```
 
-# Check options
+# Flags
 
-```bash
-$ linkerd check --help
-Check the Linkerd installation for potential problems.
-
-The check command will perform a series of checks to validate that the linkerd
-CLI and control plane are configured correctly. If the command encounters a
-failure it will print additional information about the failure and exit with a
-non-zero exit code.
-
-Usage:
-  linkerd check [flags]
-
-Examples:
-  # Check that the Linkerd control plane is up and running
-  linkerd check
-
-  # Check that the Linkerd control plane can be installed in the "test" namespace
-  linkerd check --pre --linkerd-namespace test
-
-  # Check that the Linkerd data plane proxies in the "app" namespace are up and running
-  linkerd check --proxy --namespace app
-
-Flags:
-      --expected-version string   Overrides the version used when checking if Linkerd is running the latest version (mostly for testing)
-  -h, --help                      help for check
-  -n, --namespace string          Namespace to use for --proxy checks (default: all namespaces)
-      --pre                       Only run pre-installation checks, to determine if the control plane can be installed
-      --proxy                     Only run data-plane checks, to determine if the data plane is healthy
-      --single-namespace          When running pre-installation checks (--pre), only check the permissions required to operate the control plane in a single namespace
-      --wait duration             Retry and wait for some checks to succeed if they don't pass the first time (default 5m0s)
-
-Global Flags:
-      --api-addr string            Override kubeconfig and communicate directly with the control plane at host:port (mostly for testing)
-      --context string             Name of the kubeconfig context to use
-      --kubeconfig string          Path to the kubeconfig file to use for CLI requests
-  -l, --linkerd-namespace string   Namespace in which Linkerd is installed [$LINKERD_NAMESPACE] (default "linkerd")
-      --verbose                    Turn on debug logging
-```
-
+{{< flags "check" >}}

--- a/linkerd.io/content/2/cli/inject.md
+++ b/linkerd.io/content/2/cli/inject.md
@@ -11,33 +11,17 @@ aliases = [
   parent = "cli"
 +++
 
-The `linkerd inject` command allows for a quick and reliable setup of the
-Linkerd Proxy in a Kubernetes Deployment. This page is useful as a reference to
-help you understand what `linkerd inject` is doing under the hood, as well as
-provide a reference for the flags that can be passed at the command line.
+The `inject` command modifies Kubernetes manifests that are passed to it either
+as a file (`-f`) or as a stream (`-`). It adds two containers to the pod spec of
+the manifest. Any resource types that do not need modification or are not
+supported, such as a `Service` are skipped over. The two containers added are:
 
-## Flags
+1. An `initContainer`.
 
-{{< flags "inject" >}}
+1. A `container` that runs the Linkerd proxy.
 
-### Global flags
-
-{{< global-flags >}}
-
-## What `linkerd inject` Is Doing
-
-`linkerd inject` is modifying the Kubernetes Deployment manifest that is being passed to it
-either as a file or as a stream to its stdin. It is adding two things:
-
-1. An Init Container (supported as of Kubernetes version 1.6 or greater)
-
-1. A Linkerd Proxy sidecar container into each Pod belonging to your Deployment
-
-The Init Container is responsible for pulling configuration (such as
-certificates) from the Kubernetes API/Linkerd Controller, as well as providing
-configuration to the Linkerd Proxy container for its runtime.
-
-## Example Deployment
+The `initContainer` is responsible for configuring `iptables`. This forwards all
+incoming and outgoing traffic through the proxy.
 
 Let's say for example you have the following deployment saved as `deployment.yaml`:
 
@@ -45,97 +29,104 @@ Let's say for example you have the following deployment saved as `deployment.yam
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-deployment
-  namespace: default
+  name: nginx
 spec:
-  replicas: 3
   selector:
     matchLabels:
-      app: example-deployment
-      env: default
+      app: nginx
+  replicas: 1
   template:
     metadata:
       labels:
-        app: example-deployment
-        env: default
+        app: nginx
     spec:
       containers:
-      - name: app
-        image: quay.io/ygrene/hello-docker
+      - name: nginx
+        image: nginx
         ports:
-        - containerPort: 3000
+        - containerPort: 80
 ```
 
-Now, we can run the `linkerd inject` command as follows:
+Now, we can run the `inject` command as follows:
 
 ```bash
-linkerd inject \
-  --proxy-log-level="debug" \
-  --skip-outbound-ports=3306 \
-  deployment.yaml > deployment_with_linkerd.yaml
+linkerd inject -f deployment.yaml
 ```
 
-The output of that file should look like the following:
+The output should be that file should look like the following:
 
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
-  name: example-deployment
-  namespace: default
+  name: nginx
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
-      app: example-deployment
-      env: default
+      app: nginx
   strategy: {}
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli v18.8.2
-        linkerd.io/proxy-version: v18.8.2
+        linkerd.io/created-by: linkerd/cli edge-19.2.2
+        linkerd.io/proxy-version: edge-19.2.2
       creationTimestamp: null
       labels:
-        app: example-deployment
-        env: default
+        app: nginx
         linkerd.io/control-plane-ns: linkerd
-        linkerd.io/proxy-deployment: example-deployment
+        linkerd.io/proxy-deployment: nginx
     spec:
       containers:
-      - image: quay.io/ygrene/hello-docker
-        name: app
+      - image: nginx
+        name: nginx-foo
         ports:
-        - containerPort: 3000
+        - containerPort: 80
         resources: {}
       - env:
         - name: LINKERD2_PROXY_LOG
-          value: debug
-        - name: LINKERD2_PROXY_BIND_TIMEOUT
-          value: 10s
+          value: warn,linkerd2_proxy=info
         - name: LINKERD2_PROXY_CONTROL_URL
-          value: tcp://proxy-api.linkerd.svc.cluster.local:8086
+          value: tcp://linkerd-proxy-api.linkerd.svc.cluster.local:8086
         - name: LINKERD2_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
           value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
           value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
           value: tcp://0.0.0.0:4143
+        - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
+          value: .
         - name: LINKERD2_PROXY_POD_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:v18.8.2
+        - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
+          value: 10000ms
+        - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
+          value: 10000ms
+        - name: LINKERD2_PROXY_ID
+          value: nginx.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+        image: gcr.io/linkerd-io/proxy:edge-19.2.2
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         name: linkerd-proxy
         ports:
         - containerPort: 4143
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -150,9 +141,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        - --outbound-ports-to-ignore
-        - "3306"
-        image: gcr.io/linkerd-io/proxy-init:v18.8.2
+        image: gcr.io/linkerd-io/proxy-init:edge-19.2.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -161,10 +150,13 @@ spec:
             add:
             - NET_ADMIN
           privileged: false
+          runAsNonRoot: false
+          runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
 status: {}
 ---
 ```
 
-Note here how the `initContainer` and `linkerd-proxy` sidecar are added to the
-manifest with configuration we passed as command line flags.
+# Flags
+
+{{< flags "inject" >}}

--- a/linkerd.io/content/2/cli/inject.md
+++ b/linkerd.io/content/2/cli/inject.md
@@ -14,14 +14,13 @@ aliases = [
 The `inject` command modifies Kubernetes manifests that are passed to it either
 as a file (`-f`) or as a stream (`-`). It adds two containers to the pod spec of
 the manifest. Any resource types that do not need modification or are not
-supported, such as a `Service` are skipped over. The two containers added are:
+supported, such as a `Service`, are skipped over. The two containers added are:
 
-1. An `initContainer`.
+1. An `initContainer`, `linkerd-init`, is responsible for configuring
+   `iptables`. This activates forwarding incoming and outgoing traffic through
+   the proxy.
 
-1. A `container` that runs the Linkerd proxy.
-
-The `initContainer` is responsible for configuring `iptables`. This forwards all
-incoming and outgoing traffic through the proxy.
+1. A `container`, `linkerd-proxy`, that runs the Linkerd proxy.
 
 Let's say for example you have the following deployment saved as `deployment.yaml`:
 

--- a/linkerd.io/content/2/cli/routes.md
+++ b/linkerd.io/content/2/cli/routes.md
@@ -8,18 +8,18 @@ weight = 3
   parent = "cli"
 +++
 
-The `linkerd routes` command displays per-route service metrics.  In order for
+The `routes` command displays per-route service metrics.  In order for
 this information to be available, a service profile must be defined for the
 service that is receiving the requests.  For more information about how to
 create a service profile, see [service profiles](/2/features/service-profiles).
 
-## Inbound Metrics
+# Inbound Metrics
 
-By default, `linkerd routes` displays *inbound* metrics for a target.  In other
+By default, `routes` displays *inbound* metrics for a target.  In other
 words, it shows information about requests which are sent to the target and
 responses which are returned by the target.  For example, the command:
 
-```
+```bash
 linkerd routes deploy/webapp
 ```
 
@@ -28,15 +28,7 @@ Displays the request volume, success rate, and latency of requests to the
 perspective, which means that, for example, these latencies do not include the
 network latency between a client and the `webapp` deployment.
 
-## Flags
-
-{{< flags "routes" >}}
-
-### Global flags
-
-{{< global-flags >}}
-
-## Outbound Metrics
+# Outbound Metrics
 
 If you specify the `--to` flag then `linkerd routes` displays *outbound* metrics
 from the target resource to the resource in the `--to` flag.  In contrast to
@@ -44,23 +36,23 @@ the inbound metrics, these metrics are from the perspective of the sender.  This
 means that these latencies do include the network latency between the client
 and the server.  For example, the command:
 
-```
+```bash
 linkerd routes deploy/traffic --to deploy/webapp
 ```
 
 Displays the request volume, success rate, and latency of requests from
 `traffic` to `webapp` from the perspective of the `traffic` deployment.
 
-## Effective and Actual Metrics
+# Effective and Actual Metrics
 
 If you are looking at *outbound* metrics (by specifying the `--to` flag) you
 can also supply the `-o wide` flag to differentiate between *effective* and
 *actual* metrics.
 
 Effective requests are requests which are sent by some client to the Linkerd
-proxy.  Actual requests are requests which the Linkerd proxy sends to some
-server.  If the Linkerd proxy is performing retries, one effective request can
-translate into more than one actual request.  If the Linkerd proxy is not
+proxy. Actual requests are requests which the Linkerd proxy sends to some
+server. If the Linkerd proxy is performing retries, one effective request can
+translate into more than one actual request. If the Linkerd proxy is not
 performing retries, effective requests and actual requests will always be equal.
 When enabling retries, you should expect to see the actual request rate
 increase and the effective success rate increase.  See the
@@ -68,3 +60,7 @@ increase and the effective success rate increase.  See the
 
 Because retries are only performed on the *outbound* (client) side, the
 `-o wide` flag can only be used when the `--to` flag is specified.
+
+# Flags
+
+{{< flags "routes" >}}

--- a/linkerd.io/content/2/debugging/_index.md
+++ b/linkerd.io/content/2/debugging/_index.md
@@ -9,14 +9,12 @@ aliases = [
   weight = 10
 +++
 
-This section assumes you've followed the steps in the
+The demo application emojivoto has some issues. Let's use that and Linkerd to
+diagnose an application that fails in ways which are a little more subtle than
+the entire service crashing. This guide assumes that you've followed the steps in the
 [Getting Started](../getting-started) guide and have Linkerd and the demo
-application running in a Kubernetes cluster.
-
-## Using Linkerd to debug a failing application
-
-The demo application has some issues. Let's use Linkerd to diagnose these
-issues.
+application running in a Kubernetes cluster. If you've not done that yet, go get
+started and come back when you're done!
 
 If you glance at the Linkerd dashboard (by running the `linkerd dashboard`
 command), you should see all the resources in the `emojivoto` namespace,

--- a/linkerd.io/content/2/edge/_index.md
+++ b/linkerd.io/content/2/edge/_index.md
@@ -2,7 +2,7 @@
 date = "2018-07-31T12:00:00-07:00"
 title = "Release Channels"
 [menu.l5d2docs]
-  name = "Release Channels" 
+  name = "Release Channels"
   weight = 18
 +++
 
@@ -11,7 +11,7 @@ choose between stability or getting the latest and greatest functionality. The
 latest release for each channel is listed below. The full list of releases can
 be found on [GitHub](https://github.com/linkerd/linkerd2/releases).
 
-### Stable (latest version: {{% latestversion %}})
+# Stable (latest version: {{% latestversion %}})
 
 Stable releases are periodic, and focus on stability. To install a stable
 release, you can run:
@@ -20,7 +20,7 @@ release, you can run:
 curl -sL https://run.linkerd.io/install | sh
 ```
 
-### Edge (latest version: {{% latestedge %}})
+# Edge (latest version: {{% latestedge %}})
 
 Edge releases are frequent (usually, weekly) and can be used to work with the
 latest and greatest features. These releases are intended to be stable, but are

--- a/linkerd.io/content/2/faq/_index.md
+++ b/linkerd.io/content/2/faq/_index.md
@@ -9,7 +9,7 @@ title = "Frequently Asked Questions"
   weight = 9
 +++
 
-## What is Linkerd?
+# What is Linkerd?
 
 Linkerd is a [service
 mesh](https://blog.buoyant.io/2017/04/25/whats-a-service-mesh-and-why-do-i-need-one/).
@@ -25,13 +25,13 @@ with a uniform point at which they can control and measure the behavior of the
 data plane. Operators typically interact with Linkerd using the [CLI](../cli)
 and the [web dashboard UI](../getting-started/#step-4-explore-linkerd).
 
-## Who owns Linkerd and how is it licensed?
+# Who owns Linkerd and how is it licensed?
 
 Linkerd is licensed under Apache v2 and is a [Cloud Native Computing
 Foundation](https://cncf.io) (CNCF) project. The CNCF owns the trademark; the
 copyright is held by the Linkerd authors themselves.
 
-## Who maintains Linkerd?
+# Who maintains Linkerd?
 
 See the [2.x
 maintainers](https://github.com/linkerd/linkerd2/blob/master/MAINTAINERS.md)
@@ -39,11 +39,11 @@ file, and the [1.x
 maintainers](https://github.com/linkerd/linkerd/blob/master/MAINTAINERS.md)
 file.
 
-## Is there an Enterprise edition, or a commercial edition?
+# Is there an Enterprise edition, or a commercial edition?
 
 No. Everything in Linkerd is fully open source.
 
-## How do I pronounce Linkerd?
+# How do I pronounce Linkerd?
 
 The "d" is pronounced separately, i.e. "Linker-DEE". (It's a UNIX thing.)
 
@@ -55,26 +55,26 @@ lighter-weight. However, Linkerd 2.x currently does not have the full platform
 support or featureset of 1.x. (See [the full list of supported
 platforms](../../choose-your-platform) across both versions.)
 
-## Is Linkerd 1.x still supported?
+# Is Linkerd 1.x still supported?
 
 Yes, the 1.x branch of Linkerd is under active development, and continues
 to power the production infrastructure of companies around the globe.
 
 [The full Linkerd 1.x documentation is here](/1/).
 
-## Does Linkerd require Kubernetes?
+# Does Linkerd require Kubernetes?
 
 Linkerd 2.x currently requires Kubernetes, though this will change in the
 future. Linkerd 1.x can be installed on any platform, and supports Kubernetes,
 DC/OS, Mesos, Consul, and ZooKeeper-based environments.
 
-## Where's the Linkerd roadmap?
+# Where's the Linkerd roadmap?
 
 As a community project, there is no official roadmap, but a glance at the
 [active GitHub issues](https://github.com/linkerd/linkerd2/issues) will give
 you a sense of what is in store for the future.
 
-## What happens to Linkerd's proxies if the control plane is down?
+# What happens to Linkerd's proxies if the control plane is down?
 
 Linkerd's proxies do not integrate with Kubernetes directly, but rely on the
 control plane for service discovery information. The proxies are designed to

--- a/linkerd.io/content/2/faq/_index.md
+++ b/linkerd.io/content/2/faq/_index.md
@@ -1,6 +1,7 @@
 +++
 date = "2018-09-17T08:00:00-07:00"
 title = "Frequently Asked Questions"
+include_toc = true
 [sitemap]
   priority = 1.0
 [menu.l5d2docs]

--- a/linkerd.io/content/2/getting-started/_index.md
+++ b/linkerd.io/content/2/getting-started/_index.md
@@ -20,8 +20,6 @@ services by adding the the data plane proxies. (See the
 
 We'll walk you through this process step by step.
 
-____
-
 ## Step 0: Setup
 
 Before we can do anything, we need to ensure you have access to a Kubernetes
@@ -55,8 +53,6 @@ kubectl create clusterrolebinding cluster-admin-binding-$USER \
 In the next step, we will install the CLI and validate that your cluster is
 ready to install the control plane.
 
-____
-
 ## Step 1: Install the CLI
 
 If this is your first time running Linkerd, you’ll need to download the
@@ -87,8 +83,6 @@ linkerd version
 
 You should see the CLI version, and also "Server version: unavailable". This
 is because we haven't installed the control plane. We'll do that soon.
-
-____
 
 ## Step 2: Validate your Kubernetes cluster
 
@@ -158,8 +152,6 @@ linkerd -n linkerd top deploy/linkerd-web
 
 This is the traffic you're generating by looking at the dashboard itself!
 
-____
-
 ## Step 5: Install the demo app
 
 To get a feel for how Linkerd would work for one of your services, you can
@@ -226,8 +218,6 @@ the way it should with the data plane. To do this check, run:
 linkerd -n emojivoto check --proxy
 ```
 
-____
-
 ## Step 6: Watch it run!
 
 You can glance at the Linkerd dashboard and see all the HTTP/2 (gRPC) and HTTP/1
@@ -285,8 +275,6 @@ dashboards. You can get to these by clicking the Grafana icon in the overview
 page.
 
 {{< fig src="/images/getting-started/grafana.png" title="Deployment Detail Dashboard">}}
-
-____
 
 ## That’s it! 👏
 

--- a/linkerd.io/content/2/observability/exporting-metrics.md
+++ b/linkerd.io/content/2/observability/exporting-metrics.md
@@ -19,12 +19,12 @@ Internally, Linkerd stores its metrics in a Prometheus instance that runs as
 part of the control plane.  There are several basic approaches to exporting
 metrics data from Linkerd:
 
-1. [Federating data to your own Prometheus cluster](#federation)
-1. [Using a Prometheus integration](#integration)
-1. [Extracting data via Prometheus's APIs](#api)
-1. [Gather data from the proxies directly](#proxy)
+- [Federating data to your own Prometheus cluster](#federation)
+- [Using a Prometheus integration](#integration)
+- [Extracting data via Prometheus's APIs](#api)
+- [Gather data from the proxies directly](#proxy)
 
-## Using the Prometheus federation API {#federation}
+# Using the Prometheus federation API {#federation}
 
 If you are using Prometheus as your own metrics store, we recommend taking
 advantage of Prometheus's *federation* API, which is designed exactly for the
@@ -67,7 +67,7 @@ label definitions, have a look at [Proxy Metrics](../proxy-metrics).
 For more information on Prometheus' `/federate` endpoint, have a look at the
 [Prometheus federation docs](https://prometheus.io/docs/prometheus/latest/federation/).
 
-## Using a Prometheus integration {#integration}
+# Using a Prometheus integration {#integration}
 
 If you are not using Prometheus as your own long-term data store, you may be
 able to leverage one of Prometheus's [many
@@ -75,7 +75,7 @@ integrations](https://prometheus.io/docs/operating/integrations/) to
 automatically extract data from Linkerd's Prometheus instance into the data
 store of your choice. Please refer to the Prometheus documentation for details.
 
-## Extracting data via Prometheus's APIs {#api}
+# Extracting data via Prometheus's APIs {#api}
 
 If neither Prometheus federation nor Prometheus integrations are options for
 you, it is possible to call Prometheus's APIs to extract data from Linkerd.
@@ -83,15 +83,16 @@ you, it is possible to call Prometheus's APIs to extract data from Linkerd.
 For example, you can call the federation API directly via a command like:
 
 ```bash
-curl -G --data-urlencode 'match[]={job="linkerd-proxy"}' --data-urlencode 'match[]={job="linkerd-controller"}' http://prometheus.linkerd.svc.cluster.local:9090/federate
+curl -G \
+  --data-urlencode 'match[]={job="linkerd-proxy"}' \
+  --data-urlencode 'match[]={job="linkerd-controller"}' \
+  http://prometheus.linkerd.svc.cluster.local:9090/federate
 ```
 
-From outside the Kubernetes cluster, you will need to port forward first:
-
-```bash
-kubectl -n linkerd port-forward $(kubectl -n linkerd get po --selector=linkerd.io/control-plane-component=prometheus -o jsonpath='{.items[*].metadata.name}') 9090:9090
-curl -G --data-urlencode 'match[]={job="linkerd-proxy"}' --data-urlencode 'match[]={job="linkerd-controller"}' http://localhost:9090/federate
-```
+Note: if your data store is outside the Kubernetes cluster, it is likely that
+you'll want to setup
+[ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/)
+at a domain name of your choice with authentication.
 
 Similar to the `/federate` API, Prometheus provides a JSON query API to
 retrieve all metrics:
@@ -100,7 +101,7 @@ retrieve all metrics:
 curl http://prometheus.linkerd.svc.cluster.local:9090/api/v1/query?query=request_total
 ```
 
-## Gathering data from the Linkerd proxies directly {#proxy}
+# Gathering data from the Linkerd proxies directly {#proxy}
 
 Finally, if you want to avoid Linkerd's Prometheus entirely, you can query the
 Linkerd proxies directly on their `/metrics` endpoint.
@@ -109,9 +110,15 @@ For example, to view `/metrics` from a single Linkerd proxy, running in the
 `linkerd` namespace:
 
 ```bash
-kubectl port-forward -n linkerd $(kubectl -n linkerd get pods -l linkerd.io/control-plane-ns=linkerd -o jsonpath='{.items[0].metadata.name}') 4191:4191
+kubectl -n linkerd port-forward \
+  $(kubectl -n linkerd get pods \
+    -l linkerd.io/control-plane-ns=linkerd \
+    -o jsonpath='{.items[0].metadata.name}') \
+  4191:4191
 ```
+
 and then:
+
 ```bash
 curl localhost:4191/metrics
 ```

--- a/linkerd.io/content/2/observability/proxy-metrics.md
+++ b/linkerd.io/content/2/observability/proxy-metrics.md
@@ -12,9 +12,9 @@ aliases = [
 
 The Linkerd proxy exposes metrics that describe the traffic flowing through the
 proxy.  The following metrics are available at `/metrics` on the proxy's metrics
-port (default: `:4191`) in the [Prometheus format][prom-format]:
+port (default: `:4191`) in the [Prometheus format][prom-format].
 
-## Protocol-Level Metrics
+# Protocol-Level Metrics
 
 * `request_total`: A counter of the number of requests the proxy has received.
   This is incremented when the request stream begins.
@@ -30,8 +30,8 @@ port (default: `:4191`) in the [Prometheus format][prom-format]:
   application behavior when a server provides response headers immediately but is
   slow to begin serving the response body.
 
-* `route_request_total`, `route_response_latency_ms`, and `route_response_total`: 
-  These metrics are analogous to `request_total`, `response_latency_ms`, and 
+* `route_request_total`, `route_response_latency_ms`, and `route_response_total`:
+  These metrics are analogous to `request_total`, `response_latency_ms`, and
   `response_total` except that they are collected at the route level.  This
   means that they do not have `authority`, `tls`, `grpc_status_code` or any
   outbound labels but instead they have:
@@ -39,7 +39,7 @@ port (default: `:4191`) in the [Prometheus format][prom-format]:
   * `rt_route`: The name of the route for this request.
 
 * `control_request_total`, `control_response_latency_ms`, and `control_response_total`:
-  These metrics are analogous to `request_total`, `response_latency_ms`, and 
+  These metrics are analogous to `request_total`, `response_latency_ms`, and
   `response_total` but for requests that the proxy makes to the Linkerd control
   plane.  Instead of `authority`, `direction`, or any outbound labels, instead
   they have:
@@ -155,7 +155,7 @@ request_total{
 }
 ```
 
-## Transport-Level Metrics
+# Transport-Level Metrics
 
 The following metrics are collected at the level of the underlying transport
 layer.

--- a/linkerd.io/data/cli.yaml
+++ b/linkerd.io/data/cli.yaml
@@ -3,20 +3,27 @@ commands:
   link: true
   description: Check the Linkerd installation for potential problems
   flags:
-  - name: --expected-version
+  - names:
+    - --expected-version
     arg: string
     description: Overrides the version used when checking if Linkerd is running the latest version (mostly for testing)
-  - names: [-n,--namespace]
+  - names:
+    - --namespace
+    - -n
     arg: string
     description: Namespace to use for `--proxy` checks
     default: all
-  - name: --pre
+  - names:
+    - --pre
     description: Only run pre-installation checks, to determine if the control plane can be installed
-  - name: --proxy
+  - names:
+    - --proxy
     description: Only run data-plane checks, to determine if the data plane is healthy
-  - name: --single-namespace
+  - names:
+    - --single-namespace
     description: When running pre-installation checks (`--pre`), only check the permissions required to operate the control plane in a single namespace
-  - name: --wait
+  - names:
+    - --wait
     arg: duration
     description: Retry and wait for some checks to succeed if they don't pass the first time
     default: 5m0s
@@ -24,92 +31,110 @@ commands:
   link: true
   description: Add the Linkerd proxy to a Kubernetes config. The `inject` command makes it easy to add Linkerd to your service. It consumes Kubernetes resources in YAML format and adds the proxy sidecar. The output is in a format that can be immediately applied to the cluster via kubectl.
   flags:
-  - name: --api-port
+  - names:
+    - --api-port
     arg: uint
     description: Port where the Linkerd controller is running
     default: 8086
     example: 9045
-  - name: --control-port
+  - names:
+    - --control-port
     arg: uint
     description: Proxy port to use for control
     default: 4190
     example: 5431
-  - name: --disable-external-profiles
+  - names:
+    - --disable-external-profiles
     description: Disables service profiles for non-Kubernetes services
-  - name: --image-pull-policy
+  - names:
+    - --image-pull-policy
     arg: string
     description: Docker image pull policy
     default: IfNotPresent
     example: Always
-  - name: --inbound-port
+  - names:
+    - --inbound-port
     arg: uint
     description: Proxy port to use for inbound traffic
     default: 4143
     example: 1234
-  - name: --init-image
+  - names:
+    - --init-image
     arg: string
     description: Linkerd init container image name
     default: gcr.io/linkerd-io/proxy-init
     example: quay.io/org/imagename
-  - names: [--linkerd-version,-v]
+  - names:
+    - --linkerd-version
+    - -v
     arg: string
     description: Tag to be used for Linkerd images
     default: stable-2.1.0
     example: 1.0.0
-  - name: --metrics-port
+  - names:
+    - --metrics-port
     arg: uint
     description: Proxy port to serve metrics on
     default: 4191
     example: 10234
-  - name: --outbound-port
+  - names:
+    - --outbound-port
     arg: uint
     description: Proxy port to use for outbound traffic
     default: 4140
     example: 1234
-  - name: --proxy-bind-timeout
+  - names:
+    - --proxy-bind-timeout
     arg: duration
     description: Timeout the proxy will us
     default: 10s
     example: 30s
-  - name: --proxy-cpu
+  - names:
+    - --proxy-cpu
     arg: float
     description: Amount of CPU units that the proxy sidecar requests
     example: 10m
-  - name: --proxy-image
+  - names:
+    - --proxy-image
     arg: string
     description: Linkerd proxy container image name
     default: gcr.io/linkerd-io/proxy
     example: quay.io/org/imagename
-  - name: --proxy-log-level
+  - names:
+    - --proxy-log-level
     arg: string
     description: Log level for the proxy
     default: warn,linkerd2_proxy=info
-    example: info,linkder2_proxy=debug
-  - name: --proxy-memory
+    example: info,linkerd2_proxy=debug
+  - names:
+    - --proxy-memory
     arg: uint
     description: Amount of Memory that the proxy sidecar requests
     example: 50Mi
-  - name: --proxy-uid
+  - names:
+    - --proxy-uid
     arg: int
     description: Run the proxy under this user ID
     default: 2012
     example: 123
-  - name: --registry
+  - names:
+    - --registry
     arg: string
     description: Docker registry to pull images from
     default: gcr.io/linkerd-io
     example: quay.io/ygrene
-  - name: --skip-inbound-ports
+  - names:
+    - --skip-inbound-ports
     arg: uintSlice
     description: Ports that should skip the proxy and send directly to the application
-    default: "[]"
     example: "25,26,27"
-  - name: --skip-outbound-ports
+  - names:
+    - --skip-outbound-ports
     arg: uintSlice
     description: Outbound ports that should skip the proxy
-    default: "[]"
     example: "25,3306,5432"
-  - name: --tls
+  - names:
+    - --tls
     arg: string
     description: |
       Enable TLS. Valid settings: `optional`.
@@ -121,27 +146,35 @@ commands:
 
     The `route` command will only display traffic sent to a service with a defined Service Profile.
   flags:
-  - names: [--namespace,-n]
+  - names:
+    - --namespace
+    - -n
     arg: string
     description: |
       Namespace of the specified resource
     default: default
     example: emojivoto
-  - names: [--output,-o]
+  - names:
+    - --output
+    - -o
     arg: string
     description: Output format. Currently only `table`, `wide`, and `json` are supported.
     default: table
     example: wide
-  - names: [--time-window,-t]
+  - names:
+    - --time-window
+    - -t
     arg: duration
     description: Stat window, e.g. `10s`, `1m`, `10m`, `1h`, etc.
     default: 1m
     example: 30s
-  - name: --to
+  - names:
+    - --to
     arg: string
     description: If present, shows outbound stats to the specified resources
     example: deploy/webapp
-  - name: --to-namespace
+  - names:
+    - --to-namespace
     arg: string
     description: Sets the namespace used to look up the `--to` resources. By default, the current `--namespace` is used.
     example: emojivoto
@@ -166,13 +199,17 @@ commands:
 - name: version
   description: Print the client and server version information
 globalflags:
-- name: --api-addr
+- names:
+    - --api-addr
   arg: string
   description: Override kubeconfig and communicate directly with the control plane at host:port (mostly for testing)
-- name: --context
+- names:
+    - --context
   arg: string
   description: Name of the kubeconfig context to use
-- names: [--linkerd-namespace,-l]
+- names:
+    - --linkerd-namespace
+    - -l
   arg: string
   description: |
     The namespace in which Linkerd is installed.

--- a/linkerd.io/layouts/partials/docs.html
+++ b/linkerd.io/layouts/partials/docs.html
@@ -4,9 +4,9 @@
       {{ partial "sidebar.html" . }}
     </div>
 
-    <div class="col-md-9 pt-5 border-left docs-content">
-      <h1 class="title">{{ .page.Title }}</h1>
-      <div class="content">{{ .page.Content }}</div>
+    <div class="col-md-9 border-left docs-content">
+      <h1 class="title display-4 mb-4">{{ .page.Title }}</h1>
+      <div class="content language-markup">{{ .page.Content }}</div>
     </div>
   </div>
 </div>

--- a/linkerd.io/layouts/partials/docs.html
+++ b/linkerd.io/layouts/partials/docs.html
@@ -6,7 +6,12 @@
 
     <div class="col-md-9 border-left docs-content">
       <h1 class="title display-4 mb-4">{{ .page.Title }}</h1>
-      <div class="content language-markup">{{ .page.Content }}</div>
+      <div class="content language-markup">
+        {{ if .page.Params.include_toc }}
+        {{ .page.TableOfContents }}
+        {{ end }}
+        {{ .page.Content }}
+      </div>
     </div>
   </div>
 </div>

--- a/linkerd.io/layouts/partials/flags.html
+++ b/linkerd.io/layouts/partials/flags.html
@@ -24,13 +24,12 @@
     {{ $arg := .arg }}
     <tr>
       <td class="cli">
-        {{ with .name }}
-        <code>{{ . }}{{ with $arg }}=<strong>{{ . }}</strong>{{ end }}</code>
-        {{ end }}
-          
-        {{ with .names }}
-        <code>{{ index . 0 }}{{ with $arg }}=<strong>{{ . }}</strong>{{ end }}</code>,
-        <br /><code>{{ index . 1 }}{{ with $arg }}=<strong>{{ . }}</strong>{{ end }}</code>
+        {{ range $index, $name := .names }}
+          {{ if (ne $index 0) }}
+            <br />
+
+          {{ end }}
+          <kbd>{{ $name }}{{ with $arg }}=<strong>{{ . }}</strong>{{ end }}</kbd>
         {{ end }}
       </td>
       <td>
@@ -42,18 +41,14 @@
       {{ $names   := .names }}
       <td class="cli">
         {{ with $example }}
-        {{ with $name }}
-        <code>{{ . }}={{ $example }}</code>
-        {{ end }}
-
-        {{ with $names }}
-        <code>{{ index . 0 }}={{ $example }}</code>
-        {{ end }}
+        <kbd>{{ index $names 0 }}=<strong>{{ $example }}</strong></kbd>
         {{ end }}
       </td>
       {{ end }}
       <td class="cli">
+        {{ if (isset . "default") }}
         <code>{{ .default }}</code>
+        {{ end}}
       </td>
     </tr>
     {{ end}}

--- a/linkerd.io/layouts/shortcodes/cli.html
+++ b/linkerd.io/layouts/shortcodes/cli.html
@@ -17,12 +17,10 @@
       <td>
         {{ if .link }}
         <a href="{{ .name }}">
-          <code>{{ .name }}</code>
+          {{ .name }}
         </a>
         {{ else }}
-        <code>
-          {{ .name }}
-        </code>
+        {{ .name }}
         {{ end }}
       </td>
       <td>


### PR DESCRIPTION
- Uses Roboto as the default font.
- Adds a border for h1/h2 to make them a little more readable.
- Converts the title into a display header to differentiate and reduce the header nesting.
- Moves the margin around for headers a little to reduce bottom padding and increase top padding a little.
- Fixes inline formatting to pop more during reading.
- Fixes CLI table formatting.
- Adds the ability to show a TOC at the top of a page (see the FAQ).

<img width="1186" alt="screenshot 2019-02-11 17 16 49" src="https://user-images.githubusercontent.com/47992/52604749-04bffc00-2e21-11e9-86b2-09e047a531c9.png">
<img width="914" alt="screenshot 2019-02-11 17 17 14" src="https://user-images.githubusercontent.com/47992/52604750-05589280-2e21-11e9-8371-d5054c31fae3.png">
