### PR TITLE
Update 'from-manifest' upgrade docs

### DIFF
--- a/linkerd.io/content/2/tasks/upgrade.md
+++ b/linkerd.io/content/2/tasks/upgrade.md
@@ -255,25 +255,13 @@ linkerd upgrade control-plane | kubectl apply --prune -l linkerd.io/control-plan
 
 #### Upgrading via manifests
 
-`edge-19.4.5` introduced a new `--from-manifests` flag to `linkerd upgrade`
-allowing manually feeding a previously saved output of `linkerd install` into
-the command, instead of requiring a connection to the cluster to fetch the
-config:
-
-```bash
-# save Linkerd installation manifest
-linkerd install > linkerd-install.yaml
-
-# deploy Linkerd
-cat linkerd-install.yaml | kubectl apply -f -
-
-# upgrade Linkerd via manifests
-cat linkerd-install.yaml | linkerd upgrade --from-manifests -
-```
-
-Alternatively, if you have already installed Linkerd without saving a manifest,
-you may save the relevant Linkerd resources from your existing installation for
-use in upgrading later.
+By default, the `linkerd upgrade` command reuses the existing `linkerd-config`
+config map and the `linkerd-identity-issuer` secret, by fetching them via the
+the Kubernetes API. `edge-19.4.5` introduced a new `--from-manifests` flag to
+allow the upgrade command to read the `linkerd-config` config map and the
+`linkerd-identity-issuer` secret from a static YAML file. This option is
+relevant to CI/CD workflows where the Linkerd configuration is managed by a
+configuration repository.
 
 ```bash
 kubectl -n linkerd get \
@@ -281,7 +269,7 @@ kubectl -n linkerd get \
   configmap/linkerd-config \
   -oyaml > linkerd-manifests.yaml
 
-cat linkerd-manifests.yaml | linkerd upgrade --from-manifests -
+linkerd upgrade --from-manifests linkerd-manifests.yaml | kubectl apply --prune -l linkerd.io/control-plane-ns=linkerd -f -
 ```
 
 {{< note >}}

--- a/linkerd.io/content/2/tasks/upgrade.md
+++ b/linkerd.io/content/2/tasks/upgrade.md
@@ -272,6 +272,19 @@ kubectl -n linkerd get \
 linkerd upgrade --from-manifests linkerd-manifests.yaml | kubectl apply --prune -l linkerd.io/control-plane-ns=linkerd -f -
 ```
 
+For releases prior to `edge-19.8.1`/`stable-2.5.0`, and after `stable-2.6.0`,
+you may pipe a full `linkerd install` manifest into the upgrade command:
+
+```bash
+linkerd install > linkerd-install.yaml
+
+# deploy Linkerd
+cat linkerd-install.yaml | kubectl apply -f -
+
+# upgrade Linkerd via manifests
+cat linkerd-install.yaml | linkerd upgrade --from-manifests -
+```
+
 {{< note >}}
 `secret/linkerd-identity-issuer` contains the trust root of Linkerd's Identity
 system, in the form of a private key. Care should be taken if storing this


### PR DESCRIPTION
This PR updates the `--from-manifests` portion of the upgrade docs, by removing the first example where the whole output of the `linkerd install` command is written to a manifest file. As filed in https://github.com/linkerd/linkerd2/issues/3559, this approach is now causing the `linkerd upgrade` command to fail due to the `k8s.FakeClientSet` not being able to deserialize the `APIService` kind. Since the original intent of this option (see https://github.com/linkerd/linkerd2/issues/2629) is to read the `linkerd-config` config map, I think it's fair to remove the failing example in the docs.

Fixes https://github.com/linkerd/linkerd2/issues/3559.

Signed-off-by: Ivan Sim <ivan@buoyant.io>