### PR TITLE
Add docs for multi stage installation

### DIFF
--- a/linkerd.io/content/2/getting-started/_index.md
+++ b/linkerd.io/content/2/getting-started/_index.md
@@ -132,6 +132,11 @@ Check out the [architecture](/2/reference/architecture/#control-plane)
 documentation for an in depth explanation of what these components are and what
 they do.
 
+{{< note >}}
+For organizations that distinguish cluster privileges by role, see the
+[Multi-stage install](/2/tasks/install/#multi-stage-install) instructions.
+{{< /note >}}
+
 ## Step 4: Explore Linkerd
 
 With the control plane installed and running, you can now view the Linkerd

--- a/linkerd.io/content/2/tasks/install.md
+++ b/linkerd.io/content/2/tasks/install.md
@@ -55,6 +55,11 @@ linkerd install | kubectl apply -f -
 
 See [Getting Started](/2/getting-started/) for an example.
 
+{{< note >}}
+For organizations that distinguish cluster privileges by role, jump to the
+[Multi-stage install](#multi-stage-install) section.
+{{< /note >}}
+
 ## Verification
 
 After installation, you can validate that the installation was successful by
@@ -67,3 +72,73 @@ linkerd check
 ## Uninstalling
 
 See [Uninstalling Linkerd](/2/tasks/uninstall/).
+
+## Multi-stage install
+
+If your organization assigns Kuberenetes cluster privileges based on role
+(typically cluster owner and service owner), Linkerd provides a "multi-stage"
+installation to accomodate these two roles. The two installation stages are
+`config` (for the cluster owner) and `control-plane` (for the service owner).
+The cluster owner has privileges necessary to create namespaces, as well as
+global resources including cluster roles, bindings, and custom resource
+definitions. The service owner has privileges within a namespace necessary to
+create deployments, configmaps, services, and secrets.
+
+### Stage 1: config
+
+The `config` stage is intended to be run by the cluster owner, the role with
+more privileges. It is also the cluster owner's responsbility to run the
+initial pre-install check:
+
+```bash
+linkerd check --pre
+```
+
+Once the pre-install check passes, install the config stage with:
+
+```bash
+linkerd install config | kubectl apply -f -
+```
+
+In addition to creating the `linkerd` namespace, this command installs the
+following resources onto your Kubernetes cluster:
+
+- ClusterRole
+- ClusterRoleBinding
+- CustomResourceDefinition
+- MutatingWebhookConfiguration
+- PodSecurityPolicy
+- Role
+- RoleBinding
+- Secret
+- ServiceAccount
+- ValidatingWebhookConfiguration
+
+To validate the `config` stage succeeded, run:
+
+```bash
+linkerd check config
+```
+
+### Stage 2: control-plane
+
+Following successfuly installation of the `config` stage, the service owner may
+install the `control-plane` with:
+
+```bash
+linkerd install control-plane | kubectl apply -f -
+```
+
+This command installs the following resources onto your Kubernetes cluster, all
+within the `linkerd` namespace:
+
+- ConfigMap
+- Deployment
+- Secret
+- Service
+
+To validate the `control-plane` stage succeeded, run:
+
+```bash
+linkerd check
+```

--- a/linkerd.io/content/2/tasks/uninstall.md
+++ b/linkerd.io/content/2/tasks/uninstall.md
@@ -32,3 +32,9 @@ service accounts, CRDs, and more; `kubectl delete` then deletes those resources.
 This command also removes control planes that have been only partially
 installed.
 {{< /note >}}
+
+{{< note >}}
+If the initial installation was performed as a
+[Multi-stage install](/2/tasks/install/#multi-stage-install), uninstallation
+should be done by the cluster owner.
+{{< /note >}}

--- a/linkerd.io/content/2/tasks/upgrade.md
+++ b/linkerd.io/content/2/tasks/upgrade.md
@@ -48,6 +48,25 @@ linkerd upgrade | kubectl apply -f -
 Follow instructions for
 [upgrading the data plane](#upgrade-the-data-plane).
 
+#### Upgading a multi-stage install
+
+`edge-19.4.5` introduced a
+[Multi-stage install](/2/tasks/install/#multi-stage-install) feature. If you
+previously installed Linkerd via a multi-stage install process, you can upgrade
+each stage, analogous to the original multi-stage installation process.
+
+Stage 1, for the cluster owner:
+
+```bash
+linkerd upgrade config | kubectl apply -f -
+```
+
+Stage 2, for the service owner:
+
+```bash
+linkerd upgrade control-plane | kubectl apply -f -
+```
+
 #### Upgrading via manifests
 
 `edge-19.4.5` introduced a new `--from-manifests` flag to `linkerd upgrade`


### PR DESCRIPTION
Add a multi-stage section to `/tasks/install`, link to it from Getting
Started page.

Fixes #380

Signed-off-by: Andrew Seigner <siggy@buoyant.io>