### PR TITLE
stop indexing 1.x content

### DIFF
--- a/linkerd.io/layouts/partials/meta.html
+++ b/linkerd.io/layouts/partials/meta.html
@@ -2,6 +2,10 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
+{{ if eq .Section "1" }}
+<meta name="robots" content="noindex">
+{{ end }}
+
 <meta name="description" content="{{ partial "description.html" . }}" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@Linkerd" />


### PR DESCRIPTION
Having these ancient search results crop up as at the top of searches like
"linkerd grpc" is producing all sorts of confusing content for 2.x users.

Keep the content around, just don't let it be returned in search results.

Signed-off-by: William Morgan <william@buoyant.io>