### PR TITLE
Add edit page/site button

### DIFF
--- a/linkerd.io/layouts/partials/footer.html
+++ b/linkerd.io/layouts/partials/footer.html
@@ -1,8 +1,19 @@
+{{ $isHome   := .IsHome }}
+{{ $filepath := .File.Path }}
+{{ $editUrl  := printf "https://github.com/linkerd/website/edit/master/linkerd.io/content/%s" $filepath }}
 <div class="border-top">
   <footer class="container">
     <div class="row my-5">
       <div class="col-md-6 pb-3">
-	<a href="https://github.com/linkerd/website">(edit this site)</a>
+        {{ if $isHome }}
+        <a class="btn btn-dark" href="https://github.com/linkerd/website/tree/master/linkerd.io/content">
+          <i class="fab fa-github"></i> Edit this site
+        </a>
+        {{ else }}
+        <a class="btn btn-dark" href="{{ $editUrl }}">
+          <i class="fab fa-github"></i> Edit this page
+        </a>
+        {{ end }}
         <!-- <ul class="list-unstyled">
           <li>
             <a href="{{ relref . "/2/getting-started/_index.md" }}"


### PR DESCRIPTION
This PR adds a nice-looking button to the footer to replace the "edit this site" logic currently in place. On the home page it links to the root of the repo. On specific pages it takes you straight to the "edit" page on GitHub for that specific page.