### PR TITLE
make /getting-started go to 2.x docs, not 1.x docs

### DIFF
--- a/linkerd.io/content/1/getting-started/_index.md
+++ b/linkerd.io/content/1/getting-started/_index.md
@@ -1,5 +1,5 @@
 +++
-aliases = ["/doc/getting-started", "/doc/0.1.0/guides", "/doc/0.2.0/guides", "/doc/0.2.1/guides", "/doc/0.3.0/guides", "/doc/0.3.1/guides", "/doc/0.4.0/guides", "/doc/0.5.0/guides", "/doc/0.6.0/guides", "/doc/0.7.0/guides", "/doc/0.7.1/guides", "/doc/0.7.2/guides", "/doc/0.7.3/guides", "/doc/0.7.4/guides", "/doc/0.7.5/guides", "/doc/0.8.0/guides", "/doc/head/guides", "/doc/latest/guides", "/doc/guides", "/getting-started", "/1/overview"]
+aliases = ["/doc/0.1.0/guides", "/doc/0.2.0/guides", "/doc/0.2.1/guides", "/doc/0.3.0/guides", "/doc/0.3.1/guides", "/doc/0.4.0/guides", "/doc/0.5.0/guides", "/doc/0.6.0/guides", "/doc/0.7.0/guides", "/doc/0.7.1/guides", "/doc/0.7.2/guides", "/doc/0.7.3/guides", "/doc/0.7.4/guides", "/doc/0.7.5/guides", "/doc/0.8.0/guides", "/doc/head/guides", "/doc/latest/guides", "/doc/guides", "/1/overview"]
 description = "Provides concrete instructions for setting up and running Linkerd in various environments. Go here for a quick start."
 layout = "getting-started"
 title = "Overview"

--- a/linkerd.io/content/2/getting-started/_index.md
+++ b/linkerd.io/content/2/getting-started/_index.md
@@ -3,7 +3,9 @@ title = "Getting Started"
 aliases = [
   "/getting-started/istio/",
   "/choose-your-platform/",
-  "/2/katacoda/"
+  "/2/katacoda/",
+  "/doc/getting-started",
+  "/getting-started"
 ]
 weight = 2
 [sitemap]


### PR DESCRIPTION
Signed-off-by: William Morgan <william@buoyant.io>