### PR TITLE
proxy-configuration page description clipping fix

### DIFF
--- a/linkerd.io/layouts/partials/cli/annotations.html
+++ b/linkerd.io/layouts/partials/cli/annotations.html
@@ -1,6 +1,6 @@
 <tr>
   <td>
-    <code class="text-nowrap">{{ .Name }}</code>
+    <code>{{ .Name }}</code>
   </td>
   <td>
     {{ .Description | markdownify }}


### PR DESCRIPTION
Image depicting issue (Chrome):
![linkerd_before](https://user-images.githubusercontent.com/8674362/85487613-c6446080-b581-11ea-9a06-fbbb1694b7d8.png)

Image depicting layout after fix (Chrome):
![linkerd_after](https://user-images.githubusercontent.com/8674362/85487601-c17fac80-b581-11ea-859b-3c82e3767b62.png)

Allow annotation to wrap, preventing description from clipping on longer annotations. Also makes the page more readable at half-width.

Signed-off-by: Theodore Brockman <tbrockma@ualberta.ca>