### PR TITLE
Restoring CSS styling for dashboard update page

### DIFF
--- a/linkerd.io/layouts/page/dashboard.html
+++ b/linkerd.io/layouts/page/dashboard.html
@@ -10,7 +10,7 @@
     {{ range $index, $page := sort $subPages "Lastmod" "desc" }}
       <div class="card">
           <div class="card-body">
-            <h4>{{ $page.Title }}</h4>
+            <h6>{{ $page.Title }}</h6>
             <p>{{ dateFormat "Monday, January 2, 2006" $page.Date }}</p>
             <p>{{ $page.Content }}</p>
           </div>

--- a/linkerd.io/layouts/partials/css.html
+++ b/linkerd.io/layouts/partials/css.html
@@ -1,4 +1,12 @@
 {{ $inServerMode := site.IsServer }}
+{{ $useMaterial  := .Page.Params.use_material }}
+{{ if $useMaterial }}
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-material-design/4.0.2/bootstrap-material-design.css" />
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css">
+<link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400" rel="stylesheet">
+<link rel="stylesheet" href="/css/dashboard-updates.css" />
+{{ end }}
+{{ if not $useMaterial }}
 {{ $sass         := "scss/styles.scss" }}
 {{ $cssOutput    := "css/style.css"}}
 {{ $cssDevOpts   := (dict "targetpath" $cssOutput "enableSourceMap" true) }}
@@ -13,4 +21,5 @@
 {{ else }}
 {{ $prodCss := $css | fingerprint }}
 <link rel="stylesheet" href="{{ $prodCss.RelPermalink }}">
+{{ end }}
 {{ end }}

--- a/linkerd.io/static/css/dashboard-updates.css
+++ b/linkerd.io/static/css/dashboard-updates.css
@@ -1,0 +1,18 @@
+.dashboard-background {
+  background-color: #fafafa;
+}
+
+body {
+  color: rgba(0, 0, 0, 0.87)
+}
+
+h6 {
+  font-size: 1.25rem;
+  font-weight: 400;
+  line-height: 1.6;
+  letter-spacing: 0.0075em;
+}
+
+a {
+  color: #2196f3;
+}


### PR DESCRIPTION
This PR styles the dashboard update page at `linkerd.io/dashboard`. The styling had changed with the redesign.

Before:
![Screen Shot 2019-06-19 at 6 25 29 PM](https://user-images.githubusercontent.com/2289389/59811650-b4b9e000-92bf-11e9-9061-329d285f8eb1.png)

After:
![Screen Shot 2019-06-19 at 6 27 21 PM](https://user-images.githubusercontent.com/2289389/59811689-e92d9c00-92bf-11e9-8c91-4b61641e4b36.png)
