### PR TITLE
Remove broken JS snippet

### DIFF
--- a/linkerd.io/layouts/_default/baseof.html
+++ b/linkerd.io/layouts/_default/baseof.html
@@ -26,11 +26,6 @@
   {{ block "body-end" . }}
   {{ end }}
 
-  <script>
-    {{/*  anchors.options.icon = '';  */}}
-    anchors.add('.blog-content-container h1:not(.title), .blog-content-container h2, .blog-content-container h3, .blog-content-container h4');
-  </script>
-
   <div class="modal" id="galleryModal">
     <div class="modal-background" onclick="hideImageModal()"></div>
     <div class="modal-content">


### PR DESCRIPTION
I noticed the following JS error on linkerd.io:

![Screen Shot 2019-06-21 at 3 26 30 PM](https://user-images.githubusercontent.com/9226/59954404-4f89fa00-9439-11e9-9680-15133c501506.png)

This branch removes the JS that is causing that error, since I couldn't figure out any way to fix it. My guess is that's it's leftover from the previous design. But happy to discard this if there's a better fix.