### PR TITLE
Added DNS rebinding docs

### DIFF
--- a/linkerd.io/content/2/reference/cli/dashboard.md
+++ b/linkerd.io/content/2/reference/cli/dashboard.md
@@ -10,3 +10,7 @@ more thorough explanation of what this command does.
 {{< cli/examples "dashboard" >}}
 
 {{< cli/flags "dashboard" >}}
+
+(*) You'll need to tweak the dashboard's `enforced-host` parameter with this
+value, as explained in [the DNS-rebinding protection
+docs](/2/tasks/exposing-dashboard/#tweaking-host-requirement)

--- a/linkerd.io/content/2/tasks/exposing-dashboard.md
+++ b/linkerd.io/content/2/tasks/exposing-dashboard.md
@@ -91,7 +91,7 @@ This exposes the dashboard at `dashboard.example.com` and protects it with basic
 auth using admin/admin. Take a look at the [Traefik][traefik-auth]
 documentation for details on how to change the username and password.
 
-## DNS-Rebinding Protection
+## DNS Rebinding Protection
 
 To prevent [DNS-rebinding](https://en.wikipedia.org/wiki/DNS_rebinding) attacks,
 the dashboard rejects any request whose `Host` header is not `localhost`,

--- a/linkerd.io/content/2/tasks/exposing-dashboard.md
+++ b/linkerd.io/content/2/tasks/exposing-dashboard.md
@@ -29,11 +29,6 @@ metadata:
   namespace: linkerd
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:8084;
-      proxy_set_header Origin "";
-      proxy_hide_header l5d-remote-ip;
-      proxy_hide_header l5d-server-id;
     nginx.ingress.kubernetes.io/upstream-vhost: $service_name.$namespace.svc.cluster.local:8084
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: web-ingress-auth
@@ -95,10 +90,7 @@ documentation for details on how to change the username and password.
 
 To prevent [DNS-rebinding](https://en.wikipedia.org/wiki/DNS_rebinding) attacks,
 the dashboard rejects any request whose `Host` header is not `localhost`,
-`127.0.0.1` or the full service name `linkerd-web.linkerd.svc.cluster.local`. If
-you rely on the latter, and if you used the `--cluster-domain` flag or the
-equivalent `ClusterDomain` Helm value when you installed Linkerd, then replace
-the `cluster.local` part with the appropriate value.
+`127.0.0.1` or the service name `linkerd-web.linkerd.svc`.
 
 Note that this protection also covers the [Grafana
 dashboard](/2/reference/architecture/#grafana).

--- a/linkerd.io/content/2/tasks/exposing-dashboard.md
+++ b/linkerd.io/content/2/tasks/exposing-dashboard.md
@@ -34,6 +34,7 @@ metadata:
       proxy_set_header Origin "";
       proxy_hide_header l5d-remote-ip;
       proxy_hide_header l5d-server-id;
+    nginx.ingress.kubernetes.io/upstream-vhost: $service_name.$namespace.svc.cluster.local:8084
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: web-ingress-auth
     nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
@@ -89,6 +90,51 @@ spec:
 This exposes the dashboard at `dashboard.example.com` and protects it with basic
 auth using admin/admin. Take a look at the [Traefik][traefik-auth]
 documentation for details on how to change the username and password.
+
+## DNS-Rebinding Protection
+
+To prevent [DNS-rebinding](https://en.wikipedia.org/wiki/DNS_rebinding) attacks,
+the dashboard rejects any request whose `Host` header is not `localhost`,
+`127.0.0.1` or `linkerd-web.linkerd.svc.cluster.local` (adjust the latter
+according to your custom namespace or cluster domain settings). This protection
+also covers Grafana.
+
+The Nginx-Ingress config above uses the
+`nginx.ingress.kubernetes.io/upstream-vhost` annotation to properly set the
+upstream `Host` header. Traefik on the other hand doesn't offer that option, so
+you'll have to manually set the required `Host` as explained below.
+
+### Tweaking Host Requirement
+
+If your HTTP client (Ingress or otherwise) doesn't allow to rewrite the `Host`
+header, you can change the validation regexp that the dashboard server uses,
+which is fed into the `linkerd-web` deployment via the `enforced-host` container
+argument.
+
+One way of doing that is through Kustomize, as explained in [Customizing
+Installation](/2/tasks/customize-install/), using an overlay
+like this one:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: linkerd-web
+spec:
+  template:
+    spec:
+      containers:
+      - name: web
+        args:
+        - -api-addr=linkerd-controller-api.linkerd.svc.cluster.local:8085
+        - -grafana-addr=linkerd-grafana.linkerd.svc.cluster.local:3000
+        - -controller-namespace=linkerd
+        - -log-level=info
+        - -enforced-host=^dashboard\.example\.com$
+```
+
+If you want to completely disable the `Host` header check, use an empty string
+for `-enforced-host`.
 
 [nginx-auth]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/examples/auth/basic/README.md
 [traefik-auth]: https://docs.traefik.io/middlewares/basicauth/

--- a/linkerd.io/content/2/tasks/exposing-dashboard.md
+++ b/linkerd.io/content/2/tasks/exposing-dashboard.md
@@ -30,6 +30,10 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/upstream-vhost: $service_name.$namespace.svc.cluster.local:8084
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header Origin "";
+      proxy_hide_header l5d-remote-ip;
+      proxy_hide_header l5d-server-id;
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: web-ingress-auth
     nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"

--- a/linkerd.io/content/2/tasks/exposing-dashboard.md
+++ b/linkerd.io/content/2/tasks/exposing-dashboard.md
@@ -95,7 +95,7 @@ the dashboard rejects any request whose `Host` header is not `localhost`,
 Note that this protection also covers the [Grafana
 dashboard](/2/reference/architecture/#grafana).
 
-The Nginx-Ingress config above uses the
+The ingress-nginx config above uses the
 `nginx.ingress.kubernetes.io/upstream-vhost` annotation to properly set the
 upstream `Host` header. Traefik on the other hand doesn't offer that option, so
 you'll have to manually set the required `Host` as explained below.

--- a/linkerd.io/content/2/tasks/exposing-dashboard.md
+++ b/linkerd.io/content/2/tasks/exposing-dashboard.md
@@ -95,9 +95,13 @@ documentation for details on how to change the username and password.
 
 To prevent [DNS-rebinding](https://en.wikipedia.org/wiki/DNS_rebinding) attacks,
 the dashboard rejects any request whose `Host` header is not `localhost`,
-`127.0.0.1` or `linkerd-web.linkerd.svc.cluster.local` (adjust the latter
-according to your custom namespace or cluster domain settings). This protection
-also covers Grafana.
+`127.0.0.1` or the full service name `linkerd-web.linkerd.svc.cluster.local`. If
+you rely on the latter, and if you used the `--cluster-domain` flag or the
+equivalent `ClusterDomain` Helm value when you installed Linkerd, then replace
+the `cluster.local` part with the appropriate value.
+
+Note that this protection also covers the [Grafana
+dashboard](/2/reference/architecture/#grafana).
 
 The Nginx-Ingress config above uses the
 `nginx.ingress.kubernetes.io/upstream-vhost` annotation to properly set the

--- a/linkerd.io/data/cli.yaml
+++ b/linkerd.io/data/cli.yaml
@@ -169,7 +169,7 @@ CLIReference:
   - DefaultValue: ""
     Name: address
     Shorthand: ""
-    Usage: The address at which to serve requests
+    Usage: The address at which to serve requests (*)
   - DefaultValue: ""
     Name: help
     Shorthand: h

--- a/linkerd.io/layouts/shortcodes/pagetoc.html
+++ b/linkerd.io/layouts/shortcodes/pagetoc.html
@@ -3,7 +3,7 @@
   {{ range $headers }}
     {{ $header := replaceRE "\n## " "" .}}
     <li>
-      <a href="#{{ $header | lower }}">{{ $header }}</a>
+      <a href="#{{ $header | replaceRE " " "-" | lower }}">{{ $header }}</a>
     </li>
   {{ end }}
 </ul>

--- a/linkerd.io/static/dns-rebinding/index.html
+++ b/linkerd.io/static/dns-rebinding/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=https://linkerd.io/2/tasks/exposing-dashboard/#tweaking-host-requirement">
+    <script type="text/javascript">
+    window.onload = function() {
+      window.location.href = window.location.origin + "/2/tasks/exposing-dashboard/#tweaking-host-requirement";
+    }
+    </script>
+    <title>Linkerd Redirection</title>
+  </head>
+  <body>
+    If you are not redirected automatically, follow this
+    <a href='https://linkerd.io/2/tasks/exposing-dashboard/#tweaking-host-requirement'>link</a>.
+  </body>
+</html>


### PR DESCRIPTION
Fixes #571

@grampelberg what's the best way to create a redirect from https://linkerd.io/dns-rebinding to https://linkerd.io/2/tasks/exposing-dashboard/#tweaking-host-requirement ? Like with healthchecks, create a new page `dns-rebinding` and have javascript in there do the redirect?