### PR TITLE
Add auto-generated redirects file

### DIFF
--- a/linkerd.io/config.toml
+++ b/linkerd.io/config.toml
@@ -44,3 +44,14 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
   weight = 5
   pre = "<i class='fab fa-github mr-1' aria-hidden='true'></i>"
   url = "https://github.com/linkerd/linkerd2"
+
+# Auto-generate Netlify _redirects file
+[mediaTypes."text/netlify"]
+delimiter = ""
+
+[outputFormats.REDIRECTS]
+mediaType = "text/netlify"
+baseName = "_redirects"
+
+[outputs]
+home = ["HTML", "REDIRECTS"]

--- a/linkerd.io/layouts/index.redirects
+++ b/linkerd.io/layouts/index.redirects
@@ -1,0 +1,1 @@
+# No redirects yet


### PR DESCRIPTION
This PR adds the basic Hugo scaffolding necessary to auto-generate a Netlify `_redirects` file. There is not yet a need for redirects, but this will become necessary in the near future (see #163).