### PR TITLE
Combine JS logic into one partial

### DIFF
--- a/linkerd.io/content/1/overview/_index.md
+++ b/linkerd.io/content/1/overview/_index.md
@@ -4,6 +4,10 @@ title = "Introduction"
 layout = "overview"
 description = "Describes Linkerd features at a high level, explains the rationale behind them, and introduces important concepts that are used throughout the rest of the documentation."
 weight = 1
+js = [
+  "/js/smoothie.js",
+  "/js/linkerd-demo.js"
+]
 aliases = [
   "/doc/0.1.0/overview",
   "/doc/0.2.0/overview",

--- a/linkerd.io/layouts/1/overview.html
+++ b/linkerd.io/layouts/1/overview.html
@@ -1,8 +1,3 @@
-{{ define "scripts" }}
-<script type="text/javascript" src="/js/smoothie.js"></script>
-<script type="text/javascript" src="/js/linkerd-demo.js"></script>
-{{ end }}
-
 {{ define "main" }}
   {{ partial "landing-page.html" . }}
 {{ end }}

--- a/linkerd.io/layouts/_default/baseof.html
+++ b/linkerd.io/layouts/_default/baseof.html
@@ -13,6 +13,6 @@
 
     {{ partial "footer.html" . }}
 
-    {{ block "scripts" . }}{{ end }}
+    {{ partial "javascript.html" . }}
   </body>
 </html>

--- a/linkerd.io/layouts/partials/docs.html
+++ b/linkerd.io/layouts/partials/docs.html
@@ -16,8 +16,3 @@
     </div>
   </div>
 </div>
-
-<script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.2.0/anchor.min.js" integrity="sha256-m1eTvwEHwmsw4+XKF7BshClVJEPwTVycveNl0CS0Mkk=" crossorigin="anonymous"></script>
-<script>
-  anchors.add('.docs-content h1:not(.title), .docs-content h2, .docs-content h3, .docs-content h4');
-</script>

--- a/linkerd.io/layouts/partials/footer.html
+++ b/linkerd.io/layouts/partials/footer.html
@@ -39,29 +39,3 @@
     </div>
   </footer>
 </div>
-
-<!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="/js/prism.min.js"></script>
-
-<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
-
-<script src="https://cdnjs.cloudflare.com/ajax/libs/ekko-lightbox/5.3.0/ekko-lightbox.min.js" integrity="sha256-Y1rRlwTzT5K5hhCBfAFWABD4cU13QGuRN6P5apfWzVs=" crossorigin="anonymous"></script>
-<!-- For GitHub stat counts. -->
-<script async defer src="https://buttons.github.io/buttons.js"></script>
-
-<script>
-  // Provide lightbox functionality for the figures and gallery
-  $(document).on('click', '[data-toggle="lightbox"]', function(event) {
-    event.preventDefault();
-    $(this).ekkoLightbox();
-  });
-</script>
-
-<script>
-  !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var o=document.getElementsByTagName("script")[0];o.parentNode.insertBefore(n,o);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
-  analytics.load("bNkUVlprW8hKE72fgjKIEm9FI6pOzhT4");
-  analytics.page();
-  }}();
-</script>

--- a/linkerd.io/layouts/partials/javascript.html
+++ b/linkerd.io/layouts/partials/javascript.html
@@ -1,0 +1,39 @@
+{{ $extraJs := .Params.js }}
+{{ $isDocsPage := in (slice "1" "2") .Section }}
+
+{{ range $extraJs }}
+<script src="{{ . }}"></script>
+{{ end }}
+
+<!-- Include all compiled plugins (below), or include individual files as needed -->
+
+<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/ekko-lightbox/5.3.0/ekko-lightbox.min.js" integrity="sha256-Y1rRlwTzT5K5hhCBfAFWABD4cU13QGuRN6P5apfWzVs=" crossorigin="anonymous"></script>
+<!-- For GitHub stat counts. -->
+<script async defer src="https://buttons.github.io/buttons.js"></script>
+
+<script>
+  // Provide lightbox functionality for the figures and gallery
+  $(document).on('click', '[data-toggle="lightbox"]', function(event) {
+    event.preventDefault();
+    $(this).ekkoLightbox();
+  });
+</script>
+
+<script>
+  !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var o=document.getElementsByTagName("script")[0];o.parentNode.insertBefore(n,o);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
+  analytics.load("bNkUVlprW8hKE72fgjKIEm9FI6pOzhT4");
+  analytics.page();
+  }}();
+</script>
+
+{{ if $isDocsPage }}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.2.0/anchor.min.js" integrity="sha256-m1eTvwEHwmsw4+XKF7BshClVJEPwTVycveNl0CS0Mkk=" crossorigin="anonymous"></script>
+<script>
+  anchors.add('.docs-content h1:not(.title), .docs-content h2, .docs-content h3, .docs-content h4');
+</script>
+<script defer src="/js/prism.min.js"></script>
+{{ end }}

--- a/linkerd.io/layouts/partials/javascript.html
+++ b/linkerd.io/layouts/partials/javascript.html
@@ -1,12 +1,7 @@
 {{ $extraJs := .Params.js }}
 {{ $isDocsPage := in (slice "1" "2") .Section }}
 
-{{ range $extraJs }}
-<script src="{{ . }}"></script>
-{{ end }}
-
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-
 <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
@@ -36,4 +31,9 @@
   anchors.add('.docs-content h1:not(.title), .docs-content h2, .docs-content h3, .docs-content h4');
 </script>
 <script defer src="/js/prism.min.js"></script>
+{{ end }}
+
+
+{{ range $extraJs }}
+<script src="{{ . }}"></script>
 {{ end }}


### PR DESCRIPTION
In attempting to implement a fix for #201 I had trouble grokking JavaScript imports, the logic for which is sprinkled across several places. This PR centralizes all JS logic into a single partial and leans on conditionals for page- and section-specific importing. This should make it easier to do JavaScript-y things in the future.