### PR TITLE
Add steps to restart application proxies

### DIFF
--- a/linkerd.io/content/2/tasks/manually-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2/tasks/manually-rotating-control-plane-tls-credentials.md
@@ -235,6 +235,13 @@ LAST SEEN   TYPE     REASON          OBJECT                        MESSAGE
 9s          Normal   IssuerUpdated   deployment/linkerd-identity   Updated identity issuer
 ```
 
+Restart the proxy for all injected workloads in your cluster to ensure that
+their proxies pick up certificates issued by the new issuer:
+
+```bash
+kubectl -n emojivoto rollout restart deploy
+```
+
 Run the `check` command to make sure that everything is going as expected:
 
 ```bash


### PR DESCRIPTION
Update the trust anchor rotation doc to include steps to restart application proxies after the new issuer is deployed.

Fixes https://github.com/linkerd/linkerd2/issues/4287

Signed-off-by: Ivan Sim <ivan@buoyant.io>