### PR TITLE
Fix port for web-svc

### DIFF
--- a/linkerd.io/content/2/tasks/using-ingress.md
+++ b/linkerd.io/content/2/tasks/using-ingress.md
@@ -62,7 +62,7 @@ spec:
       paths:
       - backend:
           serviceName: web-svc
-          servicePort: 8080
+          servicePort: 80
 ```
 
 The important annotation here is:


### PR DESCRIPTION
The Kubernetes service `web-svc` listens to port 80. So this definition needs to be changed. It is already port 80 in the other Ingress definitions. Also I checked the "Getting Started" emojivote Kubernetes deployment.