### PR TITLE
Prevented the tweets from overflowing off the page

### DIFF
--- a/linkerd.io/themes/buoyant/assets/bulma/sass/grid/columns.sass
+++ b/linkerd.io/themes/buoyant/assets/bulma/sass/grid/columns.sass
@@ -8,6 +8,7 @@ $column-gap: 0.75rem !default
   padding: $column-gap
   .columns.is-mobile > &.is-narrow
     flex: none
+    max-width: 91.66666667%
   .columns.is-mobile > &.is-full
     flex: none
     width: 100%


### PR DESCRIPTION
An attempt at fixing issue #355 

Before (1080p):
![Before](https://user-images.githubusercontent.com/9866621/59756339-6be33680-9281-11e9-812c-45ad97117992.png)

After (1080p):
![After](https://user-images.githubusercontent.com/9866621/59756344-6ede2700-9281-11e9-984e-73f92a48e7c4.png)
