### PR TITLE
Don't set issuance lifetime

### DIFF
--- a/linkerd.io/content/2/tasks/generate-certificates.md
+++ b/linkerd.io/content/2/tasks/generate-certificates.md
@@ -53,7 +53,6 @@ linkerd install \
   --identity-trust-anchors-file ca.crt \
   --identity-issuer-certificate-file issuer.crt \
   --identity-issuer-key-file issuer.key \
-  --identity-issuance-lifetime 8760h \
   | kubectl apply -f -
 ```
 


### PR DESCRIPTION
the `identity-issuance-lifetime` flag configures how long service certificates that the identity service issues are valid.  It does not configure the lifetime of the issuer certificate itself.  I don't believe there is any reason here to recommend a longer issuance lifetime than the default of 24h.

Signed-off-by: Alex Leong <alex@buoyant.io>