### PR TITLE
Include 2.6 CLI Options and Annotations

### DIFF
--- a/linkerd.io/content/blog/bringing-service-communication-shadows-part-2.md
+++ b/linkerd.io/content/blog/bringing-service-communication-shadows-part-2.md
@@ -61,7 +61,7 @@ The data plane can then be polled by external metrics-collection utilities for a
 
 Dashboards help you visualize trends when troubleshooting by presenting aggregated data in easily digestible ways. Their presence is handy when using a service mesh, so they’re often included as an implementation component. But that can also be confusing to new users. Where does the dashboarding backend fit into service mesh architecture?
 
-Envoy is a data plane and it supports [using Grafana](https://medium.com/@mattklein123/lyfts-envoy-dashboards-5c91738816b1). Istio is a control plane and it supports [using Grafana](https://istio.io/docs/tasks/telemetry/using-istio-dashboard/). And Linkerd, which is both a data plane and a control plane, also supports [using Grafana](https://github.com/linkerd/linkerd-viz). Are dashboards part of the data plane or the control plane?
+Envoy is a data plane and it supports [using Grafana](https://medium.com/@mattklein123/lyfts-envoy-dashboards-5c91738816b1). Istio is a control plane and it supports using Grafana. And Linkerd, which is both a data plane and a control plane, also supports [using Grafana](https://github.com/linkerd/linkerd-viz). Are dashboards part of the data plane or the control plane?
 
 The truth is, they’re not strictly a part of either.
 

--- a/linkerd.io/data/cli.yaml
+++ b/linkerd.io/data/cli.yaml
@@ -118,6 +118,10 @@
   Name: dashboard
   Options:
   - DefaultValue: ""
+    Name: address
+    Shorthand: ""
+    Usage: The address at which to serve requests
+  - DefaultValue: ""
     Name: help
     Shorthand: h
     Usage: help for dashboard
@@ -280,7 +284,7 @@
   - DefaultValue: ""
     Name: disable-tap
     Shorthand: ""
-    Usage: Disables resources from from being tapped
+    Usage: Disables resources from being tapped
   - DefaultValue: ""
     Name: enable-debug-sidecar
     Shorthand: ""
@@ -428,6 +432,10 @@
     Shorthand: ""
     Usage: Proxy port to serve metrics on
   - DefaultValue: ""
+    Name: cluster-domain
+    Shorthand: ""
+    Usage: Set custom cluster domain
+  - DefaultValue: ""
     Name: control-plane-version
     Shorthand: ""
     Usage: |
@@ -453,6 +461,10 @@
     Shorthand: ""
     Usage: |
       Prevents the controller from instructing proxies to perform transparent HTTP/2 upgrading (default false)
+  - DefaultValue: ""
+    Name: disable-heartbeat
+    Shorthand: ""
+    Usage: Disables the heartbeat cronjob (default false)
   - DefaultValue: ""
     Name: enable-external-profiles
     Shorthand: ""
@@ -611,6 +623,10 @@
     Shorthand: ""
     Usage: Proxy port to serve metrics on
   - DefaultValue: ""
+    Name: cluster-domain
+    Shorthand: ""
+    Usage: Set custom cluster domain
+  - DefaultValue: ""
     Name: control-plane-version
     Shorthand: ""
     Usage: |
@@ -636,6 +652,10 @@
     Shorthand: ""
     Usage: |
       Prevents the controller from instructing proxies to perform transparent HTTP/2 upgrading (default false)
+  - DefaultValue: ""
+    Name: disable-heartbeat
+    Shorthand: ""
+    Usage: Disables the heartbeat cronjob (default false)
   - DefaultValue: ""
     Name: enable-external-profiles
     Shorthand: ""
@@ -1249,7 +1269,7 @@
   - DefaultValue: ""
     Name: output
     Shorthand: o
-    Usage: 'Output format. One of: wide'
+    Usage: 'Output format. One of: "wide", "json"'
   - DefaultValue: ""
     Name: path
     Shorthand: ""
@@ -1379,7 +1399,7 @@
     Note that this command should be followed by "linkerd upgrade control-plane".
   Example: |2-
       # Default upgrade.
-      linkerd upgrade config | kubectl apply -f -
+      linkerd upgrade config | kubectl apply --prune -l linkerd.io/control-plane-ns=linkerd -f -
   InheritedOptions: null
   Name: upgrade config
   Options:
@@ -1408,7 +1428,7 @@
     install command. It should be run after "linkerd upgrade config".
   Example: |2-
       # Default upgrade.
-      linkerd upgrade control-plane | kubectl apply -f -
+      linkerd upgrade control-plane | kubectl apply --prune -l linkerd.io/control-plane-ns=linkerd -f -
   InheritedOptions: null
   Name: upgrade control-plane
   Options:
@@ -1416,6 +1436,10 @@
     Name: admin-port
     Shorthand: ""
     Usage: Proxy port to serve metrics on
+  - DefaultValue: ""
+    Name: cluster-domain
+    Shorthand: ""
+    Usage: Set custom cluster domain
   - DefaultValue: ""
     Name: control-plane-version
     Shorthand: ""
@@ -1442,6 +1466,10 @@
     Shorthand: ""
     Usage: |
       Prevents the controller from instructing proxies to perform transparent HTTP/2 upgrading (default false)
+  - DefaultValue: ""
+    Name: disable-heartbeat
+    Shorthand: ""
+    Usage: Disables the heartbeat cronjob (default false)
   - DefaultValue: ""
     Name: enable-external-profiles
     Shorthand: ""
@@ -1564,7 +1592,7 @@
     install command.
   Example: |2-
       # Default upgrade.
-      linkerd upgrade | kubectl apply -f -
+      linkerd upgrade | kubectl apply --prune -l linkerd.io/control-plane-ns=linkerd -f -
 
       # Similar to install, upgrade may also be broken up into two stages, by user
       # privilege.
@@ -1575,6 +1603,10 @@
     Name: admin-port
     Shorthand: ""
     Usage: Proxy port to serve metrics on
+  - DefaultValue: ""
+    Name: cluster-domain
+    Shorthand: ""
+    Usage: Set custom cluster domain
   - DefaultValue: ""
     Name: control-plane-version
     Shorthand: ""
@@ -1601,6 +1633,10 @@
     Shorthand: ""
     Usage: |
       Prevents the controller from instructing proxies to perform transparent HTTP/2 upgrading (default false)
+  - DefaultValue: ""
+    Name: disable-heartbeat
+    Shorthand: ""
+    Usage: Disables the heartbeat cronjob (default false)
   - DefaultValue: ""
     Name: enable-external-profiles
     Shorthand: ""
@@ -1739,3 +1775,4 @@
     Usage: Print the version number(s) only, with no additional output
   SeeAlso: null
   Synopsis: Print the client and server version information
+

--- a/linkerd.io/layouts/partials/cli/annotations.html
+++ b/linkerd.io/layouts/partials/cli/annotations.html
@@ -11,7 +11,7 @@
       </tr>
     </thead>
     <tbody>
-      <!-- This list must be kept in-sync with https://github.com/linkerd/linkerd2/blob/master/pkg/k8s/labels.go#L94-L170 -->
+      <!-- This list must be kept in-sync with https://github.com/linkerd/linkerd2/blob/master/pkg/k8s/labels.go#L94-L180 -->
       {{ $labels := slice "admin-port" "control-port" "disable-identity" "disable-tap" "enable-debug-sidecar" "enable-external-profiles" "image-pull-policy" "inbound-port" "init-image" "init-image-version" "outbound-port" "proxy-cpu-limit" "proxy-cpu-request" "proxy-image" "proxy-log-level" "proxy-memory-limit" "proxy-memory-request" "proxy-uid" "proxy-version" "skip-inbound-ports" "skip-outbound-ports" }}
       {{ range . }}
       {{ if (in $labels .Name) }}
@@ -25,6 +25,26 @@
       </tr>
       {{ end }}
       {{ end }}
+      <!-- This can be removed when the tracing options are added to the CLI  -->
+      <!-- See https://github.com/linkerd/linkerd2/issues/3468 -->
+      <tr>
+        <td>
+          <code class="text-nowrap">config.linkerd.io/trace-collector</code>
+        </td>
+        <td>
+          Service name of the trace collector. E.g. <code>oc-collector.tracing:55678</code>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code class="text-nowrap">config.alpha.linkerd.io/trace-collector-service-account</code>
+        </td>
+        <td>
+          The trace collector's service account name. E.g.,
+          <code>tracing-service-account</code>. If not provided, it will be
+          defaulted to <code>default<code>.
+        </td>
+      </tr>
     </tbody>
   </table>
 </div>


### PR DESCRIPTION
This PR updated to docs to include new 2.6 CLI and annotations.

The dead link error shown by `lint` is fixed in https://github.com/linkerd/website/pull/537.

Fixes https://github.com/linkerd/linkerd2/issues/3468.