### PR TITLE
Adding redirect for linkerd.io/upgrade

### DIFF
--- a/linkerd.io/static/upgrade/index.html
+++ b/linkerd.io/static/upgrade/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=https://linkerd.io/2/tasks/upgrade/">
+    <script type="text/javascript">
+    window.onload = function() {
+      window.location.href = window.location.origin + "/2/tasks/upgrade/" + window.location.hash;
+    }
+    </script>
+    <title>Linkerd Upgrade Redirection</title>
+  </head>
+  <body>
+    If you are not redirected automatically, follow this
+    <a href='https://linkerd.io/2/tasks/upgrade/'>link</a>.
+  </body>
+</html>


### PR DESCRIPTION
This PR adds a redirect that will send `linkerd.io/upgrade/#anchor` to `linkerd.io/2/tasks/upgrade/#anchor`. 

The `linkerd.io/upgrade` pattern is currently being used by `linkerd upgrade` in the CLI.