### PR TITLE
Update the cert management documentation

### DIFF
--- a/linkerd.io/content/2/tasks/rotating_identity_certificates.md
+++ b/linkerd.io/content/2/tasks/rotating_identity_certificates.md
@@ -24,12 +24,17 @@ on how to do this.
 
 ## Prerequisites
 
-We are going to use [step 0.13.3](https://smallstep.com/cli/) and
-[jq 1.6](https://stedolan.github.io/jq/). We will also make use of the
-`linkerd check` CLI utility which will give us extra assurance that the state
-of our mTLS configuration is valid at any point. The minimum CLI version is
-[edge-19.12.3](https://github.com/linkerd/linkerd2/releases/tag/edge-19.12.3).
-To begin with, you can run:
+Upgrade your Linkerd CLI to [stable-2.7.0](https://github.com/linkerd/linkerd2/releases/tag/stable-2.7.0).
+See the [Upgrade the CLI](/2/tasks/upgrade/#upgrade-the-cli) documentation for
+instructions on how to do this.
+
+You will also need [step 0.13.3](https://smallstep.com/cli/) and
+[jq 1.6](https://stedolan.github.io/jq/).
+
+The `linkerd check` CLI command has been updated to provide visibility into the
+state of your service mesh throughout the certificate rotation process.
+
+To begin, let's make sure your service mesh is healthy:
 
 ```bash
 linkerd check --proxy

--- a/linkerd.io/content/2/tasks/use_external_certs.md
+++ b/linkerd.io/content/2/tasks/use_external_certs.md
@@ -12,11 +12,15 @@ that are issued by the proxy. The trust root, certificates and private key
 can either be generated automatically by the CLI upon installation or can
 be supplied by the user. If the latter is true, the necessity for providing
 the user with more control over the life cycle of these credential arises.
-In order to do that Linkerd [edge-19.10.5](https://github.com/linkerd/linkerd2/releases/tag/edge-19.10.5)
-introduces the functionality to read and continuously monitor Kubernetes
-secrets for certificates change and to auto-reload the `identity` component's
-in-memory issuer certificate. In the following lines, we will demonstrate how
-this allows integration with the external certificate management solution
+
+To ensure the certificate issuance process remains uninterrupted, Linkerd
+[stable-2.7.0](https://github.com/linkerd/linkerd2/releases/tag/stable-2.7.0)
+and [edge-19.10.5](https://github.com/linkerd/linkerd2/releases/tag/edge-19.10.5)
+introduced updates to the `identity` component, enabling it to seaminglessly
+auto-reload new mTLS issuer certificate.
+
+In the following lines, we will demonstrate how this allows integration with
+the external certificate management solution
 [cert-manager](https://github.com/jetstack/cert-manager).
 
 ## Prerequisites

--- a/linkerd.io/content/2/tasks/use_external_certs.md
+++ b/linkerd.io/content/2/tasks/use_external_certs.md
@@ -16,8 +16,8 @@ the user with more control over the life cycle of these credential arises.
 To ensure the certificate issuance process remains uninterrupted, Linkerd
 [stable-2.7.0](https://github.com/linkerd/linkerd2/releases/tag/stable-2.7.0)
 and [edge-19.10.5](https://github.com/linkerd/linkerd2/releases/tag/edge-19.10.5)
-introduced updates to the `identity` component, enabling it to seaminglessly
-auto-reload new mTLS issuer certificate.
+introduced updates to the `identity` component, enabling it to seamlessly
+auto-reload new mTLS issuer certificates.
 
 In the following lines, we will demonstrate how this allows integration with
 the external certificate management solution


### PR DESCRIPTION
Includes reference to stable-2.7. Added line breaks to introduce new paragraphs, and some rewording.

Fixes #578 

Signed-off-by: Ivan Sim <ivan@buoyant.io>