### PR TITLE
Improve FAQ grammar

### DIFF
--- a/linkerd.io/content/2/faq/_index.md
+++ b/linkerd.io/content/2/faq/_index.md
@@ -149,7 +149,7 @@ completed in June 2019, and Linkerd passed with flying colors.
 
 Very fast. A [third party performance evaluation of Linkerd vs
 Istio](https://linkerd.io/2019/05/18/linkerd-benchmarks/) was performed in May
-of 2019, and showed that Linkerd significantly outperformed Istio.
+of 2019 and showed that Linkerd significantly outperformed Istio.
 
 ## How do I use Linkerd to route traffic between services?
 

--- a/linkerd.io/content/2/faq/_index.md
+++ b/linkerd.io/content/2/faq/_index.md
@@ -18,8 +18,8 @@ Linkerd is a [service
 mesh](https://blog.buoyant.io/2017/04/25/whats-a-service-mesh-and-why-do-i-need-one/).
 It adds observability, reliability, and security to cloud native applications
 without requiring code changes. For example, Linkerd can monitor and report
-per-service success rates and latencies, can automatically retry failed
-requests, and can encrypt and validate connections between services, all
+per-service success rates and latencies, automatically retry failed
+requests, and encrypt and validate connections between services, all
 without requiring any modification of the application itself.
 
 Linkerd works by inserting ultralight proxies (collectively, the "data plane")

--- a/linkerd.io/content/2/faq/_index.md
+++ b/linkerd.io/content/2/faq/_index.md
@@ -99,9 +99,9 @@ Just like this: Linkerd. Capital "L", lower-case everything else.
 
 See the [2.x
 maintainers](https://github.com/linkerd/linkerd2/blob/main/MAINTAINERS.md)
-file, and the [1.x
+[1.x
 maintainers](https://github.com/linkerd/linkerd/blob/main/MAINTAINERS.md)
-file.
+files.
 
 ## Is there an Enterprise edition, or a commercial edition?
 

--- a/linkerd.io/content/2/faq/_index.md
+++ b/linkerd.io/content/2/faq/_index.md
@@ -38,7 +38,7 @@ significantly [smaller and
 faster](https://linkerd.io/2019/05/18/linkerd-benchmarks) than Istio, though it
 currently has fewer features.
 
-2. Linkerd is built for security from the ground up, ranging from feature like
+2. Linkerd is built for security from the ground up, ranging from features like
 [on-by-default mTLS](https://linkerd.io/2/features/automatic-mtls/), a data
 plane that is [built in a memory-safe
 language](https://github.com/linkerd/linkerd2-proxy), and [regular security

--- a/linkerd.io/content/2/faq/_index.md
+++ b/linkerd.io/content/2/faq/_index.md
@@ -179,7 +179,7 @@ normal.
 
 If *new* proxies are deployed when the control plane is unreachable, these new
 proxies will not be able to operate. They will timeout all new requests until
-such time as they can reach the control plane.
+such a time as they can reach the control plane.
 
 ## How do I get involved?
 

--- a/linkerd.io/content/2/faq/_index.md
+++ b/linkerd.io/content/2/faq/_index.md
@@ -126,7 +126,7 @@ to power the production infrastructure of companies around the globe.
 ## Does Linkerd require Kubernetes?
 
 Linkerd 2.x currently requires Kubernetes. Linkerd 1.x can be installed on any
-platform, and supports Kubernetes, DC/OS, Mesos, Consul, and ZooKeeper-based
+platform and supports Kubernetes, DC/OS, Mesos, Consul, and ZooKeeper-based
 environments.
 
 ## Where's the Linkerd roadmap?

--- a/linkerd.io/content/2/faq/_index.md
+++ b/linkerd.io/content/2/faq/_index.md
@@ -159,7 +159,7 @@ or `service-name` if within the same namespace.
 
 ## How does Linkerd handle ingress?
 
-(2.x) For reasons of simplicity, Linkerd doesn't provide ingress itself, but
+(2.x) For reasons of simplicity, Linkerd doesn't provide ingress itself but
 instead [works in conjunction with the ingress
 controller](https://linkerd.io/2/features/ingress/) of your choice.
 

--- a/linkerd.io/content/2/faq/_index.md
+++ b/linkerd.io/content/2/faq/_index.md
@@ -137,7 +137,7 @@ sense of what is in store for the future.
 
 The public [Linkerd Meetup
 slides](https://docs.google.com/presentation/d/1qseWDYWD4KzYFhb4bcp8WuDPYFVwB8sYeNnjCsgDUOw/edit)
-also provides a coarse-grained roadmap.
+also provide a coarse-grained roadmap.
 
 ## How secure is Linkerd?
 

--- a/linkerd.io/content/2/faq/_index.md
+++ b/linkerd.io/content/2/faq/_index.md
@@ -165,7 +165,7 @@ controller](https://linkerd.io/2/features/ingress/) of your choice.
 
 ## What happens to Linkerd's proxies if the control plane is down?
 
-Linkerd's proxies do not integrate with Kubernetes directly, but rely on the
+Linkerd's proxies do not integrate with Kubernetes directly but rely on the
 control plane for service discovery information. The proxies are designed to
 continue operating even if they can't reach the control plane.
 

--- a/linkerd.io/content/2/faq/_index.md
+++ b/linkerd.io/content/2/faq/_index.md
@@ -118,7 +118,7 @@ lighter weight than 1.x, but currently only supports Kubernetes.
 
 ## Is Linkerd 1.x still supported?
 
-Yes, the 1.x branch of Linkerd is under active development, and continues
+Yes, the 1.x branch of Linkerd is under active development and continues
 to power the production infrastructure of companies around the globe.
 
 [The full Linkerd 1.x documentation is here](/1/).


### PR DESCRIPTION
Grammarly also objects to `third party` favoring `third-party`.

FWIW, this repository is inconsistent: https://github.com/linkerd/website/search?q=%22third+party%22&unscoped_q=%22third+party%22

Note: I make individual commits for individual changes because it makes dropping controversial changes much easier. I'm not attached to any individual change (or PR as a whole for that matter).