### PR TITLE
New hint anchor reflecting new pre-install check

### DIFF
--- a/linkerd.io/content/2/tasks/troubleshooting.md
+++ b/linkerd.io/content/2/tasks/troubleshooting.md
@@ -60,6 +60,12 @@ permissions to install Linkerd.
 For more information on cluster access, see the
 [GKE Setup](/2/tasks/install/#gke) section above.
 
+## √ no clock skew detected {#pre-k8s-clock-skew}
+
+This check verifies whether there is a  clock skew between system running
+the `linkerd install` command and the Kubernetes node(s), causing 
+potential issues.
+
 ## The "pre-kubernetes-capability" checks {#pre-k8s-capability}
 
 These checks only run when the `--pre` flag is set. This flag is intended for

--- a/linkerd.io/content/2/tasks/troubleshooting.md
+++ b/linkerd.io/content/2/tasks/troubleshooting.md
@@ -62,7 +62,7 @@ For more information on cluster access, see the
 
 ## √ no clock skew detected {#pre-k8s-clock-skew}
 
-This check verifies whether there is a  clock skew between system running
+This check verifies whether there is clock skew between the system running
 the `linkerd install` command and the Kubernetes node(s), causing 
 potential issues.
 


### PR DESCRIPTION
Subject
New hint anchor reflecting new pre-install check

Problem
There is a pending PR for new healthcheck. In order for this healthcheck to be fully implemented, an update is also required for the troubleshooting page.

Solution
Updated the relevant page with anchor and a paragraph with hint

References [issue 2762 ](https://github.com/linkerd/linkerd2/issues/2762) in the `linkerd2` repository

Signed-off-by: Matej Gera <matejgera@gmail.com>