### PR TITLE
emojivoto: Add service accounts

### DIFF
--- a/run.linkerd.io/public/emojivoto-daemonset.yml
+++ b/run.linkerd.io/public/emojivoto-daemonset.yml
@@ -4,6 +4,24 @@ kind: Namespace
 metadata:
   name: emojivoto
 ---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: emoji
+  namespace: emojivoto
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: voting
+  namespace: emojivoto
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: web
+  namespace: emojivoto
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -20,6 +38,7 @@ spec:
       labels:
         app: emoji-svc
     spec:
+      serviceAccountName: emoji
       containers:
       - env:
         - name: GRPC_PORT
@@ -63,6 +82,7 @@ spec:
       labels:
         app: voting-svc
     spec:
+      serviceAccountName: voting
       containers:
       - env:
         - name: GRPC_PORT
@@ -106,6 +126,7 @@ spec:
       labels:
         app: web-svc
     spec:
+      serviceAccountName: web
       containers:
       - env:
         - name: WEB_PORT

--- a/run.linkerd.io/public/emojivoto-daemonset.yml
+++ b/run.linkerd.io/public/emojivoto-daemonset.yml
@@ -87,7 +87,7 @@ spec:
       - env:
         - name: GRPC_PORT
           value: "8080"
-        image: buoyantio/emojivoto-voting-svc:v5
+        image: buoyantio/emojivoto-voting-svc:v6
         name: voting-svc
         ports:
         - containerPort: 8080
@@ -137,7 +137,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v5
+        image: buoyantio/emojivoto-web:v6
         name: web-svc
         ports:
         - containerPort: 80
@@ -182,7 +182,7 @@ spec:
         env:
         - name: WEB_HOST
           value: web-svc.emojivoto:80
-        image: buoyantio/emojivoto-web:v5
+        image: buoyantio/emojivoto-web:v6
         name: vote-bot
         resources:
           requests:

--- a/run.linkerd.io/public/emojivoto.yml
+++ b/run.linkerd.io/public/emojivoto.yml
@@ -4,6 +4,24 @@ kind: Namespace
 metadata:
   name: emojivoto
 ---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: emoji
+  namespace: emojivoto
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: voting
+  namespace: emojivoto
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: web
+  namespace: emojivoto
+---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
@@ -22,6 +40,7 @@ spec:
       labels:
         app: emoji-svc
     spec:
+      serviceAccountName: emoji
       containers:
       - env:
         - name: GRPC_PORT
@@ -68,6 +87,7 @@ spec:
       labels:
         app: voting-svc
     spec:
+      serviceAccountName: voting
       containers:
       - env:
         - name: GRPC_PORT
@@ -114,6 +134,7 @@ spec:
       labels:
         app: web-svc
     spec:
+      serviceAccountName: web
       containers:
       - env:
         - name: WEB_PORT


### PR DESCRIPTION
Though emojivoto doesn't currently _need_ service accounts for any good
reason, they enhance the identity demo.

All services now have dedicated accounts except the vote-bot, which continues
to use the "default" account.