### PR TITLE
update helm install docs to use linkerd/ instead of charts/ as the base

### DIFF
--- a/linkerd.io/content/2/tasks/generate-certificates.md
+++ b/linkerd.io/content/2/tasks/generate-certificates.md
@@ -66,5 +66,5 @@ helm install \
   --set-file identity.issuer.tls.crtPEM=issuer.crt \
   --set-file identity.issuer.tls.keyPEM=issuer.key \
   --set identity.issuer.crtExpiry=$(date -d '+8760 hour' +"%Y-%m-%dT%H:%M:%SZ") \
-  charts/linkerd2
+  linkerd/linkerd2
 ```


### PR DESCRIPTION
Signed-off-by: alex lundberg <alex.lundberg@commonbond.co>