### PR TITLE
Remove default field from flags table

### DIFF
--- a/linkerd.io/layouts/partials/cli/flags.html
+++ b/linkerd.io/layouts/partials/cli/flags.html
@@ -7,9 +7,6 @@
       <th>
         Usage
       </th>
-      <th>
-        Default
-      </th>
     </tr>
   </thead>
   <tbody>
@@ -24,11 +21,6 @@
       </td>
       <td>
         {{ .Usage | markdownify }}
-      </td>
-      <td>
-        {{ with .DefaultValue }}
-        <code>{{ . }}</code>
-        {{ end }}
       </td>
     </tr>
     {{ end }}


### PR DESCRIPTION
The **Default** column is no longer used for CLI flags, so it should be removed from the template.