### PR TITLE
run multicluster example website as nonroot

### DIFF
--- a/multicluster/base/frontend.yml
+++ b/multicluster/base/frontend.yml
@@ -69,6 +69,8 @@ spec:
             requests:
               cpu: 10m
               memory: 10Mi
+          securityContext:
+            runAsUser: 1337
         - image: buoyantio/slow_cooker:1.2.0
           name: internal
           env:
@@ -87,6 +89,8 @@ spec:
             requests:
               cpu: 10m
               memory: 10Mi
+          securityContext:
+            runAsUser: 1337
         - image: buoyantio/slow_cooker:1.2.0
           name: external
           env:
@@ -105,6 +109,8 @@ spec:
             requests:
               cpu: 10m
               memory: 10Mi
+          securityContext:
+            runAsUser: 1337
       volumes:
         - name: cfg
           configMap:

--- a/multicluster/base/patch.yml
+++ b/multicluster/base/patch.yml
@@ -9,6 +9,11 @@ spec:
     metadata:
       annotations:
         linkerd.io/inject: enabled
+    spec:
+      containers:
+        - name: podinfod
+          securityContext:
+            runAsUser: 1337
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
All containers are able to run as non-root. Therefore it's okay add the `securityContext` to the Kubernetes deployments.

<sub>Tobias Giese <tobias.giese@daimler.com>, Daimler TSS GmbH, [legal info/Impressum](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)</sub>