### PR TITLE
Set subject of the linkerd-trust-anchor CA certificate to reflect its purpose

### DIFF
--- a/linkerd.io/content/2/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -57,13 +57,13 @@ Next, using the [`step`](https://smallstep.com/cli/) tool, create a signing key
 pair and store it in a Kubernetes Secret in the namespace created above:
 
 ```bash
-step certificate create identity.linkerd.cluster.local ca.crt ca.key \
+step certificate create linkerd-trust-anchor ca.crt ca.key \
   --profile root-ca --no-password --insecure &&
   kubectl create secret tls \
-   linkerd-trust-anchor \
-   --cert=ca.crt \
-   --key=ca.key \
-   --namespace=linkerd
+    linkerd-trust-anchor \
+    --cert=ca.crt \
+    --key=ca.key \
+    --namespace=linkerd
 ```
 
 For a longer-lived trust anchor certificate, pass the `--not-after` argument

--- a/linkerd.io/content/2/tasks/installing-multicluster.md
+++ b/linkerd.io/content/2/tasks/installing-multicluster.md
@@ -253,7 +253,7 @@ field with your tool of choice.
 Now, you'll want to create a new trust anchor and issuer for the new cluster:
 
 ```bash
-step certificate create identity.linkerd.cluster.local root.crt root.key \
+step certificate create linkerd-trust-anchor root.crt root.key \
    --profile root-ca --no-password --insecure
 step certificate create identity.linkerd.cluster.local issuer.crt issuer.key \
   --profile intermediate-ca --not-after 8760h --no-password --insecure \

--- a/linkerd.io/content/2/tasks/multicluster.md
+++ b/linkerd.io/content/2/tasks/multicluster.md
@@ -70,7 +70,7 @@ certificates. If you prefer `openssl` instead, feel free to use that! To
 generate the trust anchor with step, you can run:
 
 ```bash
-step certificate create identity.linkerd.cluster.local root.crt root.key \
+step certificate create linkerd-trust-anchor root.crt root.key \
   --profile root-ca --no-password --insecure
 ```
 


### PR DESCRIPTION
Problem: The subject of the linkerd-trust-anchor CA certificate in 'Automatically Rotating Control Plane TLS Credentials' and 'Multi-cluster communication' is currently `identity.linkerd.cluster.local` which is the same as intermediate CA certificate linkerd-identity-issuer and I found this confusing. 

Solution:  The subject should be changed to `linkerd-trust-anchor` to reflect its purpose.

Fixes: #883

Signed-off-by: Keith Burdis <keith.burdis@gs.com>