### PR TITLE
fix canonical og urls

### DIFF
--- a/linkerd.io/layouts/partials/meta.html
+++ b/linkerd.io/layouts/partials/meta.html
@@ -12,7 +12,7 @@
 <meta property="og:title" content="{{ .Title }}" />
 <meta property="og:description" content="{{ partial "description.html" . }}" />
 <meta property="og:type" content="website" />
-<meta property="og:url" content="https://linkerd.io" />
+<meta property="og:url" content="{{ .Page.RelPermalink | absURL }}" />
 
 {{ if .Params.thumbnail }}
   <meta property="og:image" content="{{ .Params.thumbnail | absURL | safeHTMLAttr }}" />


### PR DESCRIPTION
Per https://ogp.me/, we should be setting `og:url` to

> The canonical URL of your object that will be used as its permanent ID in the graph, e.g., "http://www.imdb.com/title/tt0117500/".

Currently we set it to `https://linkerd.io` for everything, which breaks sharing on LinkedIn.

This patch changes it to what I *believe* is the actual canonical URL for the page.
