### PR TITLE
2.4 - Upgrade notes

### DIFF
--- a/linkerd.io/content/2/tasks/upgrade.md
+++ b/linkerd.io/content/2/tasks/upgrade.md
@@ -375,25 +375,21 @@ your Kubernetes cluster, it is time to upgrade the data plane. This will change
 the version of the `linkerd-proxy` sidecar container and run a rolling deploy on
 your service.
 
-If your workloads are annotated with the auto-inject
-`linkerd.io/inject: enabled` annotation, then you can use the
-`kubectl set image` command to upgrade the Linkerd proxies. Kubernetes will
-automatically perform a rolling update across all your pods.
+For `stable-2.3.0`+, if your workloads are annotated with the auto-inject
+`linkerd.io/inject: enabled` annotation, then you can just restart your pods
+using your Kubernetes cluster management tools (`helm`, `kubectl` etc.).
+
+{{< note >}}
+With `kubectl` 1.15+, you can use the `kubectl rollout restart` command to
+restart all your meshed services. For example,
 
 ```bash
-# retrieve the version of the new proxy
-kubectl -n linkerd get configmap linkerd-config -ojsonpath={.data.proxy} \
-  | jq -r .proxyVersion
-stable-2.4.0
-
-# update all pods' linkerd-proxy container's image to stable-2.4.0
-kubectl -n emojivoto set image po linkerd-proxy=gcr.io/linkerd-io/proxy:stable-2.4.0 --all
+kubectl -n <namespace> rollout restart deploy
 ```
 
-Note that for Kubernetes 1.15+, you can use the `kubectl rollout restart`
-command to restart all your meshed services.
+{{< /note >}}
 
-As the new pods are being created, the proxy injector will auto-inject the new
+As the pods are being re-created, the proxy injector will auto-inject the new
 version of the proxy into the pods.
 
 If the auto-injection is not part of your workflow, you can still manually

--- a/linkerd.io/content/2/tasks/upgrade.md
+++ b/linkerd.io/content/2/tasks/upgrade.md
@@ -18,13 +18,12 @@ incrementally without taking down any of your services.
 
 ## Upgrade notice: stable-2.4.0
 
-Note that the minimum supported Kubernetes version for the `stable-2.4.0`
-release is 1.12.
+This release supports Kubernetes 1.12+.
 
-### Upgrading from stable-2.3.x, edge-19.5.x, edge-19.6.x
+### Upgrading from stable-2.3.x, edge-19.4.5, edge-19.5.x, edge-19.6.x, edge-19.7.1
 
 Use the `linkerd upgrade` command to upgrade the control plane. This command
-ensures that all existing control plane's configuration and mTLS secret are
+ensures that all existing control plane's configuration and mTLS secrets are
 retained.
 
 ```bash
@@ -50,7 +49,7 @@ indicate that the webhooks have no side effects on other resources.
 
 For HA setup, the `linkerd upgrade` command will also retain all previous HA
 configuration. Note that the mutating and validating webhook configuration are
-updated to set its `failurePolicy` field to `fail` to ensure that un-injected
+updated to set their `failurePolicy` fields to `fail` to ensure that un-injected
 workloads (as a result of unexpected errors) are rejected during the admission
 process. The HA mode has also been updated to schedule multiple replicas of the
 `linkerd-proxy-injector` and `linkerd-sp-validator` deployments.
@@ -65,7 +64,11 @@ Name:"linkerd-linkerd-tap"}: cannot change roleRef
 ```
 
 This can be resolved by simply deleting the `linkerd-linkerd-tap` cluster role
-binding resource, and re-run the `linkerd upgrade` command.
+binding resource, and re-running the `linkerd upgrade` command:
+
+```bash
+kubectl delete clusterrole/linkerd-linkerd-tap
+```
 
 For upgrading a multi-stage installation setup, follow the instructions at
 [Upgrading a multi-stage install](/2/tasks/upgrade/#upgading-a-multi-stage-install).
@@ -75,12 +78,24 @@ files can follow the instructions at
 [Upgrading via manifests](/2/tasks/upgrade/#upgrading-via-manifests)
 to ensure those configuration are retained by the `linkerd upgrade` command.
 
-Once the `upgrade` command exits, use the `linkerd check` command to confirm
-the control plane is ready. (Note that the `stable-2.4` `linkerd check` command
-doesn't work with older versions of the control plane, because the command is
-updated to select the resources by labels, instead of by names. The benign error
-returned by the command regarding missing required RBAC resources will be
-resolved once the control plane is upgraded to `stable-2.4`.)
+Once the `upgrade` command completes, use the `linkerd check` command to confirm
+the control plane is ready.
+
+{{< note >}}
+The `stable-2.4` `linkerd check` command will return an error when run against
+an older control plane. This error is benign and will resolve itself once the
+control plane is upgraded to `stable-2.4`:
+
+```bash
+linkerd-config
+--------------
+√ control plane Namespace exists
+× control plane ClusterRoles exist
+    missing ClusterRoles: linkerd-linkerd-controller, linkerd-linkerd-identity, linkerd-linkerd-prometheus, linkerd-linkerd-proxy-injector, linkerd-linkerd-sp-validator, linkerd-linkerd-tap
+    see https://linkerd.io/checks/#l5d-existence-cr for hints
+```
+
+{{< /note >}}
 
 When ready, proceed to upgrading the data plane by following the instructions at
 [Upgrade the data plane](#upgrade-the-data-plane).
@@ -89,7 +104,7 @@ When ready, proceed to upgrading the data plane by following the instructions at
 
 Follow the [stable-2.3.0 upgrade instructions](/2/tasks/upgrade/#upgrading-from-stable-2-2-x-1)
 to upgrade the control plane to the stable-2.3.2 release first. Then follow
-[these instructions](/2/tasks/upgrade/#upgrading-from-stable-2-3-x-edge-19-5-x-edge-19-6-x)
+[these instructions](/2/tasks/upgrade/#upgrading-from-stable-2-3-x-edge-19-4-5-edge-19-5-x-edge-19-6-x-edge-19-7-1)
 to upgrade the stable-2.3.2 control plane to `stable-2.4.0`.
 
 ## Upgrade notice: stable-2.3.0
@@ -381,7 +396,7 @@ command to restart all your meshed services.
 As the new pods are being created, the proxy injector will auto-inject the new
 version of the proxy into the pods.
 
-If the auto-injection isn't part of your workflow, you can still manually
+If the auto-injection is not part of your workflow, you can still manually
 upgrade your meshed services by re-injecting your applications in-place.
 
 Begin by retrieving your YAML resources via `kubectl`, and pass them through the


### PR DESCRIPTION
Tested the following scenarios with stable-2.3 and stable-2.3.2:

- [x] HA mode - ensures that multiple replicas of the proxy injector and sp validators are provisioned, and work without conflicts, and the MWC and VWC `failurePolicy` is set to `fail`.
- [x] From manifest - ensures that `linkerd upgrade --from-manifest` is compatible with the new `linkerd-proxy-injector-tls` and `linkerd-sp-validator-tls` secrets. The webhooks now read their TLS cert and private keys from these secrets to support multiple replicas, instead of storing them in memory.
- [x] Multi-stage upgrade
- [x] Make sure the control plane's PSP and its RBAC are added during upgrade
- [x] Tested with k8s 1.11 to make sure `linkerd upgrade --omit-webhook-side-effects` doesn't set the MWC and VWC `sideEffects` field
- [x] Make sure all resources are labelled and we can select them with

```sh
`kubectl get all,sa,cm,secret,role,rolebinding,clusterrole,clusterrolebinding,mutatingwebhookconfiguration,validatingwebhookconfiguration,crd,psp --all-namespaces -l linkerd.io/control-plane-ns=linkerd -L linkerd.io/control-plane-ns`
```

Fixes #349.

Signed-off-by: Ivan Sim <ivan@buoyant.io>