### PR TITLE
Add missing selector to flagger.yml

### DIFF
--- a/run.linkerd.io/public/flagger.yml
+++ b/run.linkerd.io/public/flagger.yml
@@ -5,6 +5,9 @@ metadata:
   name: load
   namespace: test
 spec:
+  selector:
+    matchLabels:
+      app: load
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
Due to missing deployment selector apply fail with 'missing required field "selector" in io.k8s.api.apps.v1.DeploymentSpec'

Adding selector solve the issue.

Fixes #533

Signed-off-by: Mario Vejlupek mario@vejlupek.cz