### PR TITLE
Update GKE firewall setup instructions

### DIFF
--- a/linkerd.io/content/2/reference/cluster-configuration.md
+++ b/linkerd.io/content/2/reference/cluster-configuration.md
@@ -22,11 +22,11 @@ CLUSTER_NAME=your-cluster-name
 gcloud config set compute/zone your-zone-or-region
 ```
 
-Get the cluster `MASTER_IPV4_CIDR`:
+Get the cluster `CLUSTER_IPV4_CIDR`:
 
 ```bash
-MASTER_IPV4_CIDR=$(gcloud container clusters describe $CLUSTER_NAME \
-  | grep "masterIpv4CidrBlock: " \
+CLUSTER_IPV4_CIDR=$(gcloud container clusters describe $CLUSTER_NAME \
+  | grep "clusterIpv4CidrBlock: " \
   | awk '{print $2}')
 ```
 
@@ -52,7 +52,7 @@ The format of the network tag should be something like `gke-cluster-name-xxxx-no
 Verify the values:
 
 ```bash
-echo $MASTER_IPV4_CIDR $NETWORK $NETWORK_TARGET_TAG
+echo $CLUSTER_IPV4_CIDR $NETWORK $NETWORK_TARGET_TAG
 
 # example output
 10.0.0.0/28 foo-network gke-foo-cluster-c1ecba83-node
@@ -64,7 +64,7 @@ Create the firewall rules for `proxy-injector` and `tap`:
 gcloud compute firewall-rules create gke-to-linkerd-control-plane \
   --network "$NETWORK" \
   --allow "tcp:8443,tcp:8089" \
-  --source-ranges "$MASTER_IPV4_CIDR" \
+  --source-ranges "$CLUSTER_IPV4_CIDR" \
   --target-tags "$NETWORK_TARGET_TAG" \
   --priority 1000 \
   --description "Allow traffic on ports 8843, 8089 for linkerd control-plane components"


### PR DESCRIPTION
Subject
Updating instructions to create firewall rules for GKE.

Problem
Cannot setup Linkerd on a GKE private cluster due to a variable name change in GCP.

Solution
Update docs to use the current variable. The old variable was masterIpv4CidrBlock. The new variable is clusterIpv4CidrBlock

Signed-off-by: Vijay Savanth Madala <vijaysavanth@gmail.com>