### PR TITLE
Use cut instead of awk in the install scripts

### DIFF
--- a/run.linkerd.io/public/install
+++ b/run.linkerd.io/public/install
@@ -22,7 +22,7 @@ url="https://github.com/linkerd/linkerd2/releases/download/${LINKERD2_VERSION}/$
   curl -LO "${url}"
   echo ""
   echo "Download complete!, validating checksum..."
-  checksum=$(openssl dgst -sha256 "${filename}" | awk '{ print $2 }')
+  checksum=$(openssl dgst -sha256 "${filename}" | cut -d' ' -f2)
   if [ "$checksum" != "$SHA" ]; then
     echo "Checksum validation failed." >&2
     exit 1

--- a/run.linkerd.io/public/install-edge
+++ b/run.linkerd.io/public/install-edge
@@ -22,7 +22,7 @@ url="https://github.com/linkerd/linkerd2/releases/download/${LINKERD2_VERSION}/$
   curl -LO "${url}"
   echo ""
   echo "Download complete!, validating checksum..."
-  checksum=$(openssl dgst -sha256 "${filename}" | awk '{ print $2 }')
+  checksum=$(openssl dgst -sha256 "${filename}" | cut -d' ' -f2)
   if [ "$checksum" != "$SHA" ]; then
     echo "Checksum validation failed." >&2
     exit 1


### PR DESCRIPTION
If the install scripts rely on awk, they malfunction when run on a
device with a limited environment where awk is not available. This patch
replaces the use of awk with cut, which is expected to be more
ubiquitous than awk (and as a bonus also more lightweight on footprint,
execution time and command line length).

Change-Id: I035bf20cb891402677d0a8fbd49ca6fcd099341d
Signed-off-by: Joakim Roubert <joakimr@axis.com>