### PR TITLE
Clarify data-plane restart requirements

### DIFF
--- a/linkerd.io/content/2/tasks/upgrade.md
+++ b/linkerd.io/content/2/tasks/upgrade.md
@@ -95,7 +95,10 @@ to ensure zero downtime upgrade for previous stable releases.
 
 The `destination` container is now deployed as its own `Deployment` workload.
 Once your control plane is successfully upgraded, your data plane must be
-restarted.
+restarted if you are upgrading from one of the edge versions listed above.
+
+If you are upgrading from a previous stable version, restarting the data-plane
+is __recommended__ as a best practice, although not necessary.
 
 If you have previously labelled any of your namespaces with the
 `linkerd.io/is-control-plane` label so that their pod creation events are

--- a/linkerd.io/content/2/tasks/upgrade.md
+++ b/linkerd.io/content/2/tasks/upgrade.md
@@ -94,8 +94,11 @@ to ensure zero downtime upgrade for previous stable releases.
 {{< /note >}}
 
 The `destination` container is now deployed as its own `Deployment` workload.
-Once your control plane is successfully upgraded, your data plane must be
-restarted if you are upgrading from one of the edge versions listed above.
+When you are planning the upgrade from one of the edge versions listed above,
+be sure to allocate time to restart the data plane once the control plane is
+successfully upgraded. This restart can be done at your convenience with the
+recommendation that it be done over the course of time appropriate for your
+application.
 
 If you are upgrading from a previous stable version, restarting the data-plane
 is __recommended__ as a best practice, although not necessary.


### PR DESCRIPTION
Signed-off-by: Charles Pretzer <charles@buoyant.io>

@grampelberg, per our conversation I ran these upgrade tests:
- 2.4.0 to 2.6.0
- 2.5.0 to 2.6.0

In both cases, the 2.4.0 and 2.5.0 proxies running under the 2.6.0 control plane continued to run without error.

I also confirmed that a pod injected with a 2.4.0 proxy could successfully communicate with a pod injected with a 2.6.0 proxy.

I'll run the same tests with 2.6.1, and for now, the tests support the documentation.