### PR TITLE
Add breadcrumb implementation for docs

### DIFF
--- a/linkerd.io/assets/scss/custom.scss
+++ b/linkerd.io/assets/scss/custom.scss
@@ -11,3 +11,16 @@ $kbd-padding-x: 0.2rem;
 $kbd-color: #212529; // $body-color
 $kbd-bg: #dee2e6; // $gray-300
 
+// Breadcrumb overrides
+$breadcrumb-bg: #fafafa;
+$breadcrumb-padding-x: 1rem;
+$breadcrumb-border-radius: 0;
+
+.breadcrumb-item a {
+  color: $primary;
+
+  &:hover {
+    color: darken($primary, 20%);
+    text-decoration: none;
+  }
+}

--- a/linkerd.io/assets/scss/index.scss
+++ b/linkerd.io/assets/scss/index.scss
@@ -46,7 +46,7 @@ footer li {
 }
 
 .docs-content {
-  h1, h2 {
+  h1:not(.title), h2 {
     border-bottom: 1px solid $gray-500;
     padding-bottom: .5rem;
   }

--- a/linkerd.io/layouts/partials/breadcrumb.html
+++ b/linkerd.io/layouts/partials/breadcrumb.html
@@ -1,11 +1,7 @@
-{{ $version       := index (split .File.Path "/") 0 }}
 {{ $pathN         := len (split .ctx.File.Path "/") }}
 {{ $isSectionPage := eq .ctx.File.LogicalName "_index.md"}}
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb">
-    <li class="breadcrumb-item"><a href="{{ site.BaseURL }}">Home</a></li>
-    <li class="breadcrumb-item"><a href="/{{ .version }}/overview">{{ .version }}</a></li>
-
     {{ if or (and (eq $pathN 3) (not $isSectionPage)) (and (eq $pathN 4) $isSectionPage) }}
     <li class="breadcrumb-item"><a href="{{ .ctx.Parent.URL }}">{{ .ctx.Parent.Title }}</a></li>
     {{ end }}

--- a/linkerd.io/layouts/partials/breadcrumb.html
+++ b/linkerd.io/layouts/partials/breadcrumb.html
@@ -1,0 +1,20 @@
+{{ $version       := index (split .File.Path "/") 0 }}
+{{ $pathN         := len (split .ctx.File.Path "/") }}
+{{ $isSectionPage := eq .ctx.File.LogicalName "_index.md"}}
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><a href="{{ site.BaseURL }}">Home</a></li>
+    <li class="breadcrumb-item"><a href="/{{ .version }}/overview">{{ .version }}</a></li>
+
+    {{ if and (eq $pathN 3) (not $isSectionPage) }}
+    <li class="breadcrumb-item"><a href="{{ .ctx.Parent.URL }}">{{ .ctx.Parent.Title }}</a></li>
+    {{ end }}
+
+    {{ if and (eq $pathN 4) (not $isSectionPage) }}
+    <li class="breadcrumb-item"><a href="{{ .ctx.Parent.Parent.URL }}">{{ .ctx.Parent.Parent.Title }}</a></li>
+    <li class="breadcrumb-item"><a href="{{ .ctx.Parent.URL }}">{{ .ctx.Parent.Title }}</a></li>
+    {{ end }}
+
+    <li class="breadcrumb-item active" aria-current="page">{{ .ctx.Title }}</li>
+  </ol>
+</nav>

--- a/linkerd.io/layouts/partials/breadcrumb.html
+++ b/linkerd.io/layouts/partials/breadcrumb.html
@@ -1,5 +1,7 @@
 {{ $pathN         := len (split .ctx.File.Path "/") }}
 {{ $isSectionPage := eq .ctx.File.LogicalName "_index.md"}}
+
+{{ if or (not $isSectionPage) (gt $pathN 3) }}
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb">
     {{ if or (and (eq $pathN 3) (not $isSectionPage)) (and (eq $pathN 4) $isSectionPage) }}
@@ -14,3 +16,4 @@
     <li class="breadcrumb-item active" aria-current="page">{{ .ctx.Title }}</li>
   </ol>
 </nav>
+{{ end }}

--- a/linkerd.io/layouts/partials/breadcrumb.html
+++ b/linkerd.io/layouts/partials/breadcrumb.html
@@ -6,7 +6,7 @@
     <li class="breadcrumb-item"><a href="{{ site.BaseURL }}">Home</a></li>
     <li class="breadcrumb-item"><a href="/{{ .version }}/overview">{{ .version }}</a></li>
 
-    {{ if and (eq $pathN 3) (not $isSectionPage) }}
+    {{ if or (and (eq $pathN 3) (not $isSectionPage)) (and (eq $pathN 4) $isSectionPage) }}
     <li class="breadcrumb-item"><a href="{{ .ctx.Parent.URL }}">{{ .ctx.Parent.Title }}</a></li>
     {{ end }}
 

--- a/linkerd.io/layouts/partials/docs.html
+++ b/linkerd.io/layouts/partials/docs.html
@@ -1,12 +1,17 @@
+{{ $docsVersion := index (split .page.URL "/") 1 }}
 <div class="container">
   <div class="row">
     <div class="col-md-3 pt-5">
-      {{ $docsVersion := index (split .page.URL "/") 1 }}
       {{ partial (printf "%s/%s" $docsVersion "sidebar") . }}
     </div>
 
     <div class="col-md-9 border-left docs-content">
-      <h1 class="title display-4 mb-4">{{ .page.Title }}</h1>
+      <h1 class="title display-4">
+        {{ .page.Title }}
+      </h1>
+
+      {{ partial "breadcrumb.html" (dict "version" $docsVersion "ctx" .page) }}
+
       <div class="content language-markup">
         {{ if .page.Params.include_toc }}
         {{ .page.TableOfContents }}


### PR DESCRIPTION
Addresses issue #223. The implementation isn't super elegant but it works.

**Important caveat**: If the documentation "tree" goes any deeper than it currently does, the breadcrumb will not work. Make sure to adjust for additional levels should the need arise.

You can see an example implementation here:

https://deploy-preview-224--linkerd.netlify.com/2/reference/cli/completion/