### PR TITLE
303: fix ingress note typo

### DIFF
--- a/linkerd.io/content/2/tasks/using-ingress.md
+++ b/linkerd.io/content/2/tasks/using-ingress.md
@@ -71,7 +71,7 @@ FQDN (`web-svc.emojivoto.svc.cluster.local`) *and* the destination
 `servicePort`.
 
 {{< note >}}
-When using Nginx to terminal HTTPS, Linkerd is unable to strip internal headers
+When using Nginx to terminate HTTPS, Linkerd is unable to strip internal headers
 that are normally provided to applications to make decisions. The
 `proxy_hide_header` lines will strip these headers out so that any internal
 cluster details do not leak.
@@ -137,7 +137,7 @@ FQDN (`web-svc.emojivoto.svc.cluster.local`) *and* the destination
 `servicePort`.
 
 {{< note >}}
-When using Traefik to terminal HTTPS, Linkerd is unable to strip internal
+When using Traefik to terminate HTTPS, Linkerd is unable to strip internal
 headers that are normally provided to applications to make decisions. The
 `ingress.kubernetes.io/custom-response-headers` line will strip these headers
 out so that any internal cluster details do not leak.


### PR DESCRIPTION
Subject
Small typo on [using-ingress](https://linkerd.io/2/tasks/using-ingress/) page

Problem
The text reads "terminal HTTPS" and it should read "terminate HTTPS"

Solution
Fix the typo

Validation
Just eyeballed it.

Fixes #303
