### PR TITLE
Add version label to ease SMI TrafficSplit config

### DIFF
--- a/run.linkerd.io/public/emojivoto-daemonset.yml
+++ b/run.linkerd.io/public/emojivoto-daemonset.yml
@@ -80,10 +80,12 @@ spec:
   selector:
     matchLabels:
       app: emoji-svc
+      version: v10
   template:
     metadata:
       labels:
         app: emoji-svc
+        version: v10
     spec:
       containers:
       - env:
@@ -116,10 +118,12 @@ spec:
   selector:
     matchLabels:
       app: vote-bot
+      version: v10
   template:
     metadata:
       labels:
         app: vote-bot
+        version: v10
     spec:
       containers:
       - command:
@@ -146,10 +150,12 @@ spec:
   selector:
     matchLabels:
       app: voting-svc
+      version: v10
   template:
     metadata:
       labels:
         app: voting-svc
+        version: v10
     spec:
       containers:
       - env:
@@ -182,10 +188,12 @@ spec:
   selector:
     matchLabels:
       app: web-svc
+      version: v10
   template:
     metadata:
       labels:
         app: web-svc
+        version: v10
     spec:
       containers:
       - env:

--- a/run.linkerd.io/public/emojivoto-statefulset.yml
+++ b/run.linkerd.io/public/emojivoto-statefulset.yml
@@ -81,11 +81,13 @@ spec:
   selector:
     matchLabels:
       app: emoji-svc
+      version: v10
   serviceName: emoji-svc
   template:
     metadata:
       labels:
         app: emoji-svc
+        version: v10
     spec:
       containers:
       - env:
@@ -119,11 +121,13 @@ spec:
   selector:
     matchLabels:
       app: vote-bot
+      version: v10
   serviceName: vote-bot
   template:
     metadata:
       labels:
         app: vote-bot
+        version: v10
     spec:
       containers:
       - command:
@@ -151,11 +155,13 @@ spec:
   selector:
     matchLabels:
       app: voting-svc
+      version: v10
   serviceName: voting-svc
   template:
     metadata:
       labels:
         app: voting-svc
+        version: v10
     spec:
       containers:
       - env:
@@ -189,11 +195,13 @@ spec:
   selector:
     matchLabels:
       app: web-svc
+      version: v10
   serviceName: web-svc
   template:
     metadata:
       labels:
         app: web-svc
+        version: v10
     spec:
       containers:
       - env:

--- a/run.linkerd.io/public/emojivoto.yml
+++ b/run.linkerd.io/public/emojivoto.yml
@@ -81,10 +81,12 @@ spec:
   selector:
     matchLabels:
       app: emoji-svc
+      version: v10
   template:
     metadata:
       labels:
         app: emoji-svc
+        version: v10
     spec:
       containers:
       - env:
@@ -118,10 +120,12 @@ spec:
   selector:
     matchLabels:
       app: vote-bot
+      version: v10
   template:
     metadata:
       labels:
         app: vote-bot
+        version: v10
     spec:
       containers:
       - command:
@@ -149,10 +153,12 @@ spec:
   selector:
     matchLabels:
       app: voting-svc
+      version: v10
   template:
     metadata:
       labels:
         app: voting-svc
+        version: v10
     spec:
       containers:
       - env:
@@ -186,10 +192,12 @@ spec:
   selector:
     matchLabels:
       app: web-svc
+      version: v10
   template:
     metadata:
       labels:
         app: web-svc
+        version: v10
     spec:
       containers:
       - env:


### PR DESCRIPTION
The SMI `TrafficSplit` resouce makes it easy to configure canary releases
in Linkerd. It relies on a `Service` that resolves to all versions
of an application and each version having their own `Service` that
resolves to only endpoints for that version.

Since the current `Deployment` manifests at https://run.linkerd.io/emojivoto.yml
only include the `app` label, you have to redeploy the service you want
to demo `TrafficSplit` with with a `version` label in order to get it
to work properly.

Adding a `version` label will make it so we do not have to redeploy the
current version.

See: https://github.com/BuoyantIO/emojivoto/pull/90

Signed-off-by: Noah Krause <krausenoah@gmail.com>