### PR TITLE
Add missing selectors

### DIFF
--- a/linkerd.io/content/2/tasks/customize-install.md
+++ b/linkerd.io/content/2/tasks/customize-install.md
@@ -76,7 +76,7 @@ Then, add this as a strategic merge option to `kustomization.yaml`:
 resources:
 - linkerd.yaml
 patchesStrategicMerge:
-- priorityclass.yaml
+- priority-class.yaml
 ```
 
 Applying this to your cluster requires taking the output of `kustomize build`

--- a/run.linkerd.io/public/booksapp.yml
+++ b/run.linkerd.io/public/booksapp.yml
@@ -23,6 +23,10 @@ metadata:
     project: booksapp
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: webapp
+      project: booksapp
   template:
     metadata:
       labels:
@@ -73,6 +77,10 @@ metadata:
     project: booksapp
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: authors
+      project: booksapp
   template:
     metadata:
       labels:
@@ -123,6 +131,10 @@ metadata:
     project: booksapp
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: books
+      project: booksapp
   template:
     metadata:
       labels:
@@ -156,6 +168,10 @@ metadata:
     project: booksapp
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: traffic
+      project: booksapp
   template:
     metadata:
       labels:

--- a/run.linkerd.io/public/daemonset/servicemesh.yml
+++ b/run.linkerd.io/public/daemonset/servicemesh.yml
@@ -279,6 +279,9 @@ metadata:
   name: l5d
   namespace: linkerd
 spec:
+  selector:
+    matchLabels:
+      app: l5d
   template:
     metadata:
       labels:


### PR DESCRIPTION
Followup to #509

These selectors are required when using the `apps/v1` group.
The booksapps should be fine now.