### PR TITLE
Fix whitespace linting issue

### DIFF
--- a/linkerd.io/content/2/tasks/troubleshooting.md
+++ b/linkerd.io/content/2/tasks/troubleshooting.md
@@ -63,7 +63,7 @@ For more information on cluster access, see the
 ## √ no clock skew detected {#pre-k8s-clock-skew}
 
 This check verifies whether there is clock skew between the system running
-the `linkerd install` command and the Kubernetes node(s), causing 
+the `linkerd install` command and the Kubernetes node(s), causing
 potential issues.
 
 ## The "pre-kubernetes-capability" checks {#pre-k8s-capability}


### PR DESCRIPTION
#297 introduced trailing whitespace that broke the `make lint` check. I'm not sure why that wasn't detected on the branch and only appeared once the change made it to master. This should fix it.