### PR TITLE
Use sha256sum instead of openssl in the install scripts

### DIFF
--- a/run.linkerd.io/public/install
+++ b/run.linkerd.io/public/install
@@ -22,7 +22,8 @@ url="https://github.com/linkerd/linkerd2/releases/download/${LINKERD2_VERSION}/$
   curl -LO "${url}"
   echo ""
   echo "Download complete!, validating checksum..."
-  checksum=$(openssl dgst -sha256 "${filename}" | awk '{ print $2 }')
+  checksum=$(sha256sum "${filename}")
+  checksum=${checksum%%[[:blank:]]*}
   if [ "$checksum" != "$SHA" ]; then
     echo "Checksum validation failed." >&2
     exit 1

--- a/run.linkerd.io/public/install-edge
+++ b/run.linkerd.io/public/install-edge
@@ -22,7 +22,8 @@ url="https://github.com/linkerd/linkerd2/releases/download/${LINKERD2_VERSION}/$
   curl -LO "${url}"
   echo ""
   echo "Download complete!, validating checksum..."
-  checksum=$(openssl dgst -sha256 "${filename}" | awk '{ print $2 }')
+  checksum=$(sha256sum "${filename}")
+  checksum=${checksum%%[[:blank:]]*}
   if [ "$checksum" != "$SHA" ]; then
     echo "Checksum validation failed." >&2
     exit 1


### PR DESCRIPTION
It seems sha256sum is more ubiquitous than openssl which would suggest
using it in the install scripts make them more portable. Also using
shell script built-in functionality to trim the sha256sum output which
eliminates the depdency towards awk.

Change-Id: I2e6ceed6ffbb406bc440d5f7d2f816d1f23b4f85
Signed-off-by: Joakim Roubert <joakimr@axis.com>