### PR TITLE
Describe how to achieve longer lived trust anchor certificates.

### DIFF
--- a/linkerd.io/content/2/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -55,6 +55,9 @@ step certificate create identity.linkerd.cluster.local ca.crt ca.key \
    --namespace=linkerd
 ```
 
+For a longer-lived trust anchor certificate, pass the `--not-after` argument
+to the step command with the desired value (e.g. `--not-after=87600h`).
+
 #### Create an Issuer referencing the secret
 
 With the Secret in place, we can create a cert-manager "Issuer" resource that

--- a/linkerd.io/content/2/tasks/generate-certificates.md
+++ b/linkerd.io/content/2/tasks/generate-certificates.md
@@ -22,11 +22,14 @@ this tutorial, we'll walk you through how to to use the `step` CLI to do this.
 
 ## Generating the certificates with `step`
 
+### Trust anchor certificate
+
 First generate the root certificate with its private key (using `step` version
 0.10.1):
 
 ```bash
-step certificate create identity.linkerd.cluster.local ca.crt ca.key --profile root-ca --no-password --insecure
+step certificate create identity.linkerd.cluster.local ca.crt ca.key \
+--profile root-ca --no-password --insecure
 ```
 
 This generates the `ca.crt` and `ca.key` files. The `ca.crt` file is what you
@@ -36,6 +39,11 @@ Linkerd with Helm.
 
 Note we use `--no-password --insecure` to avoid encrypting those files with a
 passphrase.
+
+For a longer-lived trust anchor certificate, pass the `--not-after` argument
+to the step command with the desired value (e.g. `--not-after=87600h`).
+
+### Issuer certificate and key
 
 Then generate the intermediate certificate and key pair that will be used to
 sign the Linkerd proxies' CSR.


### PR DESCRIPTION
It is in some cases desirable to have a longer than default lived trust anchor certificate for long lived clusters.

Also added headers to distinguish between Trust anchor creation and Issuer Cert/Key creation.