### PR TITLE
Document the nginx.ingress.kubernetes.io/upstream-vhost annotation

### DIFF
--- a/linkerd.io/content/2/tasks/using-ingress.md
+++ b/linkerd.io/content/2/tasks/using-ingress.md
@@ -79,6 +79,7 @@ The important annotation here for http traffic is:
 
 When using gRPC, NGINX has a distinct set of directives for managing
  headers:
+
 ```yaml
     nginx.ingress.kubernetes.io/configuration-snippet: |
       grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
@@ -87,7 +88,6 @@ When using gRPC, NGINX has a distinct set of directives for managing
 In the examples above and below, we include both headers for brevity. You
 should include the directives that are relevant for the type of traffic that
 your service uses.
-
 
 In addition, the line below ensures that the `edge` between the ingress
 controller and the backend service are shown in the

--- a/linkerd.io/content/2/tasks/using-ingress.md
+++ b/linkerd.io/content/2/tasks/using-ingress.md
@@ -51,6 +51,7 @@ metadata:
   namespace: emojivoto
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/upstream-vhost: web-svc.emojivoto.svc.cluster.local:8080
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
 spec:
@@ -60,7 +61,7 @@ spec:
       paths:
       - backend:
           serviceName: web-svc
-          servicePort: 80
+          servicePort: 8080
 ```
 
 The important annotation here is:
@@ -68,6 +69,14 @@ The important annotation here is:
 ```yaml
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
+```
+
+In addition, the line below ensures that the `edge` between the ingress
+controller and the backend service are shown in the
+[`linkerd edges`](/2/reference/cli/edges/) command:
+
+```yaml
+nginx.ingress.kubernetes.io/upstream-vhost: web-svc.emojivoto.svc.cluster.local:8080
 ```
 
 This sample ingress definition uses a single ingress for an application

--- a/linkerd.io/content/2/tasks/using-ingress.md
+++ b/linkerd.io/content/2/tasks/using-ingress.md
@@ -51,13 +51,8 @@ metadata:
   namespace: emojivoto
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/upstream-vhost: web-svc.emojivoto.svc.cluster.local:8080
     nginx.ingress.kubernetes.io/configuration-snippet: |
-
-      # for http traffic
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
-
-      # for gRPC traffic
       grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
 
 spec:
@@ -70,32 +65,19 @@ spec:
           servicePort: 8080
 ```
 
-The important annotation here for http traffic is:
+The important annotation here is:
 
 ```yaml
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
-```
-
-When using gRPC, NGINX has a distinct set of directives for managing
- headers:
-
-```yaml
-    nginx.ingress.kubernetes.io/configuration-snippet: |
       grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
 ```
 
-In the examples above and below, we include both headers for brevity. You
-should include the directives that are relevant for the type of traffic that
-your service uses.
-
-In addition, the line below ensures that the `edge` between the ingress
-controller and the backend service are shown in the
-[`linkerd edges`](/2/reference/cli/edges/) command:
-
-```yaml
-nginx.ingress.kubernetes.io/upstream-vhost: web-svc.emojivoto.svc.cluster.local:8080
-```
+This example combines the two directives that NGINX uses for proxying HTTP
+and gRPC traffic. In practice, it is only necessary to set either the
+`proxy_set_header` or `grpc_set_header` directive, depending on the protocol
+used by the service, however NGINX will ignore any directives that it doesn't
+need.
 
 This sample ingress definition uses a single ingress for an application
 with multiple endpoints using different ports.
@@ -109,11 +91,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/configuration-snippet: |
-
-      # for normal http traffic
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
-
-      # for gRPC traffic
       grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
 spec:
   rules:

--- a/linkerd.io/content/2/tasks/using-ingress.md
+++ b/linkerd.io/content/2/tasks/using-ingress.md
@@ -56,13 +56,9 @@ metadata:
 
       # for http traffic
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
-      proxy_hide_header l5d-remote-ip;
-      proxy_hide_header l5d-server-id;
 
       # for gRPC traffic
       grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
-      grpc_hide_header l5d-remote-ip;
-      grpc_hide_header l5d-server-id;
 
 spec:
   rules:
@@ -86,8 +82,6 @@ When using gRPC, NGINX has a distinct set of directives for managing
 ```yaml
     nginx.ingress.kubernetes.io/configuration-snippet: |
       grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
-      grpc_hide_header l5d-remote-ip;
-      grpc_hide_header l5d-server-id;
 ```
 
 In the examples above and below, we include both headers for brevity. You
@@ -118,13 +112,9 @@ metadata:
 
       # for normal http traffic
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
-      proxy_hide_header l5d-remote-ip;
-      proxy_hide_header l5d-server-id;
 
       # for gRPC traffic
       grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
-      grpc_hide_header l5d-remote-ip;
-      grpc_hide_header l5d-server-id;
 spec:
   rules:
   - host: example.com

--- a/linkerd.io/content/2/tasks/using-ingress.md
+++ b/linkerd.io/content/2/tasks/using-ingress.md
@@ -53,7 +53,17 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/upstream-vhost: web-svc.emojivoto.svc.cluster.local:8080
     nginx.ingress.kubernetes.io/configuration-snippet: |
+
+      # for http traffic
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
+      proxy_hide_header l5d-remote-ip;
+      proxy_hide_header l5d-server-id;
+
+      # for gRPC traffic
+      grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
+      grpc_hide_header l5d-remote-ip;
+      grpc_hide_header l5d-server-id;
+
 spec:
   rules:
   - host: example.com
@@ -64,12 +74,26 @@ spec:
           servicePort: 8080
 ```
 
-The important annotation here is:
+The important annotation here for http traffic is:
 
 ```yaml
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
 ```
+
+When using gRPC, NGINX has a distinct set of directives for managing
+ headers:
+```yaml
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
+      grpc_hide_header l5d-remote-ip;
+      grpc_hide_header l5d-server-id;
+```
+
+In the examples above and below, we include both headers for brevity. You
+should include the directives that are relevant for the type of traffic that
+your service uses.
+
 
 In addition, the line below ensures that the `edge` between the ingress
 controller and the backend service are shown in the
@@ -91,7 +115,16 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/configuration-snippet: |
+
+      # for normal http traffic
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
+      proxy_hide_header l5d-remote-ip;
+      proxy_hide_header l5d-server-id;
+
+      # for gRPC traffic
+      grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
+      grpc_hide_header l5d-remote-ip;
+      grpc_hide_header l5d-server-id;
 spec:
   rules:
   - host: example.com


### PR DESCRIPTION
Documenting the `nginx.ingress.kubernetes.io/upstream-vhost` annotation with a static value for now.

We'll need to explore the correct way to dynamically set this value. the `$` nginx variables are not available to the annotation based on the testing that I've done. Will have to dig in to where this is added in the nginx configuration 