### PR TITLE
Added an example to expose dashboard via Ambassador Ingress

### DIFF
--- a/linkerd.io/content/2/tasks/exposing-dashboard.md
+++ b/linkerd.io/content/2/tasks/exposing-dashboard.md
@@ -152,6 +152,27 @@ This exposes the dashboard at `dashboard.example.com` and protects it with basic
 auth using admin/admin. Take a look at the [Traefik][traefik-auth] documentation
 for details on how to change the username and password.
 
+## Ambassador
+
+Ambassador works by defining a [mapping
+](https://www.getambassador.io/docs/latest/topics/using/intro-mappings/) as an
+annotation on a service.
+
+The below annotation exposes the dashboard at `dashboard.example.com`.
+
+```yaml
+  annotations:
+    getambassador.io/config: |-
+      ---
+      apiVersion: ambassador/v1
+      kind: Mapping
+      name: linkerd-web-mapping
+      host: dashboard.example.com
+      prefix: /
+      host_rewrite: linkerd-web.linkerd.svc.cluster.local:8084
+      service: linkerd-web.linkerd.svc.cluster.local:8084
+```
+
 ## DNS Rebinding Protection
 
 To prevent [DNS-rebinding](https://en.wikipedia.org/wiki/DNS_rebinding) attacks,


### PR DESCRIPTION
Hey Maintainers,

I have added an example to expose the dashboard via [Ambassador](https://www.getambassador.io/) Ingress. I stumbled on this [issue](https://github.com/linkerd/linkerd2/issues/4929) and thought of documenting this.

Thanks,
Vikas