### PR TITLE
Fix link to smi-spec traffic-split

### DIFF
--- a/linkerd.io/content/2/features/traffic-split.md
+++ b/linkerd.io/content/2/features/traffic-split.md
@@ -14,7 +14,7 @@ a newer version.
 
 Linkerd exposes this functionality via the [Service Mesh
 Interface](https://smi-spec.io/) (SMI) [TrafficSplit
-API](https://github.com/deislabs/smi-spec/blob/master/traffic-split.md). To
+API](https://github.com/servicemeshinterface/smi-spec/blob/master/apis/traffic-split/traffic-split-wd.md). To
 use this feature, you create a Kubernetes resource as described in the
 TrafficSplit spec, and Linkerd takes care of the rest.
 


### PR DESCRIPTION
The link to the smi-spec was broken, it was moved in the upstream repo.


This was tested by running the site locally and checking the link was valid and to the expected page.

Fixes #755 

Signed-off-by: Alistair Hey <alistair.hey@form3.tech>