### PR TITLE
update community page for 2.3.1 release.

### DIFF
--- a/linkerd.io/content/dashboard/20190531.md
+++ b/linkerd.io/content/dashboard/20190531.md
@@ -3,6 +3,8 @@ title: "Announcing Linkerd2 stable-2.3.1"
 date: 2019-05-31T13:19:42-07:00
 ---
 
-We are pleased to announce that Linkerd2 stable-2.3.1 has been released! This
-stable release adds a number of proxy stability improvements. Full release
-notes are available [here](https://lists.cncf.io/g/cncf-linkerd-dev/message/127)
+We are pleased to announce that
+[Linkerd2 stable-2.3.1](https://github.com/linkerd/linkerd2/releases/tag/stable-2.3.1)
+has been released! This stable release adds a number of proxy stability
+improvements. Full release notes are available
+[here.](https://lists.cncf.io/g/cncf-linkerd-dev/message/127)

--- a/linkerd.io/content/dashboard/20190531.md
+++ b/linkerd.io/content/dashboard/20190531.md
@@ -1,0 +1,8 @@
+---
+title: "Announcing Linkerd2 stable-2.3.1"
+date: 2019-05-31T13:19:42-07:00
+---
+
+We are pleased to announce that Linkerd2 stable-2.3.1 has been released! This
+stable release adds a number of proxy stability improvements. Full release
+notes are available [here](https://lists.cncf.io/g/cncf-linkerd-dev/message/127)


### PR DESCRIPTION
Updates the community dashboard page to include a Linkerd2 stable-2.3.1 announcement.

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>