### PR TITLE
Fix pagetoc shortcode problem

### DIFF
--- a/linkerd.io/content/2/tasks/exposing-dashboard.md
+++ b/linkerd.io/content/2/tasks/exposing-dashboard.md
@@ -6,7 +6,7 @@ description = "Make it easy for others to access Linkerd and Grafana dashboards 
 Instead of using `linkerd dashboard` every time you'd like to see what's going
 on, you can expose the dashboard via an ingress. This will also expose Grafana.
 
-{{% pagetoc %}}
+{{< pagetoc >}}
 
 ## Nginx
 

--- a/linkerd.io/content/2/tasks/setting-up-service-profiles.md
+++ b/linkerd.io/content/2/tasks/setting-up-service-profiles.md
@@ -62,7 +62,7 @@ For a complete demo walkthrough, check out the
 There are a couple different ways to use `linkerd profile` to create service
 profiles.
 
-{{% pagetoc %}}
+{{< pagetoc >}}
 
 Requests which have been associated with a route will have a `rt_route`
 annotation. To manually verify if the requests are being associated correctly,


### PR DESCRIPTION
Right now the `pagetoc` on these two pages is rendering incorrectly due to a Hugo syntax error:

* https://linkerd.io/2/tasks/setting-up-service-profiles
* https://linkerd.io/2/tasks/exposing-dashboard

This PR fixes that with a small syntax change.