### PR TITLE
Post message with body height from dashboard template 

### DIFF
--- a/linkerd.io/layouts/page/dashboard.html
+++ b/linkerd.io/layouts/page/dashboard.html
@@ -16,5 +16,10 @@
           </div>
         </div>
     {{ end }}
+    <script type="text/javascript">
+      (() => {
+        window.parent.postMessage({ "dashboardHeight": document.body.offsetHeight }, "*");
+      })();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
#### Problem
From `Linkerd2 Dashboard`, we need to know the body height of this template to render it properly into an iframe injected on `Community` section.

#### Solution
We post a message with the body height from `dashboard` template using `postMessage` method to its parent. This height is going to be used by `Linkerd2 Dashboard` to render properly the iframe, which contains these community updates.

Related to [#3764](https://github.com/linkerd/linkerd2/issues/3764)

Signed-off-by: Cintia Sanchez Garcia <cynthiasg@icloud.com>