### PR TITLE
ha mwc: add label to kube-system

### DIFF
--- a/linkerd.io/content/2/features/ha.md
+++ b/linkerd.io/content/2/features/ha.md
@@ -51,3 +51,11 @@ considered non-critical.
 HA mode assumes that there are always at least three nodes in the Kubernetes
 cluster. If this assumption is violated (e.g. the cluster is scaled down to two
 or fewer nodes), then the system will likely be left in a non-functional state.
+
+However, this behavior can be mitigated by applying a label to the `kube-system`
+namespace to specify that it should be ignored by the proxy injector mutating
+webhook:
+
+```bash
+kubectl label namespace kube-system config.linkerd.io/admission-webhooks=disabled
+```


### PR DESCRIPTION
Adds documentation (per linkerd/linkerd2#3346) for proxy injector mutating webhook "skip webhook" label on `kube-system` in `--ha` mode as implemented in linkerd/linkerd2#3460