### PR TITLE
Fix link linting on getting started page

### DIFF
--- a/linkerd.io/content/2/getting-started/_index.md
+++ b/linkerd.io/content/2/getting-started/_index.md
@@ -219,10 +219,10 @@ linkerd -n emojivoto check --proxy
 ```
 
 {{< note >}}
-In this step, we meshed the emojivoto app when the app was already running. While
-this ad hoc approach works fine in many cases, Linkerd also supports [automated
-proxy injection](/2/tasks/automating-injection), which is typically more suitable
-for applications using automated deployment patterns.
+In this step, we meshed the emojivoto app when the app was already running.
+While this ad hoc approach works fine in many cases, Linkerd also supports
+[automated proxy injection](/2/tasks/automating-injection/), which is typically
+more suitable for applications using automated deployment patterns.
 {{< /note >}}
 
 ## Step 6: Watch it run


### PR DESCRIPTION
I didn't realize when reviewing #207 that we're now using a link checker that requires trailing slashes on internal links. That change fails `make check`, with:

```
htmltest started at 10:59:15 on public
========================================================================
2/getting-started/index.html
  target is a directory, href lacks trailing slash --- 2/getting-started/index.html --> /2/tasks/automating-injection
========================================================================
✘✘✘ failed in 2m55.29255331s
1 errors in 319 documents
```

This update fixes it and should fix the [CI failure](https://circleci.com/gh/linkerd/website/53). Maybe we should be running the link checker on non-master branches, too?