### PR TITLE
Fix navbar CSS issue

### DIFF
--- a/linkerd.io/layouts/partials/main-menu.html
+++ b/linkerd.io/layouts/partials/main-menu.html
@@ -3,8 +3,10 @@
     {{ $currentPage := . }}
     {{ range .Site.Menus.top }}
     {{ $isCurrent := $currentPage.IsMenuCurrent "top" . }}
+    {{ $isGetStarted := eq .Name "GET STARTED" }}
+    {{ $underlineOnActive := and $isCurrent (not $isGetStarted) }}
 
-      <a href="{{ .URL }}" class="navbar-item has-text-white is-uppercase  {{ if $isCurrent }} is-active {{ end }}" {{if hasPrefix .URL "http"}}target="_blank"{{end}}><span
+      <a href="{{ .URL }}" class="navbar-item has-text-white is-uppercase  {{ if $underlineOnActive }} is-active {{ end }}" {{if hasPrefix .URL "http"}}target="_blank"{{end}}><span
           class="navbar-item-helper">{{ .Pre }}{{ .Name }}{{ .Post }}</span></a>
     {{ end }}
   </div>


### PR DESCRIPTION
If you navigate to the [Get Started](https://linkerd.io/2/getting-started/), the `is-active` class makes the Get Started button a little funky because it applies the same underline style to *all* menu components. This PR changes the `is-active` logic to not apply to the button.

The relevant page is here: https://5d3f39e4abf08f00080e4bf1--linkerd.netlify.com/2/getting-started/