### PR TITLE
l5d install script: Mute error when attempting to move unexisting file

### DIFF
--- a/run.linkerd.io/public/install
+++ b/run.linkerd.io/public/install
@@ -139,7 +139,7 @@ fi
 (
   mkdir -p "${INSTALLROOT}/bin"
   # shellcheck disable=SC2031
-  if ! mv "${tmpdir}/${srcfile}" "${dstfile}"; then
+  if ! mv "${tmpdir}/${srcfile}" "${dstfile}" 2>/dev/null; then
     mv "${tmpdir}/linkerd2-cli-${LINKERD2_VERSION}-${OS}" "${dstfile}"
   fi
   chmod +x "${dstfile}"

--- a/run.linkerd.io/public/install-edge
+++ b/run.linkerd.io/public/install-edge
@@ -139,7 +139,7 @@ fi
 (
   mkdir -p "${INSTALLROOT}/bin"
   # shellcheck disable=SC2031
-  if ! mv "${tmpdir}/${srcfile}" "${dstfile}"; then
+  if ! mv "${tmpdir}/${srcfile}" "${dstfile}" 2>/dev/null; then
     mv "${tmpdir}/linkerd2-cli-${LINKERD2_VERSION}-${OS}" "${dstfile}"
   fi
   chmod +x "${dstfile}"


### PR DESCRIPTION
Followup to #785

When we move the downloaded binary to its final location, we first try
with the file using the architecture suffix, and if that doesn't work we
fallback to not use that suffix. That works, but if the first try fails
we're showing an ugly error:
```
$ curl -sL https://run.linkerd.io/install-edge|sh
...
Download complete!
Validating checksum...
Checksum valid.
mv: cannot stat '/tmp/linkerd2.qY5SfJ/linkerd2-cli-edge-20.7.5-linux-amd64': No such
file or directory
Linkerd edge-20.7.5 was successfully installed 🎉
Add the linkerd CLI to your path with:
  export PATH=$PATH:/home/alpeb/.linkerd2/bin
  Now run:
    linkerd check --pre                     # validate that Linkerd can
    be installed
      linkerd install | kubectl apply -f -    # install the control
      plane into the 'linkerd' namespace
        linkerd check                           # validate everything
        worked!
          linkerd dashboard                       # launch the dashboard
          Looking for more? Visit https://linkerd.io/2/next-steps
```
This PR mutes that error. Tested on Linux and Cygwin.