### PR TITLE
added nginx ingress example to use var  Signed-off-by: Jeff Puccinell…

### DIFF
--- a/linkerd.io/content/2/tasks/using-ingress.md
+++ b/linkerd.io/content/2/tasks/using-ingress.md
@@ -74,6 +74,36 @@ The important annotation here is:
       proxy_hide_header l5d-server-id;
 ```
 
+This sample ingress definition uses a single ingress for an application
+with multiple endpoints using different ports.
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: web-ingress
+  namespace: emojivoto
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
+      proxy_hide_header l5d-remote-ip;
+      proxy_hide_header l5d-server-id;
+spec:
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: web-svc
+          servicePort: 80
+      - path: /another-endpoint
+        backend:
+          serviceName: another-svc
+          servicePort: 8080
+```
+
 Nginx will add a `l5d-dst-override` header to instruct Linkerd what service
 the request is destined for. You'll want to include both the Kubernetes service
 FQDN (`web-svc.emojivoto.svc.cluster.local`) *and* the destination

--- a/linkerd.io/content/2/tasks/using-ingress.md
+++ b/linkerd.io/content/2/tasks/using-ingress.md
@@ -52,7 +52,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:80;
+      proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
       proxy_hide_header l5d-remote-ip;
       proxy_hide_header l5d-server-id;
 spec:
@@ -69,7 +69,7 @@ The important annotation here is:
 
 ```yaml
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:80;
+      proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
       proxy_hide_header l5d-remote-ip;
       proxy_hide_header l5d-server-id;
 ```


### PR DESCRIPTION
…i <lamemail@gmail.com>

Fixes: https://github.com/linkerd/website/issues/510

Adds a `Nginx` example that illustrates how to template the port number to support multiple services using different port numbers behind a single ingress.  