### PR TITLE
Add server speaks first ports

### DIFF
--- a/linkerd.io/content/2/features/protocol-detection.md
+++ b/linkerd.io/content/2/features/protocol-detection.md
@@ -52,16 +52,16 @@ For example, if your application makes requests to a MySQL database running on
 port 4406, use the command:
 
 ```bash
-linkerd inject deployment.yml --skip-outbound-ports=4406 \
-  | kubectl apply -f -
+linkerd inject deployment.yml --skip-outbound-ports=4406 |
+  kubectl apply -f -
 ```
 
 Likewise if your application runs an SMTP server that accepts incoming requests
 on port 35, use the command:
 
 ```bash
-linkerd inject deployment.yml --skip-inbound-ports=35 \
-  | kubectl apply -f -
+linkerd inject deployment.yml --skip-inbound-ports=35 |
+  kubectl apply -f -
 ```
 
 ## Plaintext MySQL and SMTP

--- a/linkerd.io/content/2/features/protocol-detection.md
+++ b/linkerd.io/content/2/features/protocol-detection.md
@@ -38,6 +38,12 @@ The following protocols are known to be server-speaks-first:
 * 4222 - NATS
 * 27017 - MongoDB
 
+The following protocols are likely but to be confirmed to be
+server-speaks-first(users have had to ignore these ports):
+
+* 7000 - Cassandra inter-node cluster communication
+* 26379 - Redis Sentinel
+
 If you're working with a protocol that can't be automatically recognized by
 Linkerd, use the `--skip-inbound-ports` and `--skip-outbound-ports` flags when
 running `linkerd inject`.

--- a/linkerd.io/content/2/features/protocol-detection.md
+++ b/linkerd.io/content/2/features/protocol-detection.md
@@ -38,8 +38,8 @@ The following protocols are known to be server-speaks-first:
 * 4222 - NATS
 * 27017 - MongoDB
 
-The following protocols are likely but to be confirmed to be
-server-speaks-first(users have had to ignore these ports):
+The following protocols are most likely (but yet to be confirmed)
+server-speaks-first:
 
 * 7000 - Cassandra inter-node cluster communication
 * 26379 - Redis Sentinel


### PR DESCRIPTION
Cassandra internode communication and Redis Sentinel.

There is no clear documentation as to these protocol's behaviour in terms of server speaks first, but they had to be ignored to keep things working.