### PR TITLE
Update Helm install doc with renamed value

### DIFF
--- a/linkerd.io/content/2/tasks/install-helm.md
+++ b/linkerd.io/content/2/tasks/install-helm.md
@@ -53,10 +53,8 @@ file passed with a `-f` option, or overriding specific values using the family o
 
 ## Disabling The Proxy Init Container
 
-If installing with CNI, make sure that you add the
-`--set global.noInitContainer=true` and
-`--set installNamespace=false` flags to your `helm install` command as these
-are required when using CNI.
+If installing with CNI, make sure that you add the `--set
+global.cniEnabled=true` flag to your `helm install` command.
 
 ## Setting High-Availability
 


### PR DESCRIPTION
globals.noInitContainer is now globals.cniEnabled

This is to be merged after linkerd/linkerd2#3956 merges