### PR TITLE
Fix two trace-collector references in documentation

### DIFF
--- a/linkerd.io/content/2/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2/tasks/distributed-tracing.md
@@ -252,7 +252,7 @@ If using helm to install ingress-nginx, you can configure tracing by using:
 controller:
   config:
     enable-opentracing: "true"
-    zipkin-collector-host: oc-collector.tracing
+    zipkin-collector-host: linkerd-collector.linkerd
 ```
 
 ### Client Library

--- a/linkerd.io/data/cli.yaml
+++ b/linkerd.io/data/cli.yaml
@@ -47,7 +47,7 @@ AnnotationsReference:
   Name: config.linkerd.io/disable-tap
 - Description: Inject a debug sidecar for data plane debugging
   Name: config.linkerd.io/enable-debug-sidecar
-- Description: Service name of the trace collector. E.g. `oc-collector.tracing:55678`
+- Description: Service name of the trace collector. E.g. `linkerd-collector.linkerd:55678`
   Name: config.linkerd.io/trace-collector
 - Description: The trace collector's service account name. E.g., `tracing-service-account`.
     If not provided, it will be defaulted to `default`.


### PR DESCRIPTION
Under the NGINX ingress section of the distributed tracing task, there is a reference indicating to use a service as a trace collector that will not exist after a traditional Linkerd2 installation (the same reference is copied to the CLI documentation).

Slack message giving context here: https://linkerd.slack.com/archives/C89RTCWJF/p1596584278173200

Signed-off-by: Theodore Brockman <tbrockma@ualberta.ca>