### PR TITLE
Update the CLI and annotation docs for 2.4

### DIFF
--- a/linkerd.io/content/2/reference/cli/check.md
+++ b/linkerd.io/content/2/reference/cli/check.md
@@ -57,3 +57,16 @@ Status check results are √
 ```
 
 {{< cli/flags "check" >}}
+
+## Subcommands
+
+Check supports subcommands as part of the
+[Multi-stage install](/2/tasks/install/#multi-stage-install) feature.
+
+### config
+
+{{< cli/description "check config" >}}
+
+{{< cli/examples "check config" >}}
+
+{{< cli/flags "check config" >}}

--- a/linkerd.io/content/2/reference/cli/install.md
+++ b/linkerd.io/content/2/reference/cli/install.md
@@ -10,3 +10,24 @@ the [install documentation](/2/tasks/install/).
 {{< cli/examples "install" >}}
 
 {{< cli/flags "install" >}}
+
+## Subcommands
+
+Install supports subcommands as part of the
+[Multi-stage install](/2/tasks/install/#multi-stage-install) feature.
+
+### config
+
+{{< cli/description "install config" >}}
+
+{{< cli/examples "install config" >}}
+
+{{< cli/flags "install config" >}}
+
+### control-plane
+
+{{< cli/description "install control-plane" >}}
+
+{{< cli/examples "install control-plane" >}}
+
+{{< cli/flags "install control-plane" >}}

--- a/linkerd.io/content/2/reference/cli/upgrade.md
+++ b/linkerd.io/content/2/reference/cli/upgrade.md
@@ -7,3 +7,24 @@ title = "upgrade"
 {{< cli/examples "upgrade" >}}
 
 {{< cli/flags "upgrade" >}}
+
+## Subcommands
+
+Upgrade supports subcommands as part of the
+[Multi-stage install](/2/tasks/install/#multi-stage-install) feature.
+
+### config
+
+{{< cli/description "upgrade config" >}}
+
+{{< cli/examples "upgrade config" >}}
+
+{{< cli/flags "upgrade config" >}}
+
+### control-plane
+
+{{< cli/description "upgrade control-plane" >}}
+
+{{< cli/examples "upgrade control-plane" >}}
+
+{{< cli/flags "upgrade control-plane" >}}

--- a/linkerd.io/data/cli.yaml
+++ b/linkerd.io/data/cli.yaml
@@ -1,4 +1,25 @@
 - Description: |-
+    Check the Linkerd cluster-wide resources for potential problems.
+
+    The check command will perform a series of checks to validate that the Linkerd
+    cluster-wide resources are configured correctly. It is intended to validate that
+    "linkerd install config" succeeded. If the command encounters a failure it will
+    print additional information about the failure and exit with a non-zero exit
+    code.
+  Example: |2-
+      # Check that the Linkerd cluster-wide resource are installed correctly
+      linkerd check config
+  InheritedOptions: null
+  Name: check config
+  Options:
+  - DefaultValue: ""
+    Name: help
+    Shorthand: h
+    Usage: help for config
+  SeeAlso: null
+  Synopsis: |
+    Check the Linkerd cluster-wide resources for potential problems
+- Description: |-
     Check the Linkerd installation for potential problems.
 
     The check command will perform a series of checks to validate that the linkerd
@@ -11,6 +32,9 @@
 
       # Check that the Linkerd control plane can be installed in the "test" namespace
       linkerd check --pre --linkerd-namespace test
+
+      # Check that "linkerd install config" succeeded
+      linkerd check config
 
       # Check that the Linkerd data plane proxies in the "app" namespace are up and running
       linkerd check --proxy --namespace app
@@ -36,6 +60,10 @@
     Shorthand: "n"
     Usage: |
       Namespace to use for --proxy checks (default: all namespaces)
+  - DefaultValue: ""
+    Name: output
+    Shorthand: o
+    Usage: 'Output format. One of: basic, json'
   - DefaultValue: ""
     Name: pre
     Shorthand: ""
@@ -111,6 +139,54 @@
   SeeAlso: null
   Synopsis: Open the Linkerd dashboard in a web browser
 - Description: |-
+    Display connections between resources, and Linkerd proxy identities.
+
+      The RESOURCETYPE argument specifies the type of resource to display edges within.
+
+      Examples:
+      * deploy
+      * ds
+      * job
+      * po
+      * rc
+      * sts
+
+      Valid resource types include:
+      * daemonsets
+      * deployments
+      * jobs
+      * pods
+      * replicationcontrollers
+      * statefulsets
+  Example: "  # Get all edges between pods that either originate from or terminate
+    in the demo namespace.\n  linkerd edges po -n test\n\n  # Get all edges between
+    pods that either originate from or terminate in the default namespace.\n  linkerd
+    edges po\n\t\t\n  # Get all edges between pods in all namespaces.\n  linkerd edges
+    po --all-namespaces"
+  InheritedOptions: null
+  Name: edges
+  Options:
+  - DefaultValue: ""
+    Name: all-namespaces
+    Shorthand: ""
+    Usage: |
+      If present, returns edges across all namespaces, ignoring the "--namespace" flag
+  - DefaultValue: ""
+    Name: help
+    Shorthand: h
+    Usage: help for edges
+  - DefaultValue: ""
+    Name: namespace
+    Shorthand: "n"
+    Usage: Namespace of the specified resource
+  - DefaultValue: ""
+    Name: output
+    Shorthand: o
+    Usage: 'Output format; one of: "table" or "json"'
+  SeeAlso: null
+  Synopsis: |
+    Display connections between resources, and Linkerd proxy identities
+- Description: |-
     Introspect Linkerd's service discovery state.
 
     This command provides debug information about the internal state of the
@@ -182,8 +258,8 @@
       # Inject all the deployments in the default namespace.
       kubectl get deploy -o yaml | linkerd inject - | kubectl apply -f -
 
-      # Download a resource and inject it through stdin.
-      curl http://url.to/yml | linkerd inject - | kubectl apply -f -
+      # Injecting a file from a remote URL
+      linkerd inject http://url.to/yml | kubectl apply -f -
 
       # Inject all the resources inside a folder and its sub-folders.
       linkerd inject <folder> | kubectl apply -f -
@@ -202,6 +278,14 @@
     Name: disable-identity
     Shorthand: ""
     Usage: Disables resources from participating in TLS identity
+  - DefaultValue: ""
+    Name: disable-tap
+    Shorthand: ""
+    Usage: Disables resources from from being tapped
+  - DefaultValue: ""
+    Name: enable-debug-sidecar
+    Shorthand: ""
+    Usage: Inject a debug sidecar for data plane debugging
   - DefaultValue: ""
     Name: enable-external-profiles
     Shorthand: ""
@@ -228,9 +312,14 @@
     Shorthand: ""
     Usage: Linkerd init container image name
   - DefaultValue: ""
-    Name: linkerd-version
-    Shorthand: v
-    Usage: Tag to be used for Linkerd images
+    Name: init-image-version
+    Shorthand: ""
+    Usage: Linkerd init container image version
+  - DefaultValue: ""
+    Name: manual
+    Shorthand: ""
+    Usage: |
+      Include the proxy sidecar container spec in the YAML output (the auto-injector won't pick it up, so config annotations aren't supported) (default false)
   - DefaultValue: ""
     Name: outbound-port
     Shorthand: ""
@@ -272,6 +361,10 @@
     Shorthand: ""
     Usage: Run the proxy under this user ID
   - DefaultValue: ""
+    Name: proxy-version
+    Shorthand: v
+    Usage: Tag to be used for the Linkerd proxy images
+  - DefaultValue: ""
     Name: registry
     Shorthand: ""
     Usage: Docker registry to pull images from
@@ -286,8 +379,221 @@
     Usage: Outbound ports that should skip the proxy
   SeeAlso: null
   Synopsis: Add the Linkerd proxy to a Kubernetes config
-- Description: Output Kubernetes configs to install Linkerd.
-  Example: ""
+- Description: |-
+    Output Kubernetes cluster-wide resources to install Linkerd.
+
+    This command provides Kubernetes configs necessary to install cluster-wide
+    resources for the Linkerd control plane. This command should be followed by
+    "linkerd install control-plane".
+  Example: |2-
+      # Default install.
+      linkerd install config | kubectl apply -f -
+
+      # Install Linkerd into a non-default namespace.
+      linkerd install config -l linkerdtest | kubectl apply -f -
+  InheritedOptions: null
+  Name: install config
+  Options:
+  - DefaultValue: ""
+    Name: help
+    Shorthand: h
+    Usage: help for config
+  - DefaultValue: ""
+    Name: linkerd-cni-enabled
+    Shorthand: ""
+    Usage: |
+      Experimental: Omit the NET_ADMIN capability in the PSP and the proxy-init container when injecting the proxy; requires the linkerd-cni plugin to already be installed
+  SeeAlso: null
+  Synopsis: Output Kubernetes cluster-wide resources to install Linkerd
+- Description: |-
+    Output Kubernetes control plane resources to install Linkerd.
+
+    This command provides Kubernetes configs necessary to install the Linkerd
+    control plane. It should be run after "linkerd install config".
+  Example: |2-
+      # Default install.
+      linkerd install control-plane | kubectl apply -f -
+
+      # Install Linkerd into a non-default namespace.
+      linkerd install control-plane -l linkerdtest | kubectl apply -f -
+  InheritedOptions: null
+  Name: install control-plane
+  Options:
+  - DefaultValue: ""
+    Name: admin-port
+    Shorthand: ""
+    Usage: Proxy port to serve metrics on
+  - DefaultValue: ""
+    Name: control-plane-version
+    Shorthand: ""
+    Usage: |
+      (Development) Tag to be used for the control plane component images
+  - DefaultValue: ""
+    Name: control-port
+    Shorthand: ""
+    Usage: Proxy port to use for control
+  - DefaultValue: ""
+    Name: controller-log-level
+    Shorthand: ""
+    Usage: Log level for the controller and web components
+  - DefaultValue: ""
+    Name: controller-replicas
+    Shorthand: ""
+    Usage: Replicas of the controller to deploy
+  - DefaultValue: ""
+    Name: controller-uid
+    Shorthand: ""
+    Usage: Run the control plane components under this user ID
+  - DefaultValue: ""
+    Name: disable-h2-upgrade
+    Shorthand: ""
+    Usage: |
+      Prevents the controller from instructing proxies to perform transparent HTTP/2 upgrading (default false)
+  - DefaultValue: ""
+    Name: enable-external-profiles
+    Shorthand: ""
+    Usage: Enable service profiles for non-Kubernetes services
+  - DefaultValue: ""
+    Name: ha
+    Shorthand: ""
+    Usage: |
+      Experimental: Enable HA deployment config for the control plane (default false)
+  - DefaultValue: ""
+    Name: help
+    Shorthand: h
+    Usage: help for control-plane
+  - DefaultValue: ""
+    Name: identity-clock-skew-allowance
+    Shorthand: ""
+    Usage: |
+      The amount of time to allow for clock skew within a Linkerd cluster
+  - DefaultValue: ""
+    Name: identity-issuance-lifetime
+    Shorthand: ""
+    Usage: |
+      The amount of time for which the Identity issuer should certify identity
+  - DefaultValue: ""
+    Name: identity-issuer-certificate-file
+    Shorthand: ""
+    Usage: |
+      A path to a PEM-encoded file containing the Linkerd Identity issuer certificate (generated by default)
+  - DefaultValue: ""
+    Name: identity-issuer-key-file
+    Shorthand: ""
+    Usage: |
+      A path to a PEM-encoded file containing the Linkerd Identity issuer private key (generated by default)
+  - DefaultValue: ""
+    Name: identity-trust-anchors-file
+    Shorthand: ""
+    Usage: |
+      A path to a PEM-encoded file containing Linkerd Identity trust anchors (generated by default)
+  - DefaultValue: ""
+    Name: identity-trust-domain
+    Shorthand: ""
+    Usage: Configures the name suffix used for identities.
+  - DefaultValue: ""
+    Name: image-pull-policy
+    Shorthand: ""
+    Usage: Docker image pull policy
+  - DefaultValue: ""
+    Name: inbound-port
+    Shorthand: ""
+    Usage: Proxy port to use for inbound traffic
+  - DefaultValue: ""
+    Name: init-image
+    Shorthand: ""
+    Usage: Linkerd init container image name
+  - DefaultValue: ""
+    Name: init-image-version
+    Shorthand: ""
+    Usage: Linkerd init container image version
+  - DefaultValue: ""
+    Name: linkerd-cni-enabled
+    Shorthand: ""
+    Usage: |
+      Experimental: Omit the NET_ADMIN capability in the PSP and the proxy-init container when injecting the proxy; requires the linkerd-cni plugin to already be installed
+  - DefaultValue: ""
+    Name: omit-webhook-side-effects
+    Shorthand: ""
+    Usage: |
+      Omit the sideEffects flag in the webhook manifests, This flag must be provided during install or upgrade for Kubernetes versions pre 1.12
+  - DefaultValue: ""
+    Name: outbound-port
+    Shorthand: ""
+    Usage: Proxy port to use for outbound traffic
+  - DefaultValue: ""
+    Name: proxy-cpu
+    Shorthand: ""
+    Usage: Amount of CPU units that the proxy sidecar requests
+  - DefaultValue: ""
+    Name: proxy-cpu-limit
+    Shorthand: ""
+    Usage: Maximum amount of CPU units that the proxy sidecar can use
+  - DefaultValue: ""
+    Name: proxy-cpu-request
+    Shorthand: ""
+    Usage: Amount of CPU units that the proxy sidecar requests
+  - DefaultValue: ""
+    Name: proxy-image
+    Shorthand: ""
+    Usage: Linkerd proxy container image name
+  - DefaultValue: ""
+    Name: proxy-log-level
+    Shorthand: ""
+    Usage: Log level for the proxy
+  - DefaultValue: ""
+    Name: proxy-memory
+    Shorthand: ""
+    Usage: Amount of Memory that the proxy sidecar requests
+  - DefaultValue: ""
+    Name: proxy-memory-limit
+    Shorthand: ""
+    Usage: Maximum amount of Memory that the proxy sidecar can use
+  - DefaultValue: ""
+    Name: proxy-memory-request
+    Shorthand: ""
+    Usage: Amount of Memory that the proxy sidecar requests
+  - DefaultValue: ""
+    Name: proxy-uid
+    Shorthand: ""
+    Usage: Run the proxy under this user ID
+  - DefaultValue: ""
+    Name: proxy-version
+    Shorthand: v
+    Usage: Tag to be used for the Linkerd proxy images
+  - DefaultValue: ""
+    Name: registry
+    Shorthand: ""
+    Usage: Docker registry to pull images from
+  - DefaultValue: ""
+    Name: skip-checks
+    Shorthand: ""
+    Usage: Skip checks for namespace existence
+  - DefaultValue: ""
+    Name: skip-inbound-ports
+    Shorthand: ""
+    Usage: |
+      Ports that should skip the proxy and send directly to the application
+  - DefaultValue: ""
+    Name: skip-outbound-ports
+    Shorthand: ""
+    Usage: Outbound ports that should skip the proxy
+  SeeAlso: null
+  Synopsis: Output Kubernetes control plane resources to install Linkerd
+- Description: |-
+    Output Kubernetes configs to install Linkerd.
+
+    This command provides all Kubernetes configs necessary to install the Linkerd
+    control plane.
+  Example: |2-
+      # Default install.
+      linkerd install | kubectl apply -f -
+
+      # Install Linkerd into a non-default namespace.
+      linkerd install -l linkerdtest | kubectl apply -f -
+
+      # Installation may also be broken up into two stages by user privilege, via
+      # subcommands.
   InheritedOptions: null
   Name: install
   Options:
@@ -295,6 +601,11 @@
     Name: admin-port
     Shorthand: ""
     Usage: Proxy port to serve metrics on
+  - DefaultValue: ""
+    Name: control-plane-version
+    Shorthand: ""
+    Usage: |
+      (Development) Tag to be used for the control plane component images
   - DefaultValue: ""
     Name: control-port
     Shorthand: ""
@@ -376,23 +687,23 @@
     Shorthand: ""
     Usage: Linkerd init container image name
   - DefaultValue: ""
+    Name: init-image-version
+    Shorthand: ""
+    Usage: Linkerd init container image version
+  - DefaultValue: ""
     Name: linkerd-cni-enabled
     Shorthand: ""
     Usage: |
-      Experimental: Omit the proxy-init container when injecting the proxy; requires the linkerd-cni plugin to already be installed
+      Experimental: Omit the NET_ADMIN capability in the PSP and the proxy-init container when injecting the proxy; requires the linkerd-cni plugin to already be installed
   - DefaultValue: ""
-    Name: linkerd-version
-    Shorthand: v
-    Usage: Tag to be used for Linkerd images
+    Name: omit-webhook-side-effects
+    Shorthand: ""
+    Usage: |
+      Omit the sideEffects flag in the webhook manifests, This flag must be provided during install or upgrade for Kubernetes versions pre 1.12
   - DefaultValue: ""
     Name: outbound-port
     Shorthand: ""
     Usage: Proxy port to use for outbound traffic
-  - DefaultValue: ""
-    Name: proxy-auto-inject
-    Shorthand: ""
-    Usage: |
-      Enable proxy sidecar auto-injection via a webhook (default false)
   - DefaultValue: ""
     Name: proxy-cpu
     Shorthand: ""
@@ -429,6 +740,10 @@
     Name: proxy-uid
     Shorthand: ""
     Usage: Run the proxy under this user ID
+  - DefaultValue: ""
+    Name: proxy-version
+    Shorthand: v
+    Usage: Tag to be used for the Linkerd proxy images
   - DefaultValue: ""
     Name: registry
     Shorthand: ""
@@ -1029,19 +1344,43 @@
   SeeAlso: null
   Synopsis: Remove the Linkerd proxy from a Kubernetes config
 - Description: |-
-    Output Kubernetes configs to upgrade an existing Linkerd control plane.
+    Output Kubernetes cluster-wide resources to upgrade an existing Linkerd.
+
+    Note that this command should be followed by "linkerd upgrade control-plane".
+  Example: |2-
+      # Default upgrade.
+      linkerd upgrade config | kubectl apply -f -
+  InheritedOptions: null
+  Name: upgrade config
+  Options:
+  - DefaultValue: ""
+    Name: help
+    Shorthand: h
+    Usage: help for config
+  SeeAlso: null
+  Synopsis: |
+    Output Kubernetes cluster-wide resources to upgrade an existing Linkerd
+- Description: |-
+    Output Kubernetes control plane resources to upgrade an existing Linkerd.
 
     Note that the default flag values for this command come from the Linkerd control
     plane. The default values displayed in the Flags section below only apply to the
-    install command.
-  Example: ""
+    install command. It should be run after "linkerd upgrade config".
+  Example: |2-
+      # Default upgrade.
+      linkerd upgrade control-plane | kubectl apply -f -
   InheritedOptions: null
-  Name: upgrade
+  Name: upgrade control-plane
   Options:
   - DefaultValue: ""
     Name: admin-port
     Shorthand: ""
     Usage: Proxy port to serve metrics on
+  - DefaultValue: ""
+    Name: control-plane-version
+    Shorthand: ""
+    Usage: |
+      (Development) Tag to be used for the control plane component images
   - DefaultValue: ""
     Name: control-port
     Shorthand: ""
@@ -1075,7 +1414,7 @@
   - DefaultValue: ""
     Name: help
     Shorthand: h
-    Usage: help for upgrade
+    Usage: help for control-plane
   - DefaultValue: ""
     Name: identity-clock-skew-allowance
     Shorthand: ""
@@ -1099,23 +1438,23 @@
     Shorthand: ""
     Usage: Linkerd init container image name
   - DefaultValue: ""
+    Name: init-image-version
+    Shorthand: ""
+    Usage: Linkerd init container image version
+  - DefaultValue: ""
     Name: linkerd-cni-enabled
     Shorthand: ""
     Usage: |
-      Experimental: Omit the proxy-init container when injecting the proxy; requires the linkerd-cni plugin to already be installed
+      Experimental: Omit the NET_ADMIN capability in the PSP and the proxy-init container when injecting the proxy; requires the linkerd-cni plugin to already be installed
   - DefaultValue: ""
-    Name: linkerd-version
-    Shorthand: v
-    Usage: Tag to be used for Linkerd images
+    Name: omit-webhook-side-effects
+    Shorthand: ""
+    Usage: |
+      Omit the sideEffects flag in the webhook manifests, This flag must be provided during install or upgrade for Kubernetes versions pre 1.12
   - DefaultValue: ""
     Name: outbound-port
     Shorthand: ""
     Usage: Proxy port to use for outbound traffic
-  - DefaultValue: ""
-    Name: proxy-auto-inject
-    Shorthand: ""
-    Usage: |
-      Enable proxy sidecar auto-injection via a webhook (default false)
   - DefaultValue: ""
     Name: proxy-cpu
     Shorthand: ""
@@ -1153,6 +1492,169 @@
     Shorthand: ""
     Usage: Run the proxy under this user ID
   - DefaultValue: ""
+    Name: proxy-version
+    Shorthand: v
+    Usage: Tag to be used for the Linkerd proxy images
+  - DefaultValue: ""
+    Name: registry
+    Shorthand: ""
+    Usage: Docker registry to pull images from
+  - DefaultValue: ""
+    Name: skip-inbound-ports
+    Shorthand: ""
+    Usage: |
+      Ports that should skip the proxy and send directly to the application
+  - DefaultValue: ""
+    Name: skip-outbound-ports
+    Shorthand: ""
+    Usage: Outbound ports that should skip the proxy
+  SeeAlso: null
+  Synopsis: |
+    Output Kubernetes control plane resources to upgrade an existing Linkerd
+- Description: |-
+    Output Kubernetes configs to upgrade an existing Linkerd control plane.
+
+    Note that the default flag values for this command come from the Linkerd control
+    plane. The default values displayed in the Flags section below only apply to the
+    install command.
+  Example: |2-
+      # Default upgrade.
+      linkerd upgrade | kubectl apply -f -
+
+      # Similar to install, upgrade may also be broken up into two stages, by user
+      # privilege.
+  InheritedOptions: null
+  Name: upgrade
+  Options:
+  - DefaultValue: ""
+    Name: admin-port
+    Shorthand: ""
+    Usage: Proxy port to serve metrics on
+  - DefaultValue: ""
+    Name: control-plane-version
+    Shorthand: ""
+    Usage: |
+      (Development) Tag to be used for the control plane component images
+  - DefaultValue: ""
+    Name: control-port
+    Shorthand: ""
+    Usage: Proxy port to use for control
+  - DefaultValue: ""
+    Name: controller-log-level
+    Shorthand: ""
+    Usage: Log level for the controller and web components
+  - DefaultValue: ""
+    Name: controller-replicas
+    Shorthand: ""
+    Usage: Replicas of the controller to deploy
+  - DefaultValue: ""
+    Name: controller-uid
+    Shorthand: ""
+    Usage: Run the control plane components under this user ID
+  - DefaultValue: ""
+    Name: disable-h2-upgrade
+    Shorthand: ""
+    Usage: |
+      Prevents the controller from instructing proxies to perform transparent HTTP/2 upgrading (default false)
+  - DefaultValue: ""
+    Name: enable-external-profiles
+    Shorthand: ""
+    Usage: Enable service profiles for non-Kubernetes services
+  - DefaultValue: ""
+    Name: from-manifests
+    Shorthand: ""
+    Usage: |
+      Read config from a Linkerd install YAML rather than from Kubernetes
+  - DefaultValue: ""
+    Name: ha
+    Shorthand: ""
+    Usage: |
+      Experimental: Enable HA deployment config for the control plane (default false)
+  - DefaultValue: ""
+    Name: help
+    Shorthand: h
+    Usage: help for upgrade
+  - DefaultValue: ""
+    Name: identity-clock-skew-allowance
+    Shorthand: ""
+    Usage: |
+      The amount of time to allow for clock skew within a Linkerd cluster
+  - DefaultValue: ""
+    Name: identity-issuance-lifetime
+    Shorthand: ""
+    Usage: |
+      The amount of time for which the Identity issuer should certify identity
+  - DefaultValue: ""
+    Name: image-pull-policy
+    Shorthand: ""
+    Usage: Docker image pull policy
+  - DefaultValue: ""
+    Name: inbound-port
+    Shorthand: ""
+    Usage: Proxy port to use for inbound traffic
+  - DefaultValue: ""
+    Name: init-image
+    Shorthand: ""
+    Usage: Linkerd init container image name
+  - DefaultValue: ""
+    Name: init-image-version
+    Shorthand: ""
+    Usage: Linkerd init container image version
+  - DefaultValue: ""
+    Name: linkerd-cni-enabled
+    Shorthand: ""
+    Usage: |
+      Experimental: Omit the NET_ADMIN capability in the PSP and the proxy-init container when injecting the proxy; requires the linkerd-cni plugin to already be installed
+  - DefaultValue: ""
+    Name: omit-webhook-side-effects
+    Shorthand: ""
+    Usage: |
+      Omit the sideEffects flag in the webhook manifests, This flag must be provided during install or upgrade for Kubernetes versions pre 1.12
+  - DefaultValue: ""
+    Name: outbound-port
+    Shorthand: ""
+    Usage: Proxy port to use for outbound traffic
+  - DefaultValue: ""
+    Name: proxy-cpu
+    Shorthand: ""
+    Usage: Amount of CPU units that the proxy sidecar requests
+  - DefaultValue: ""
+    Name: proxy-cpu-limit
+    Shorthand: ""
+    Usage: Maximum amount of CPU units that the proxy sidecar can use
+  - DefaultValue: ""
+    Name: proxy-cpu-request
+    Shorthand: ""
+    Usage: Amount of CPU units that the proxy sidecar requests
+  - DefaultValue: ""
+    Name: proxy-image
+    Shorthand: ""
+    Usage: Linkerd proxy container image name
+  - DefaultValue: ""
+    Name: proxy-log-level
+    Shorthand: ""
+    Usage: Log level for the proxy
+  - DefaultValue: ""
+    Name: proxy-memory
+    Shorthand: ""
+    Usage: Amount of Memory that the proxy sidecar requests
+  - DefaultValue: ""
+    Name: proxy-memory-limit
+    Shorthand: ""
+    Usage: Maximum amount of Memory that the proxy sidecar can use
+  - DefaultValue: ""
+    Name: proxy-memory-request
+    Shorthand: ""
+    Usage: Amount of Memory that the proxy sidecar requests
+  - DefaultValue: ""
+    Name: proxy-uid
+    Shorthand: ""
+    Usage: Run the proxy under this user ID
+  - DefaultValue: ""
+    Name: proxy-version
+    Shorthand: v
+    Usage: Tag to be used for the Linkerd proxy images
+  - DefaultValue: ""
     Name: registry
     Shorthand: ""
     Usage: Docker registry to pull images from
@@ -1187,4 +1689,3 @@
     Usage: Print the version number(s) only, with no additional output
   SeeAlso: null
   Synopsis: Print the client and server version information
-

--- a/linkerd.io/layouts/partials/cli/annotations.html
+++ b/linkerd.io/layouts/partials/cli/annotations.html
@@ -11,9 +11,10 @@
       </tr>
     </thead>
     <tbody>
-      <!-- This list must be kept in-sync with https://github.com/linkerd/linkerd2/blob/master/pkg/k8s/labels.go#L89-L152 -->
+      <!-- This list must be kept in-sync with https://github.com/linkerd/linkerd2/blob/master/pkg/k8s/labels.go#L94-L170 -->
+      {{ $labels := slice "admin-port" "control-port" "disable-identity" "disable-tap" "enable-debug-sidecar" "enable-external-profiles" "image-pull-policy" "inbound-port" "init-image" "init-image-version" "outbound-port" "proxy-cpu-limit" "proxy-cpu-request" "proxy-image" "proxy-log-level" "proxy-memory-limit" "proxy-memory-request" "proxy-uid" "proxy-version" "skip-inbound-ports" "skip-outbound-ports" }}
       {{ range . }}
-      {{ if or (eq .Name "admin-port") (eq .Name "control-port") (eq .Name "enable-external-profiles") (eq .Name "image-pull-policy") (eq .Name "inbound-port") (eq .Name "init-image") (eq .Name "outbound-port") (eq .Name "proxy-cpu-limit") (eq .Name "proxy-cpu-request") (eq .Name "proxy-image") (eq .Name "proxy-log-level") (eq .Name "proxy-memory-limit") (eq .Name "proxy-memory-request") (eq .Name "proxy-uid") (eq .Name "proxy-version") (eq .Name "skip-inbound-ports") (eq .Name "skip-outbound-ports") }}
+      {{ if (in $labels .Name) }}
       <tr>
         <td>
           <code class="text-nowrap">config.linkerd.io/{{ .Name }}</code>

--- a/linkerd.io/layouts/shortcodes/cli.html
+++ b/linkerd.io/layouts/shortcodes/cli.html
@@ -13,6 +13,7 @@
     </thead>
     <tbody>
       {{ range $cli }}
+      {{ if not (in .Name " ") }}
       <tr>
         <td class="text-nowrap">
           <a href="{{ .Name }}/">
@@ -23,6 +24,7 @@
           {{ .Synopsis | markdownify }}
         </td>
       </tr>
+      {{ end }}
       {{ end }}
     </tbody>
   </table>

--- a/linkerd.io/layouts/shortcodes/cli/examples.html
+++ b/linkerd.io/layouts/shortcodes/cli/examples.html
@@ -1,6 +1,6 @@
 {{ range where site.Data.cli "Name" (.Get 0) }}
 {{ if .Example }}
-<h1>Examples</h1>
+<h2>Examples</h2>
 <pre class="language-bash"><code class="language-bash">{{ replaceRE "(?m)^[ ]{2}" "" .Example }}</code></pre>
 {{ end }}
 {{ end }}

--- a/linkerd.io/layouts/shortcodes/cli/flags.html
+++ b/linkerd.io/layouts/shortcodes/cli/flags.html
@@ -1,7 +1,7 @@
 {{ range where site.Data.cli "Name" (.Get 0) }}
 {{ $opts := where .Options "Name" "!=" "help" }}
 {{ if ge (len $opts) 1 }}
-<h1>Flags</h1>
+<h2>Flags</h2>
 {{ partial "cli/flags" $opts }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
Modified CLI reference rendering code to not display subcommands on
index page, and instead reference them in their respective parent
command pages.

Add new annotations:
- `config.linkerd.io/disable-identity`
- `config.linkerd.io/disable-tap`
- `config.linkerd.io/enable-debug-sidecar`
- `config.linkerd.io/init-image-version`

Depends on https://github.com/linkerd/linkerd2/pull/3016
Depends on #387
Fixes #381

Signed-off-by: Andrew Seigner <siggy@buoyant.io>