### PR TITLE
Update linkerd check reference with self-check

### DIFF
--- a/linkerd.io/content/2/reference/cli/check.md
+++ b/linkerd.io/content/2/reference/cli/check.md
@@ -36,7 +36,7 @@ linkerd-existence
 linkerd-api
 -----------
 √ control plane pods are ready
-√ can query the control plane API
+√ control plane self-check
 √ [kubernetes] control plane can talk to Kubernetes
 √ [prometheus] control plane can talk to Prometheus
 

--- a/linkerd.io/content/2/tasks/troubleshooting.md
+++ b/linkerd.io/content/2/tasks/troubleshooting.md
@@ -275,12 +275,12 @@ pod/linkerd-prometheus-74d66f86f6-6t6dh   2/2       Running   0          1h
 pod/linkerd-web-5f6c45d6d9-9hd9j          2/2       Running   0          3m
 ```
 
-### √ can query the control plane API {#l5d-api-control-api}
+### √ control plane self-check {#l5d-api-control-api}
 
 Example failure:
 
 ```bash
-× can query the control plane API
+× control plane self-check
     Post https://localhost:6443/api/v1/namespaces/linkerd/services/linkerd-controller-api:http/proxy/api/v1/SelfCheck: context deadline exceeded
 ```
 


### PR DESCRIPTION
linkerd/linkerd2#2361 renamed the second
`can query the control plane API` check to
`control plane self-check`.

This is the corresponding documentation change.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>