### PR TITLE
Fix variable names to proper one

### DIFF
--- a/linkerd.io/content/2/tasks/install-helm.md
+++ b/linkerd.io/content/2/tasks/install-helm.md
@@ -95,8 +95,8 @@ Helm v2's `--namespace` option.  If you're relying on a separate tool to create
 the control plane namespace, make sure that:
 
 1. The namespace is labeled with `linkerd.io/admission-webhooks: disabled`
-1. The `InstallNamespace` is set to `false`
-1. The `Namespace` variable is overridden with the name of your namespace
+1. The `installNamespace` is set to `false`
+1. The `namespace` variable is overridden with the name of your namespace
 
 {{< note >}}
 In Helm v3 the `--namespace` option must be used with an existing namespace.


### PR DESCRIPTION
In helm chart for v2.7.0 variable names changed from ```Namespace``` to ```namespace``` and ```InstallNamespace``` to ```installNamespace```