### PR TITLE
Add san field in cert generation docs

### DIFF
--- a/linkerd.io/content/2/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -47,7 +47,7 @@ pair and store it in a Kubernetes Secret in the namespace created above:
 
 ```bash
 step certificate create identity.linkerd.cluster.local ca.crt ca.key \
-  --profile root-ca --no-password --insecure &&
+  --profile root-ca --no-password --insecure --san identity.linkerd.cluster.local &&
   kubectl create secret tls \
    linkerd-trust-anchor \
    --cert=ca.crt \

--- a/linkerd.io/content/2/tasks/generate-certificates.md
+++ b/linkerd.io/content/2/tasks/generate-certificates.md
@@ -29,7 +29,7 @@ First generate the root certificate with its private key (using `step` version
 
 ```bash
 step certificate create identity.linkerd.cluster.local ca.crt ca.key \
---profile root-ca --no-password --insecure
+--profile root-ca --no-password --insecure --san identity.linkerd.cluster.local
 ```
 
 This generates the `ca.crt` and `ca.key` files. The `ca.crt` file is what you
@@ -49,7 +49,7 @@ Then generate the intermediate certificate and key pair that will be used to
 sign the Linkerd proxies' CSR.
 
 ```bash
-step certificate create identity.linkerd.cluster.local issuer.crt issuer.key --ca ca.crt --ca-key ca.key --profile intermediate-ca --not-after 8760h --no-password --insecure
+step certificate create identity.linkerd.cluster.local issuer.crt issuer.key --ca ca.crt --ca-key ca.key --profile intermediate-ca --not-after 8760h --no-password --insecure --san identity.linkerd.cluster.local
 ```
 
 This will generate the `issuer.crt` and `issuer.key` files.

--- a/linkerd.io/content/2/tasks/installing-multicluster.md
+++ b/linkerd.io/content/2/tasks/installing-multicluster.md
@@ -252,10 +252,10 @@ Now, you'll want to create a new trust anchor and issuer for the new cluster:
 
 ```bash
 step certificate create identity.linkerd.cluster.local root.crt root.key \
-   --profile root-ca --no-password --insecure
+   --profile root-ca --no-password --insecure --san identity.linkerd.cluster.local
 step certificate create identity.linkerd.cluster.local issuer.crt issuer.key \
   --profile intermediate-ca --not-after 8760h --no-password --insecure \
-  --ca root.crt --ca-key root.key
+  --ca root.crt --ca-key root.key --san identity.linkerd.cluster.local
 ```
 
 {{< note >}} We use the [step cli](https://smallstep.com/cli/) to generate

--- a/linkerd.io/content/2/tasks/manually-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2/tasks/manually-rotating-control-plane-tls-credentials.md
@@ -105,7 +105,7 @@ anchor rotation steps.
 First, generate a new trust anchor certificate and private key:
 
 ```bash
-step certificate create identity.linkerd.cluster.local ca-new.crt ca-new.key --profile root-ca --no-password --insecure
+step certificate create identity.linkerd.cluster.local ca-new.crt ca-new.key --profile root-ca --no-password --insecure --san identity.linkerd.cluster.local
 ```
 
 Note that we use `--no-password --insecure` to avoid encrypting these files
@@ -211,7 +211,7 @@ linkerd-identity-data-plane
 To rotate the issuer certificate and key pair, first generate a new pair:
 
 ```bash
-step certificate create identity.linkerd.cluster.local issuer-new.crt issuer-new.key --ca ca-new.crt --ca-key ca-new.key --profile intermediate-ca --not-after 8760h --no-password --insecure
+step certificate create identity.linkerd.cluster.local issuer-new.crt issuer-new.key --ca ca-new.crt --ca-key ca-new.key --profile intermediate-ca --not-after 8760h --no-password --insecure --san identity.linkerd.cluster.local
 ```
 
 Provided that the trust anchor has not expired and that, if recently rotated,

--- a/linkerd.io/content/2/tasks/multicluster.md
+++ b/linkerd.io/content/2/tasks/multicluster.md
@@ -71,7 +71,7 @@ generate the trust anchor with step, you can run:
 
 ```bash
 step certificate create identity.linkerd.cluster.local root.crt root.key \
-  --profile root-ca --no-password --insecure
+  --profile root-ca --no-password --insecure --san identity.linkerd.cluster.local
 ```
 
 This certificate will form the common base of trust between all your clusters.
@@ -90,7 +90,7 @@ using the trust anchor, run:
 ```bash
 step certificate create identity.linkerd.cluster.local issuer.crt issuer.key \
   --profile intermediate-ca --not-after 8760h --no-password --insecure \
-  --ca root.crt --ca-key root.key
+  --ca root.crt --ca-key root.key --san identity.linkerd.cluster.local
 ```
 
 An `identity` service in your cluster will use the certificate and key that you


### PR DESCRIPTION
This PR updates the docs to include san fields in the cert generation
commands. We already updated cert generation in the CLI to have these
fields, and this PR updates the Helm and other docs where certs are
generated manually.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>