### PR TITLE
Add shasum as fallback SHA256 sum provider

### DIFF
--- a/run.linkerd.io/public/install
+++ b/run.linkerd.io/public/install
@@ -10,6 +10,10 @@ else
   OS=linux
 fi
 
+checksumbin=$(which openssl) || checksumbin=$(which shasum) || {
+  echo Failed to find SHA256 checksum binary &>2
+  exit 1
+}
 tmp=$(mktemp -d /tmp/linkerd2.XXXXXX)
 filename="linkerd2-cli-${LINKERD2_VERSION}-${OS}"
 url="https://github.com/linkerd/linkerd2/releases/download/${LINKERD2_VERSION}/${filename}"
@@ -22,7 +26,16 @@ url="https://github.com/linkerd/linkerd2/releases/download/${LINKERD2_VERSION}/$
   curl -LO "${url}"
   echo ""
   echo "Download complete!, validating checksum..."
-  checksum=$(openssl dgst -sha256 "${filename}" | cut -d' ' -f2)
+  case $checksumbin in
+    *openssl)
+      checksum=$($checksumbin dgst -sha256 "${filename}")
+      checksum=${checksum##*[[:blank:]]}
+      ;;
+    *shasum)
+      checksum=$($checksumbin -a256 "${filename}")
+      checksum=${checksum%%[[:blank:]]*}
+      ;;
+  esac
   if [ "$checksum" != "$SHA" ]; then
     echo "Checksum validation failed." >&2
     exit 1

--- a/run.linkerd.io/public/install-edge
+++ b/run.linkerd.io/public/install-edge
@@ -10,6 +10,10 @@ else
   OS=linux
 fi
 
+checksumbin=$(which openssl) || checksumbin=$(which shasum) || {
+  echo Failed to find SHA256 checksum binary &>2
+  exit 1
+}
 tmp=$(mktemp -d /tmp/linkerd2.XXXXXX)
 filename="linkerd2-cli-${LINKERD2_VERSION}-${OS}"
 url="https://github.com/linkerd/linkerd2/releases/download/${LINKERD2_VERSION}/${filename}"
@@ -22,7 +26,16 @@ url="https://github.com/linkerd/linkerd2/releases/download/${LINKERD2_VERSION}/$
   curl -LO "${url}"
   echo ""
   echo "Download complete!, validating checksum..."
-  checksum=$(openssl dgst -sha256 "${filename}" | cut -d' ' -f2)
+  case $checksumbin in
+    *openssl)
+      checksum=$($checksumbin dgst -sha256 "${filename}")
+      checksum=${checksum##*[[:blank:]]}
+      ;;
+    *shasum)
+      checksum=$($checksumbin -a256 "${filename}")
+      checksum=${checksum%%[[:blank:]]*}
+      ;;
+  esac
   if [ "$checksum" != "$SHA" ]; then
     echo "Checksum validation failed." >&2
     exit 1


### PR DESCRIPTION
If openssl is missing on the system, the install script(s) will try to
use shasum instead.

Change-Id: Ifb453d497bc5f8e2c9db4f4438ed178390b3db99
Signed-off-by: Joakim Roubert <joakimr@axis.com>