### PR TITLE
Documentation on how to use custom domain

### DIFF
--- a/linkerd.io/content/2/tasks/using-custom-domain.md
+++ b/linkerd.io/content/2/tasks/using-custom-domain.md
@@ -1,0 +1,23 @@
++++
+title = "Using Custom Cluster Domain"
+description = "Use Linkerd with a custom cluster domain."
++++
+
+For Kubernetes clusters that use [custom cluster domain](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/),
+Linkerd must be installed using the `--cluster-domain` option:
+
+```bash
+linkerd install --cluster-domain=example.org --identity-trust-domain=example.org | kubectl apply -f -
+```
+
+This ensures that all Linkerd handles all service discovery, routing, service
+profiles and traffic split resources using the `example.org` domain.
+
+{{< note >}}
+Note that the identity trust domain must match the cluster domain for mTLS to
+work.
+{{< /note >}}
+
+{{< note >}}
+Changing the cluster domain while upgrading Linkerd isn't supported.
+{{< /note >}}


### PR DESCRIPTION
This PR adds documentation on how to use the `--cluster-domain` option introduced in https://github.com/linkerd/linkerd2/pull/3360.

Fixes https://github.com/linkerd/website/issues/530.