### PR TITLE
fixing external prometheus setup documentation

### DIFF
--- a/linkerd.io/content/2/tasks/external-prometheus.md
+++ b/linkerd.io/content/2/tasks/external-prometheus.md
@@ -124,7 +124,8 @@ The running configuration of the builtin prometheus can be used as a reference.
 kubectl -n linkerd  get configmap linkerd-prometheus-config -o yaml
 ```
 
-In order for the dashboard and grafana to work correctly the scrape settings need to be set to the following values: 
+In order for the dashboard and grafana to work correctly the scrape settings need
+to be set to the following values:
 
 ```yaml
 scrape_interval: 10s

--- a/linkerd.io/content/2/tasks/external-prometheus.md
+++ b/linkerd.io/content/2/tasks/external-prometheus.md
@@ -36,8 +36,11 @@ Before applying, it is important to replace templated values (present in `{{}}`)
 with direct values for the below configuration to work.
 
 ```yaml
-
     - job_name: 'linkerd-controller'
+
+      scrape_interval: 10s
+      scrape_timeout: 10s
+
       kubernetes_sd_configs:
       - role: pod
         namespaces:
@@ -53,6 +56,10 @@ with direct values for the below configuration to work.
         target_label: component
 
     - job_name: 'linkerd-service-mirror'
+
+      scrape_interval: 10s
+      scrape_timeout: 10s
+
       kubernetes_sd_configs:
       - role: pod
       relabel_configs:
@@ -66,6 +73,10 @@ with direct values for the below configuration to work.
         target_label: component
 
     - job_name: 'linkerd-proxy'
+
+      scrape_interval: 10s
+      scrape_timeout: 10s
+
       kubernetes_sd_configs:
       - role: pod
       relabel_configs:
@@ -123,16 +134,6 @@ The running configuration of the builtin prometheus can be used as a reference.
 ```bash
 kubectl -n linkerd  get configmap linkerd-prometheus-config -o yaml
 ```
-
-In order for the dashboard and grafana to work correctly the scrape settings need
-to be set to the following values:
-
-```yaml
-scrape_interval: 10s
-scrape_timeout: 10s
-```
-
-This can be done either globally or per scrape job.
 
 ## Control Plane Components Configuration
 

--- a/linkerd.io/content/2/tasks/external-prometheus.md
+++ b/linkerd.io/content/2/tasks/external-prometheus.md
@@ -118,6 +118,21 @@ with direct values for the below configuration to work.
         regex: __tmp_pod_label_(.+)
 ```
 
+The running configuration of the builtin prometheus can be used as a reference.
+
+```bash
+kubectl -n linkerd  get configmap linkerd-prometheus-config -o yaml
+```
+
+In order for the dashboard and grafana to work correctly the scrape settings need to be set to the following values: 
+
+```yaml
+scrape_interval: 10s
+scrape_timeout: 10s
+```
+
+This can be done either globally or per scrape job.
+
 ## Control Plane Components Configuration
 
 Linkerd's control plane components like `public-api`, etc depend
@@ -134,13 +149,8 @@ which is available both through `linkerd install` and `linkerd upgrade` commands
 
 ```yaml
 global:
-  prometheusUrl: existing-prometheus.xyz:9090/api/prom
+  prometheusUrl: existing-prometheus.xyz:9090
 ```
-
-{{< note >}}
-Rather than the plain URL of the existing Prometheus, the query path of the
-instance has to be passed which is usually at `api/prom`.
-{{< /note >}}
 
 Once applied, this configuration is persistent across upgrades, without having
 the user passing it again. The same can be overwritten as needed.


### PR DESCRIPTION
* API endpoint for prometheus is generally under / and not under /api/prom ( this endpoint is for writing back to prometheus)
* when using external prometheus the sample frequency needs to be higher than for example what is the default in prometheus helm chart 
* Using the already deployed prometheus configuration is a good starting point as a reference for an external prometheus setup.