### PR TITLE
Minor improvements to the cert rotation docs

### DIFF
--- a/linkerd.io/content/2/tasks/replacing_expired_certificates.md
+++ b/linkerd.io/content/2/tasks/replacing_expired_certificates.md
@@ -61,7 +61,8 @@ linkerd upgrade \
     --identity-issuer-certificate-file=./issuer-new.crt \
     --identity-issuer-key-file=./issuer-new.key \
     --identity-trust-anchors-file=./ca-new.crt \
-    --force
+    --force \
+    | kubectl apply -f -
 ```
 
 Usually `upgrade` will prevent you from using an issuer certificate that
@@ -100,8 +101,9 @@ linkerd-identity-data-plane
 
 ```
 
-Eventually when the old pods are terminated the `check` command should stop
-producing warning or errors:
+Additionally you can use the `kubectl rollout restart` command to bring the
+configuration of your other injected resources up to date, and then the `check`
+command should stop producing warning or errors:
 
 ```bash
 linkerd-identity

--- a/linkerd.io/content/2/tasks/rotating_identity_certificates.md
+++ b/linkerd.io/content/2/tasks/rotating_identity_certificates.md
@@ -7,7 +7,7 @@ By default, the issuer certificate and trust root that Linkerd uses are valid
 for 365 days. If either of these certificates expires, Linkerd will no longer
 be able to proxy traffic. Therefore, it is critical that you replace these
 certificates with new ones before they expire - a process called certificate
-rotation.
+rotation. This guide will show you how to achieve that without any downtime.
 
 If your control plane is installed with the
 `linkerd install --identity-external-issuer` command where your trust root is


### PR DESCRIPTION
- Usually after linkerd commands we show the pipe to kubectl, but that's missing in the linkerd upgrade command under "Replacing the root and issuer certificates"
- In that same doc, there's no instructions on rolling out the dataplane pods so they pick the new cert.
- In "Rotating your Identity Certificates" section "Generate new trust root and issuer certificates" it doesn't mention that all of this is for rotating certs without downtime.

Ref linkerd/linkerd2#3898