### PR TITLE
fix empty TOC pages in features, tasks, and references

### DIFF
--- a/linkerd.io/content/2/features/_index.md
+++ b/linkerd.io/content/2/features/_index.md
@@ -5,4 +5,10 @@ weight = 3
   priority = 1.0
 +++
 
+Linkerd offers many features, outlined below. For our walkthroughs and guides,
+please see the [Linkerd task docs]({{% ref "/2/tasks" %}}). For a reference,
+see the [Linkerd reference docs]({{% ref "/2/reference" %}}).
+
+## Linkerd's features
+
 {{% sectiontoc "features" %}}

--- a/linkerd.io/content/2/features/fault-injection.md
+++ b/linkerd.io/content/2/features/fault-injection.md
@@ -1,6 +1,6 @@
 +++
 title = "Fault Injection"
-description = "Practice chaos engineering by injecting faults into services with Linkerd."
+description = "Linkerd provides mechanisms to programmatically inject failures into services."
 +++
 
 Fault injection is a form of chaos engineering where the error rate of a service

--- a/linkerd.io/content/2/features/multicluster.md
+++ b/linkerd.io/content/2/features/multicluster.md
@@ -1,6 +1,6 @@
 +++
 title = "Multi-cluster communication"
-description = "Linkerd connects applications running in different clusters"
+description = "Linkerd can transparently and securely connect services that are running in different clusters."
 aliases = [ "multicluster_support" ]
 +++
 

--- a/linkerd.io/content/2/features/proxy-injection.md
+++ b/linkerd.io/content/2/features/proxy-injection.md
@@ -11,7 +11,7 @@ Linkerd automatically adds the data plane proxy to pods when the
 workloads, such as deployments or pods. This is known as "proxy injection".
 
 See [Adding Your Service](/2/tasks/adding-your-service/) for a walkthrough of
-how to use this feature in practice. 
+how to use this feature in practice.
 
 {{< note >}}
 Proxy injection is also where proxy *configuration* happens. While it's rarely

--- a/linkerd.io/content/2/features/proxy-injection.md
+++ b/linkerd.io/content/2/features/proxy-injection.md
@@ -8,11 +8,17 @@ aliases = [
 
 Linkerd automatically adds the data plane proxy to pods when the
 `linkerd.io/inject: enabled` annotation is present on a namespace or any
-workloads such as deployments or pods, This is known as "proxy injection".
+workloads, such as deployments or pods. This is known as "proxy injection".
 
 See [Adding Your Service](/2/tasks/adding-your-service/) for a walkthrough of
-how to use this feature in practice. There is a full list of the configuration
-options available in [reference](/2/reference/proxy-configuration/).
+how to use this feature in practice. 
+
+{{< note >}}
+Proxy injection is also where proxy *configuration* happens. While it's rarely
+necessary, you can configure proxy settings by setting additional Kubernetes
+annotations at the resource level prior to injection. See the [full list of
+proxy configuration options](/2/reference/proxy-configuration/).
+{{< /note >}}
 
 ## Details
 

--- a/linkerd.io/content/2/features/retries-and-timeouts.md
+++ b/linkerd.io/content/2/features/retries-and-timeouts.md
@@ -1,6 +1,6 @@
 +++
 title = "Retries and Timeouts"
-description = "Linkerd can be configured to perform service-specific retries and timeouts."
+description = "Linkerd can perform service-specific retries and timeouts."
 weight = 3
 +++
 

--- a/linkerd.io/content/2/features/service-profiles.md
+++ b/linkerd.io/content/2/features/service-profiles.md
@@ -1,6 +1,6 @@
 +++
 title = "Service Profiles"
-description = "Linkerd supports defining service profiles that enable per-route metrics and features such as retries and timeouts."
+description = "Linkerd's service profiles enable per-route metrics as well as retries and timeouts."
 aliases = [
   "/2/service-profiles/"
 ]

--- a/linkerd.io/content/2/tasks/_index.md
+++ b/linkerd.io/content/2/tasks/_index.md
@@ -3,4 +3,10 @@ title = "Tasks"
 weight = 4
 +++
 
+As a complement to the [Linkerd feature docs]({{% ref "/2/features" %}}) and
+the [Linkerd reference docs]({{% ref "/2/reference" %}}), we've provided guides
+and examples of common tasks that you may need to perform when using Linkerd.
+
+## Common Linkerd tasks
+
 {{% sectiontoc "tasks" %}}

--- a/linkerd.io/content/2/tasks/adding-your-service.md
+++ b/linkerd.io/content/2/tasks/adding-your-service.md
@@ -1,32 +1,32 @@
 +++
-title = "Adding Your Service"
-description = "Add your service to the mesh by marking it for data plane proxy injection."
+title = "Adding Your Services to Linkerd"
+description = "Add your services to the mesh."
 aliases = [
   "/2/adding-your-service/",
   "/2/tasks/automating-injection/"
 ]
 +++
 
-In order for your services to take advantage of Linkerd, they need to have
-Linkerd's data plane proxy added to their pods. This is typically done by
-annotating the namespace, deployment, or pod with the `linkerd.io/inject:
-enabled` Kubernetes annotation, which will trigger *automatic proxy injection*
-when the resources are created. There is a full list of the configuration
-options available in [reference](/2/reference/proxy-configuration/). (See the
-[proxy injection page](/2/features/proxy-injection/) for more on how this
-works.)
+In order for your services to take advantage of Linkerd, they need to be "added
+to the mesh" by having Linkerd's data plane proxy injected into their pods.
+This is typically done by annotating the namespace, deployment, or pod with the
+`linkerd.io/inject: enabled` Kubernetes annotation. This annotation triggers
+*automatic proxy injection* when the resources are created.
+(See the [proxy injection
+page](/2/features/proxy-injection/) for more on how this works.)
 
 For convenience, Linkerd provides a [`linkerd
 inject`](/2/reference/cli/inject/) text transform command will add this
 annotation to a given Kubernetes manifest. Of course, these annotations can be
-set by other mechanisms.
+set by any other mechanism.
 
 Note that simply adding the annotation to a resource with pre-existing pods
-will not automatically inject those pods. You will need to update the pods
-(e.g. with `kubectl rollout restart` etc.) for them to be injected.  With a
-[rolling
-update](https://kubernetes.io/docs/tutorials/kubernetes-basics/update/update-intro/),
-the proxy often can be added to a live service without interruption.)
+will not automatically inject those pods. Because of the way that Kubernetes
+works, after setting the annotation, you will need to also need to recreate or
+update the pods (e.g. with `kubectl rollout restart` etc.) before proxy
+injection can happen. Often, a [rolling
+update](https://kubernetes.io/docs/tutorials/kubernetes-basics/update/update-intro/)
+can be performed to inject the proxy into a live service without interruption.)
 
 ## Example
 

--- a/linkerd.io/content/2/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -1,6 +1,6 @@
 +++
 title = "Automatically Rotating Control Plane TLS Credentials"
-description = "Use cert-manager to automatically rotate control plane TLS credentials"
+description = "Use cert-manager to automatically rotate control plane TLS credentials."
 aliases = [ "use_external_certs" ]
 +++
 

--- a/linkerd.io/content/2/tasks/automatically-rotating-webhook-tls-credentials.md
+++ b/linkerd.io/content/2/tasks/automatically-rotating-webhook-tls-credentials.md
@@ -1,6 +1,6 @@
 +++
 title = "Automatically Rotating Webhook TLS Credentials"
-description = "Use cert-manager to automatically rotate webhook TLS credentials"
+description = "Use cert-manager to automatically rotate webhook TLS credentials."
 +++
 
 The Linkerd control plane contains several components, called webhooks, which

--- a/linkerd.io/content/2/tasks/books.md
+++ b/linkerd.io/content/2/tasks/books.md
@@ -1,6 +1,6 @@
 +++
-title = "Demo: Books"
-description = "Try out some of Linkerd's features, such as per-route metrics with a demo application."
+title = "Debugging HTTP applications with per-route metrics"
+description = "Follow a long-form example of debugging a failing HTTP application using per-route metrics."
 +++
 
 This demo is of a Ruby application that helps you manage your bookshelf. It

--- a/linkerd.io/content/2/tasks/configuring-proxy-concurrency.md
+++ b/linkerd.io/content/2/tasks/configuring-proxy-concurrency.md
@@ -1,6 +1,6 @@
 +++
 title = "Configuring Proxy Concurrency"
-description = "How to correctly limit the Linkerd proxy's CPU usage"
+description = "Limit the Linkerd proxy's CPU usage."
 +++
 
 The Linkerd data plane's proxies are multithreaded, and are capable of running a

--- a/linkerd.io/content/2/tasks/configuring-retries.md
+++ b/linkerd.io/content/2/tasks/configuring-retries.md
@@ -1,6 +1,6 @@
 +++
 title = "Configuring Retries"
-description = "Configure Linkerd to retry outgoing requests on failure."
+description = "Configure Linkerd to automatically retry failing requests."
 +++
 
 In order for Linkerd to do automatic retries of failures, there are two

--- a/linkerd.io/content/2/tasks/configuring-timeouts.md
+++ b/linkerd.io/content/2/tasks/configuring-timeouts.md
@@ -1,6 +1,6 @@
 +++
 title = "Configuring Timeouts"
-description = "Configure how long Linkerd will wait before failing an outgoing request."
+description = "Configure Linkerd to automatically fail requests that take too long."
 +++
 
 To limit how long Linkerd will wait before failing an outgoing request to

--- a/linkerd.io/content/2/tasks/customize-install.md
+++ b/linkerd.io/content/2/tasks/customize-install.md
@@ -1,6 +1,6 @@
 +++
-title = "Customizing Installation"
-description = "Modify the Linkerd Installation"
+title = "Customizing Linkerd's Configuration with Kustomize"
+description = "Use Kustomize to modify Linkerd's configuration in a programmatic way."
 +++
 
 Instead of forking the Linkerd install and upgrade process,

--- a/linkerd.io/content/2/tasks/debugging-your-service.md
+++ b/linkerd.io/content/2/tasks/debugging-your-service.md
@@ -1,6 +1,6 @@
 +++
-title = "Debugging Your Service"
-description = "Linkerd makes it easy to debug a failing application. Check out how to do it yourself with Emojivoto."
+title = "Debugging gRPC applications with request tracing"
+description = "Follow a long-form example of debugging a failing gRPC application using live request tracing."
 aliases = [
   "/debugging-an-app/",
   "/2/debugging-an-app/"

--- a/linkerd.io/content/2/tasks/enabling-addons.md
+++ b/linkerd.io/content/2/tasks/enabling-addons.md
@@ -1,6 +1,6 @@
 +++
 title = "Enabling Add-ons"
-description = "Great Out-of-the-box experience with various components that integrate well with Linkerd"
+description = "Extend Linkerd's featureset with add-ons."
 aliases = [
   "/2/add-ons/",
 ]

--- a/linkerd.io/content/2/tasks/external-prometheus.md
+++ b/linkerd.io/content/2/tasks/external-prometheus.md
@@ -1,6 +1,6 @@
 +++
-title = "Bring your own Prometheus instance"
-description = "Make it easy to use existing Prometheus instance with Linkerd"
+title = "Bringing your own Prometheus"
+description = "Use an existing Prometheus instance with Linkerd."
 +++
 
 Even though Linkerd comes with its own Prometheus instance, there can be cases

--- a/linkerd.io/content/2/tasks/gitops.md
+++ b/linkerd.io/content/2/tasks/gitops.md
@@ -1,6 +1,6 @@
 +++
-title = "GitOps with Linkerd"
-description = "Use Argo CD to manage Linkerd installation and upgrade lifecycle"
+title = "Using GitOps with Linkerd with Argo CD"
+description = "Use Argo CD to manage Linkerd installation and upgrade lifecycle."
 +++
 
 GitOps is an approach to automate the management and delivery of your Kubernetes

--- a/linkerd.io/content/2/tasks/installing-multicluster.md
+++ b/linkerd.io/content/2/tasks/installing-multicluster.md
@@ -1,6 +1,6 @@
 +++
-title = "Installing Multicluster"
-description = "Install Linkerd on multiple clusters."
+title = "Installing Multi-cluster Components"
+description = "Allow Linkerd to manage cross-cluster communication."
 +++
 
 Multicluster support in Linkerd requires extra installation and configuration on

--- a/linkerd.io/content/2/tasks/manually-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2/tasks/manually-rotating-control-plane-tls-credentials.md
@@ -1,6 +1,6 @@
 +++
 title = "Manually Rotating Control Plane TLS Credentials"
-description = "Update Linkerd's TLS trust anchor and issuer certificate"
+description = "Update Linkerd's TLS trust anchor and issuer certificate."
 aliases = [ "rotating_identity_certificates" ]
 +++
 

--- a/linkerd.io/content/2/tasks/multicluster.md
+++ b/linkerd.io/content/2/tasks/multicluster.md
@@ -1,6 +1,6 @@
 +++
-title = "Getting started with Multicluster"
-description = "Get started with Linkerd managing traffic between multiple Kubernetes clusters"
+title = "Multi-cluster communication"
+description = "Allow Linkerd to manage cross-cluster communication."
 +++
 
 This guide will walk you through installing and configuring Linkerd so that two
@@ -24,7 +24,7 @@ At a high level, you will:
 
 ## Prerequisites
 
-- Two clusters, we will refer to them as `east` and `west` in this guide. Follow
+- Two clusters. We will refer to them as `east` and `west` in this guide. Follow
   along with the
   [blog post](/2020/02/25/multicluster-kubernetes-with-service-mirroring/) as
   you walk through this guide! The easiest way to do this for development is

--- a/linkerd.io/content/2/tasks/replacing_expired_certificates.md
+++ b/linkerd.io/content/2/tasks/replacing_expired_certificates.md
@@ -1,6 +1,6 @@
 +++
 title = "Replacing expired certificates"
-description = "Follow this workflow if any of your TLS certs have expired"
+description = "Follow this workflow if any of your TLS certs have expired."
 +++
 
 If any of your TLS certs are approaching expiry and you are not relying on an

--- a/linkerd.io/content/2/tasks/rotating_webhooks_certificates.md
+++ b/linkerd.io/content/2/tasks/rotating_webhooks_certificates.md
@@ -1,6 +1,6 @@
 +++
 title = "Rotating webhooks certificates"
-description = "Follow these steps to rotate your Linkerd webhooks certificates"
+description = "Follow these steps to rotate your Linkerd webhooks certificates."
 +++
 
 Linkerd uses the

--- a/linkerd.io/content/2/tasks/securing-your-cluster.md
+++ b/linkerd.io/content/2/tasks/securing-your-cluster.md
@@ -1,6 +1,6 @@
 +++
 title = "Securing Your Cluster"
-description = "RBAC best practices for your Linkerd installation."
+description = "Best practices for securing your Linkerd installation."
 +++
 
 Linkerd provides powerful introspection into your Kubernetes cluster and

--- a/linkerd.io/content/2/tasks/securing-your-service.md
+++ b/linkerd.io/content/2/tasks/securing-your-service.md
@@ -1,5 +1,5 @@
 +++
-title = "Securing Your Service"
+title = "Securing Your Application with mTLS"
 description = "Linkerd encrypts your service's traffic by default."
 +++
 

--- a/linkerd.io/content/2/tasks/upgrade-multicluster.md
+++ b/linkerd.io/content/2/tasks/upgrade-multicluster.md
@@ -1,5 +1,5 @@
 +++
-title = "Upgrading Multicluster"
+title = "Upgrading Multicluster in Linkerd 2.9"
 description = "Upgrading Multicluster to Linkerd 2.9."
 +++
 

--- a/linkerd.io/content/2/tasks/using-a-private-docker-repository.md
+++ b/linkerd.io/content/2/tasks/using-a-private-docker-repository.md
@@ -1,6 +1,6 @@
 +++
 title = "Using A Private Docker Repository"
-description = "Using Linkerd a Private Docker Repository."
+description = "Using Linkerd with a Private Docker Repository."
 +++
 
 In some cases, you will want to use a private docker repository to store the

--- a/linkerd.io/content/2/tasks/using-custom-domain.md
+++ b/linkerd.io/content/2/tasks/using-custom-domain.md
@@ -1,5 +1,5 @@
 +++
-title = "Using Custom Cluster Domain"
+title = "Using a Custom Cluster Domain"
 description = "Use Linkerd with a custom cluster domain."
 +++
 

--- a/linkerd.io/content/2/tasks/using-debug-endpoints.md
+++ b/linkerd.io/content/2/tasks/using-debug-endpoints.md
@@ -1,6 +1,6 @@
 +++
-title = "Using Debugging Endpoints"
-description = "Use debugging endpoints provided by the control plane components."
+title = "Control Plane Debug Endpoints"
+description = "Linkerd's control plane components provide debug endpoints."
 +++
 
 All of the control plane components (with the exception of Grafana) expose

--- a/linkerd.io/content/2/tasks/using-ingress.md
+++ b/linkerd.io/content/2/tasks/using-ingress.md
@@ -1,5 +1,5 @@
 +++
-title = "Using Ingress"
+title = "Ingress traffic"
 description = "Linkerd works alongside your ingress controller of choice."
 +++
 

--- a/linkerd.io/content/2/tasks/using-psp.md
+++ b/linkerd.io/content/2/tasks/using-psp.md
@@ -1,6 +1,6 @@
 +++
-title = "Using PSP"
-description = "Use Linkerd with a pod security policy enabled."
+title = "Linkerd and Pod Security Policies (PSP)"
+description = "Using Linkerd with a pod security policies enabled."
 +++
 
 The Linkerd control plane comes with its own minimally privileged

--- a/linkerd.io/layouts/shortcodes/sectiontoc.html
+++ b/linkerd.io/layouts/shortcodes/sectiontoc.html
@@ -1,16 +1,9 @@
-<div class="columns is-fullwidth toc">
-  {{ $currentPage := .Page }}
-  {{ $subPages := .Page.Pages }}
-  {{ range $index, $page := sort $subPages "Title" }}
-  {{ if (ne $page $currentPage) }}
-  <div class="columns is-fullwidth is-marginless">
-    <div class="column text-align-left is-marginless title">
-      <a href="{{ $page.Permalink }}">{{ $page.Title }}</a>
-    </div>
-    <div class="column text-align-left is-marginless description">
-      {{ $page.Description }}
-    </div>
-  </div>
-  {{ end }}
-  {{ end }}
-</div>
+{{ $currentPage := .Page }}
+{{ $subPages := .Page.Pages }}
+{{ range $index, $page := sort $subPages "Title" }}
+{{ if (ne $page $currentPage) }}
+
+[{{ $page.Title }}]({{ $page.Permalink }}). {{ $page.Description}}
+
+{{ end }}
+{{ end }}


### PR DESCRIPTION
- Put TOCs in blank pages in Tasks, Features, and References sections
- Update all titles and descriptions for clarity and grammar
- Minor content tweaks

Signed-off-by: William Morgan <william@buoyant.io>