### PR TITLE
Add ServiceMonitor setup example

### DIFF
--- a/linkerd.io/content/2/tasks/exporting-metrics.md
+++ b/linkerd.io/content/2/tasks/exporting-metrics.md
@@ -53,6 +53,43 @@ running):
       - '{job="linkerd-controller"}'
 ```
 
+Alternatively, if you prefer to use Prometheus' ServiceMonitors to configure your Prometheus, you can use this ServiceMonitor YAML (replace `{{.Namespace}}` with the namespace where Linkerd is
+running):
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: linkerd-prometheus
+    release: monitoring
+  name: linkerd-federate
+  namespace: {{.Namespace}}
+spec:
+  endpoints:
+  - interval: 30s
+    scrapeTimeout: 30s
+    params:
+      match[]:
+      - '{job="linkerd-proxy"}'
+      - '{job="linkerd-controller"}'
+    path: /federate 
+    port: admin-http
+    honorLabels: true
+    relabelings:
+    - action: keep
+      regex: '^prometheus$'
+      sourceLabels:
+      - '__meta_kubernetes_pod_container_name'
+  jobLabel: app
+  namespaceSelector:
+    matchNames:
+    - {{.Namespace}}
+  selector:
+    matchLabels:
+      linkerd.io/control-plane-component: prometheus
+```
+
 That's it! Your Prometheus cluster is now configured to federate Linkerd's
 metrics from Linkerd's internal Prometheus instance.
 


### PR DESCRIPTION
I wanted to use a ServiceMonitor to configure my Federation Scraping. So i put one together and tested it. I thought it might help others to add that to the docs.