### PR TITLE
Update examples to use cert-manager v1

### DIFF
--- a/linkerd.io/content/2/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -107,6 +107,8 @@ spec:
     name: linkerd-trust-anchor
     kind: Issuer
   commonName: identity.linkerd.cluster.local
+  dnsNames:
+  - identity.linkerd.cluster.local
   isCA: true
   privateKey:
     algorithm: ECDSA

--- a/linkerd.io/content/2/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -76,7 +76,7 @@ references it:
 
 ```bash
 cat <<EOF | kubectl apply -f -
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: linkerd-trust-anchor
@@ -94,7 +94,7 @@ Issuer to generate the desired certificate:
 
 ```bash
 cat <<EOF | kubectl apply -f -
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: linkerd-identity-issuer
@@ -108,7 +108,8 @@ spec:
     kind: Issuer
   commonName: identity.linkerd.cluster.local
   isCA: true
-  keyAlgorithm: ecdsa
+  privateKey:
+    algorithm: ECDSA
   usages:
   - cert sign
   - crl sign
@@ -208,3 +209,8 @@ For Helm versions < v3, `--name` flag has to specifically be passed.
 In Helm v3, It has been deprecated, and is the first argument as
  specified above.
 {{< /note >}}
+
+See [Automatically Rotating Webhook TLS
+Credentials](/2/tasks/automatically-rotating-webhook-tls-credentials/) for how
+to do something similar for webhook TLS credentials.
+

--- a/linkerd.io/content/2/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -213,4 +213,3 @@ In Helm v3, It has been deprecated, and is the first argument as
 See [Automatically Rotating Webhook TLS
 Credentials](/2/tasks/automatically-rotating-webhook-tls-credentials/) for how
 to do something similar for webhook TLS credentials.
-

--- a/linkerd.io/content/2/tasks/automatically-rotating-webhook-tls-credentials.md
+++ b/linkerd.io/content/2/tasks/automatically-rotating-webhook-tls-credentials.md
@@ -88,6 +88,8 @@ spec:
     name: webhook-issuer
     kind: Issuer
   commonName: linkerd-proxy-injector.linkerd.svc
+  dnsNames:
+  - linkerd-proxy-injector.linkerd.svc
   isCA: false
   privateKey:
     algorithm: ECDSA
@@ -107,6 +109,8 @@ spec:
     name: webhook-issuer
     kind: Issuer
   commonName: linkerd-sp-validator.linkerd.svc
+  dnsNames:
+  - linkerd-sp-validator.linkerd.svc
   isCA: false
   privateKey:
     algorithm: ECDSA
@@ -126,6 +130,8 @@ spec:
     name: webhook-issuer
     kind: Issuer
   commonName: linkerd-tap.linkerd.svc
+  dnsNames:
+  - linkerd-tap.linkerd.svc
   isCA: false
   privateKey:
     algorithm: ECDSA

--- a/linkerd.io/content/2/tasks/automatically-rotating-webhook-tls-credentials.md
+++ b/linkerd.io/content/2/tasks/automatically-rotating-webhook-tls-credentials.md
@@ -57,7 +57,7 @@ references it:
 
 ```bash
 cat <<EOF | kubectl apply -f -
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: webhook-issuer
@@ -75,7 +75,7 @@ Issuer to generate the desired certificates:
 
 ```bash
 cat <<EOF | kubectl apply -f -
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: linkerd-proxy-injector
@@ -89,11 +89,12 @@ spec:
     kind: Issuer
   commonName: linkerd-proxy-injector.linkerd.svc
   isCA: false
-  keyAlgorithm: ecdsa
+  privateKey:
+    algorithm: ECDSA
   usages:
   - server auth
 ---
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: linkerd-sp-validator
@@ -107,11 +108,12 @@ spec:
     kind: Issuer
   commonName: linkerd-sp-validator.linkerd.svc
   isCA: false
-  keyAlgorithm: ecdsa
+  privateKey:
+    algorithm: ECDSA
   usages:
   - server auth
 ---
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: linkerd-tap
@@ -125,7 +127,8 @@ spec:
     kind: Issuer
   commonName: linkerd-tap.linkerd.svc
   isCA: false
-  keyAlgorithm: ecdsa
+  privateKey:
+    algorithm: ECDSA
   usages:
   - server auth
 EOF
@@ -192,3 +195,7 @@ For Helm versions < v3, `--name` flag has to specifically be passed.
 In Helm v3, It has been deprecated, and is the first argument as
  specified above.
 {{< /note >}}
+
+See [Automatically Rotating Control Plane TLS
+Credentials](/2/tasks/automatically-rotating-control-plane-tls-credentials/)
+for details on how to do something similar for control plane credentials.


### PR DESCRIPTION
Problem: Examples use older v1alpha3 syntax which has changed slightly in v1

Solution: Update examples to use cert-manager v1 which was released 4 months ago.

Fixes #881 

Signed-off-by: Keith Burdis <keith.burdis@gs.com>