### PR TITLE
Fix uninstall.md

### DIFF
--- a/linkerd.io/content/2/tasks/uninstall.md
+++ b/linkerd.io/content/2/tasks/uninstall.md
@@ -21,7 +21,7 @@ Then, to remove the [control plane](/2/reference/architecture/#control-plane),
 run:
 
 ```bash
-linkerd install | kubectl delete -f -
+linkerd install --ignore-cluster | kubectl delete -f -
 ```
 
 The `linkerd install` command outputs the YAML definitions for all of the


### PR DESCRIPTION
Running
`linkerd install | kubectl delete -f -`
will only output 
`Linkerd has already been installed on your cluster in the linkerd namespace. Please run upgrade if you'd like to update this installation. Otherwise, use the --ignore-cluster flag.`
Running `linkerd install --ignore-cluster | kubectl delete -f -` seems to do the job.