### PR TITLE
add redirect to features/multicluster_support

### DIFF
--- a/linkerd.io/content/2/features/multicluster.md
+++ b/linkerd.io/content/2/features/multicluster.md
@@ -1,6 +1,7 @@
 +++
 title = "Multi-cluster communication"
 description = "Linkerd connects applications running in different clusters"
+aliases = [ "multicluster_support" ]
 +++
 
 Linkerd can connect Kubernetes services across cluster boundaries in a way that


### PR DESCRIPTION
For some reason Google search results point to this 404 URL when searching
for "linkerd multicluster". Have it redirect to the real URL.

Signed-off-by: William Morgan <william@buoyant.io>