### PR TITLE
Use shell functionality instead of awk in install scripts

### DIFF
--- a/run.linkerd.io/public/install
+++ b/run.linkerd.io/public/install
@@ -22,7 +22,8 @@ url="https://github.com/linkerd/linkerd2/releases/download/${LINKERD2_VERSION}/$
   curl -LO "${url}"
   echo ""
   echo "Download complete!, validating checksum..."
-  checksum=$(openssl dgst -sha256 "${filename}" | awk '{ print $2 }')
+  checksum=$(openssl dgst -sha256 "${filename}")
+  checksum=${checksum##*[[:blank:]]}
   if [ "$checksum" != "$SHA" ]; then
     echo "Checksum validation failed." >&2
     exit 1

--- a/run.linkerd.io/public/install-edge
+++ b/run.linkerd.io/public/install-edge
@@ -22,7 +22,8 @@ url="https://github.com/linkerd/linkerd2/releases/download/${LINKERD2_VERSION}/$
   curl -LO "${url}"
   echo ""
   echo "Download complete!, validating checksum..."
-  checksum=$(openssl dgst -sha256 "${filename}" | awk '{ print $2 }')
+  checksum=$(openssl dgst -sha256 "${filename}")
+  checksum=${checksum##*[[:blank:]]}
   if [ "$checksum" != "$SHA" ]; then
     echo "Checksum validation failed." >&2
     exit 1


### PR DESCRIPTION
Portability is increased if built-in shell script functionality is used
instead of awk to trim the openssl SHA256 output.

Change-Id: Id1e2c4bf28d0af7ec4448e4d4dd8de2ec5e58afe
Signed-off-by: Joakim Roubert <joakimr@axis.com>