### PR TITLE
Remove fallback script for install-edge

### DIFF
--- a/run.linkerd.io/public/install-edge
+++ b/run.linkerd.io/public/install-edge
@@ -25,11 +25,7 @@ happyexit() {
 
 validate_checksum() {
   filename=$1
-  if ! SHA=$(curl -sfL "${url}.sha256"); then
-    srcfile="linkerd2-cli-${LINKERD2_VERSION}-${OS}"
-    url="https://github.com/linkerd/linkerd2/releases/download/${LINKERD2_VERSION}/${srcfile}"
-    SHA=$(curl -sfL "${url}.sha256")
-  fi
+  SHA=$(curl -sfL "${url}.sha256")
   echo ""
   echo "Validating checksum..."
 
@@ -121,13 +117,7 @@ fi
   cd "$tmpdir"
 
   echo "Downloading ${srcfile}..."
-  if ! curl -fLO "${url}"; then
-    # shellcheck disable=SC2030
-    srcfile="linkerd2-cli-${LINKERD2_VERSION}-${OS}"
-    url="https://github.com/linkerd/linkerd2/releases/download/${LINKERD2_VERSION}/${srcfile}"
-    echo "Fallback to ${url}"
-    curl -fLO "${url}"
-  fi
+  curl -fLO "${url}"
   echo "Download complete!"
 
   if ! validate_checksum "${srcfile}"; then
@@ -138,10 +128,7 @@ fi
 
 (
   mkdir -p "${INSTALLROOT}/bin"
-  # shellcheck disable=SC2031
-  if ! mv "${tmpdir}/${srcfile}" "${dstfile}" 2>/dev/null; then
-    mv "${tmpdir}/linkerd2-cli-${LINKERD2_VERSION}-${OS}" "${dstfile}"
-  fi
+  mv "${tmpdir}/${srcfile}" "${dstfile}"
   chmod +x "${dstfile}"
   rm -f "${INSTALLROOT}/bin/linkerd"
   ln -s "${dstfile}" "${INSTALLROOT}/bin/linkerd"


### PR DESCRIPTION
@cpretzer @alpeb 

As the [edge](https://github.com/linkerd/linkerd2/releases/tag/edge-20.8.1) release now already support multi-arch.
These fallback scripts are not necessary anymore, therefore we remove it.
We will do the same for the `install` script when the stable release is published.