### PR TITLE
Remove Cisco Webex endorsement

### DIFF
--- a/linkerd.io/content/_index.md
+++ b/linkerd.io/content/_index.md
@@ -64,8 +64,6 @@ companies:
   link: https://www.expedia.com
 - image: "/uploads/logos/blue/offerup.svg"
   link: https://offerup.com/
-- image: "/uploads/logos/blue/webex.svg"
-  link: https://www.webex.com/
 - image: "/uploads/logos/blue/ask.svg"
   link: https://ask.com/
 - image: "/uploads/logos/blue/bigcommerce.svg"


### PR DESCRIPTION
Hello - I'm responsible for certain elements of the Cisco Webex platform, the choice to use linkerd therein, and generally a big fan . . . however, the way the Cisco Webex product name/logo are currently displayed on the linkerd.io home page could be easily interpreted as a deliberate endorsement by Cisco of linkerd, rather than just an external observation that we are in fact using the linkerd software. Unfortunately, I've been unable to find evidence that any request was made to Cisco for permission to reference the Cisco Webex name/logo in this way.

Unless I'm mistaken, and some formal interaction with Cisco has occurred re. use of the Cisco Webex name/logo in this manner, please remove the reference either by merging this PR, or any other means.