### PR TITLE
Fix example of kube-system namespace

### DIFF
--- a/linkerd.io/content/2/tasks/troubleshooting.md
+++ b/linkerd.io/content/2/tasks/troubleshooting.md
@@ -1055,11 +1055,10 @@ $ kubectl get namespace kube-system -oyaml
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: linkerd
+  name: kube-system
   annotations:
     linkerd.io/inject: disabled
   labels:
-    linkerd.io/is-control-plane: "true"
     config.linkerd.io/admission-webhooks: disabled
 ```
 


### PR DESCRIPTION
Looks like it was cargoculted from the `linkerd` namespace.