### PR TITLE
Make install script(s) fail on unsupported systems

### DIFF
--- a/run.linkerd.io/public/install
+++ b/run.linkerd.io/public/install
@@ -4,11 +4,27 @@ set -eu
 
 LINKERD2_VERSION=${LINKERD2_VERSION:-L5D2_STABLE_VERSION}
 
-if [ "$(uname -s)" = "Darwin" ]; then
-  OS=darwin
-else
-  OS=linux
-fi
+OS=$(uname -s)
+arch=$(uname -m)
+case $OS in
+  Darwin)
+    ;;
+  Linux)
+    case $arch in
+      x86_64)
+        ;;
+      *)
+        echo "There is no linkerd $OS support for $arch" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    echo "There is no linkerd support for $OS/$arch (yet...)" >&2
+    exit 1
+    ;;
+esac
+OS=$(echo $OS | tr [:upper:] [:lower:])
 
 tmp=$(mktemp -d /tmp/linkerd2.XXXXXX)
 filename="linkerd2-cli-${LINKERD2_VERSION}-${OS}"

--- a/run.linkerd.io/public/install
+++ b/run.linkerd.io/public/install
@@ -7,6 +7,9 @@ LINKERD2_VERSION=${LINKERD2_VERSION:-L5D2_STABLE_VERSION}
 OS=$(uname -s)
 arch=$(uname -m)
 case $OS in
+  CYGWIN*)
+    OS=windows.exe
+    ;;
   Darwin)
     ;;
   Linux)

--- a/run.linkerd.io/public/install-edge
+++ b/run.linkerd.io/public/install-edge
@@ -7,6 +7,9 @@ LINKERD2_VERSION=${LINKERD2_VERSION:-L5D2_EDGE_VERSION}
 OS=$(uname -s)
 arch=$(uname -m)
 case $OS in
+  CYGWIN*)
+    OS=windows.exe
+    ;;
   Darwin)
     ;;
   Linux)

--- a/run.linkerd.io/public/install-edge
+++ b/run.linkerd.io/public/install-edge
@@ -4,11 +4,27 @@ set -eu
 
 LINKERD2_VERSION=${LINKERD2_VERSION:-L5D2_EDGE_VERSION}
 
-if [ "$(uname -s)" = "Darwin" ]; then
-  OS=darwin
-else
-  OS=linux
-fi
+OS=$(uname -s)
+arch=$(uname -m)
+case $OS in
+  Darwin)
+    ;;
+  Linux)
+    case $arch in
+      x86_64)
+        ;;
+      *)
+        echo "There is no linkerd $OS support for $arch" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    echo "There is no linkerd support for $OS/$arch (yet...)" >&2
+    exit 1
+    ;;
+esac
+OS=$(echo $OS | tr [:upper:] [:lower:])
 
 tmp=$(mktemp -d /tmp/linkerd2.XXXXXX)
 filename="linkerd2-cli-${LINKERD2_VERSION}-${OS}"


### PR DESCRIPTION
Add check not only if to use Darwin or Linux, but also make sure not to
install the Linux amd64 binaries on e.g. a Linux armv7l system. Then a
proper (?) error message will be displayed and the script aborts.
When/if more systems are supported, they are easily added with this
structure.

Change-Id: Ia0b23785cb89a6620fcbba27aff8270bcf4008ff
Signed-off-by: Joakim Roubert <joakimr@axis.com>