### PR TITLE
Update broken link for SMI traffic split api

### DIFF
--- a/linkerd.io/content/2/features/traffic-split.md
+++ b/linkerd.io/content/2/features/traffic-split.md
@@ -14,7 +14,7 @@ onto a newer version.
 
 Linkerd exposes this functionality via the
 [Service Mesh Interface](https://smi-spec.io/) (SMI)
-[TrafficSplit API](https://github.com/servicemeshinterface/smi-spec/blob/master/apis/traffic-split/traffic-split-wd.md).
+[TrafficSplit API](https://github.com/servicemeshinterface/smi-spec/blob/master/apis/traffic-split/traffic-split-WD.md).
 To use this feature, you create a Kubernetes resource as described in the
 TrafficSplit spec, and Linkerd takes care of the rest.
 


### PR DESCRIPTION
Updating the broken link for SMI's traffic split API. 

Signed-off-by: Cizer Pereira <mail@cizer.dev>