### PR TITLE
Add a note about setting the SDKROOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ master from slate-linkerd and add it to the public dir.
     ```bash
     make deploy-api.linkerd.io
     ```
+   
+   * NB: If you're running macOS 10.14+ with `ruby` installed by XCode, you
+    may have to [set the SDKROOT](https://github.com/castwide/vscode-solargraph/issues/78#issuecomment-552675511) 
+    in order to install `json 1.8.3` which is a `middleman` dependency.
+     
 
 ## Publishing
 


### PR DESCRIPTION
Signed-off-by: Charles Pretzer <charles@buoyant.io>

If `make deploy-api.linkerd.io` fails, then you may need to follow the instructions in the note.

We can also look into updating the dependencies, but I worry about breaking backward compatibility.