### PR TITLE
Bump minimum Kubernetes cluster version from 1.9 to 1.10 (Closes #311)

### DIFF
--- a/linkerd.io/content/2/getting-started/_index.md
+++ b/linkerd.io/content/2/getting-started/_index.md
@@ -25,8 +25,8 @@ We'll walk you through this process step by step.
 ## Step 0: Setup
 
 Before we can do anything, we need to ensure you have access to a Kubernetes
-cluster running 1.9 or later, and a functioning `kubectl` command on your local
-machine.
+cluster running 1.10 or later, and a functioning `kubectl` command on your
+local machine.
 
 You can run Kubernetes on your local machine. We suggest
 [Docker Desktop](https://www.docker.com/products/docker-desktop) or

--- a/linkerd.io/content/2/getting-started/_index.md
+++ b/linkerd.io/content/2/getting-started/_index.md
@@ -25,7 +25,7 @@ We'll walk you through this process step by step.
 ## Step 0: Setup
 
 Before we can do anything, we need to ensure you have access to a Kubernetes
-cluster running 1.10 or later, and a functioning `kubectl` command on your
+cluster running 1.10.0 or later, and a functioning `kubectl` command on your
 local machine.
 
 You can run Kubernetes on your local machine. We suggest


### PR DESCRIPTION
As stated in #311, minimum K8s version seems to be 1.10 instead of 1.9. This is a just a bump of this requirement on the website :slightly_smiling_face: 