### PR TITLE
Replace placeholder updates with first community update

### DIFF
--- a/linkerd.io/content/dashboard/20190313.md
+++ b/linkerd.io/content/dashboard/20190313.md
@@ -1,0 +1,8 @@
+---
+date: "2019-03-13T14:51:18-07:00"
+title: "Introducing Community Updates"
+---
+
+Good news, everyone! We've updated the Linkerd Web UI to include a Community
+page that will be refreshed periodically with news and updates, such as this
+one. Stay tuned for more exciting Linkerd content coming your way.

--- a/linkerd.io/content/dashboard/entry1.md
+++ b/linkerd.io/content/dashboard/entry1.md
@@ -1,6 +1,0 @@
-+++
-date = "2018-09-10T12:00:00-07:00"
-title = "Sample Update"
-+++
-
-TODO: This is a work in progress. Add update text here.

--- a/linkerd.io/content/dashboard/entry2.md
+++ b/linkerd.io/content/dashboard/entry2.md
@@ -1,6 +1,0 @@
-+++
-date = "2015-09-10T12:00:00-07:00"
-title = "Sample Update"
-+++
-
-TODO: This is a work in progress. Add update text here.

--- a/linkerd.io/content/dashboard/entry3.md
+++ b/linkerd.io/content/dashboard/entry3.md
@@ -1,6 +1,0 @@
-+++
-date = "2018-09-10T12:00:00-07:00"
-title = "Sample Update"
-+++
-
-TODO: This is a work in progress. Add update text here.


### PR DESCRIPTION
This branch adds our first official community updates page, announcing the updates page itself. This will be displayed in the linkerd web UI once linkerd/linkerd2#2476 ships. As part of this changed, I switched to date-based filenames for updates.