### PR TITLE
Set subject of the linkerd-trust-anchor CA certificate to reflect its purpose

### DIFF
--- a/linkerd.io/content/2/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -57,7 +57,7 @@ Next, using the [`step`](https://smallstep.com/cli/) tool, create a signing key
 pair and store it in a Kubernetes Secret in the namespace created above:
 
 ```bash
-step certificate create linkerd-trust-anchor ca.crt ca.key \
+step certificate create root.linkerd.cluster.local ca.crt ca.key \
   --profile root-ca --no-password --insecure &&
   kubectl create secret tls \
     linkerd-trust-anchor \

--- a/linkerd.io/content/2/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -57,13 +57,13 @@ Next, using the [`step`](https://smallstep.com/cli/) tool, create a signing key
 pair and store it in a Kubernetes Secret in the namespace created above:
 
 ```bash
-step certificate create identity.linkerd.cluster.local ca.crt ca.key \
+step certificate create linkerd-trust-anchor ca.crt ca.key \
   --profile root-ca --no-password --insecure &&
   kubectl create secret tls \
-   linkerd-trust-anchor \
-   --cert=ca.crt \
-   --key=ca.key \
-   --namespace=linkerd
+    linkerd-trust-anchor \
+    --cert=ca.crt \
+    --key=ca.key \
+    --namespace=linkerd
 ```
 
 For a longer-lived trust anchor certificate, pass the `--not-after` argument

--- a/linkerd.io/content/2/tasks/automatically-rotating-webhook-tls-credentials.md
+++ b/linkerd.io/content/2/tasks/automatically-rotating-webhook-tls-credentials.md
@@ -44,10 +44,10 @@ signing key pair which will be used to sign each of the webhook certificates:
 step certificate create webhook.linkerd.cluster.local ca.crt ca.key \
   --profile root-ca --no-password --insecure --san webhook.linkerd.cluster.local &&
   kubectl create secret tls \
-   webhook-issuer-tls \
-   --cert=ca.crt \
-   --key=ca.key \
-   --namespace=linkerd
+    webhook-issuer-tls \
+    --cert=ca.crt \
+    --key=ca.key \
+    --namespace=linkerd
 ```
 
 ## Create an Issuer referencing the secret

--- a/linkerd.io/content/2/tasks/generate-certificates.md
+++ b/linkerd.io/content/2/tasks/generate-certificates.md
@@ -28,7 +28,7 @@ First generate the root certificate with its private key (using `step` version
 0.10.1):
 
 ```bash
-step certificate create identity.linkerd.cluster.local ca.crt ca.key \
+step certificate create root.linkerd.cluster.local ca.crt ca.key \
 --profile root-ca --no-password --insecure
 ```
 
@@ -49,7 +49,9 @@ Then generate the intermediate certificate and key pair that will be used to
 sign the Linkerd proxies' CSR.
 
 ```bash
-step certificate create identity.linkerd.cluster.local issuer.crt issuer.key --ca ca.crt --ca-key ca.key --profile intermediate-ca --not-after 8760h --no-password --insecure
+step certificate create identity.linkerd.cluster.local issuer.crt issuer.key \
+--profile intermediate-ca --not-after 8760h --no-password --insecure \
+--ca ca.crt --ca-key ca.key 
 ```
 
 This will generate the `issuer.crt` and `issuer.key` files.

--- a/linkerd.io/content/2/tasks/generate-certificates.md
+++ b/linkerd.io/content/2/tasks/generate-certificates.md
@@ -51,7 +51,7 @@ sign the Linkerd proxies' CSR.
 ```bash
 step certificate create identity.linkerd.cluster.local issuer.crt issuer.key \
 --profile intermediate-ca --not-after 8760h --no-password --insecure \
---ca ca.crt --ca-key ca.key 
+--ca ca.crt --ca-key ca.key
 ```
 
 This will generate the `issuer.crt` and `issuer.key` files.

--- a/linkerd.io/content/2/tasks/gitops.md
+++ b/linkerd.io/content/2/tasks/gitops.md
@@ -267,7 +267,7 @@ the trust anchor certificate.
 Create a new mTLS trust anchor private key and certificate:
 
 ```sh
-step certificate create identity.linkerd.cluster.local sample-trust.crt sample-trust.key \
+step certificate create root.linkerd.cluster.local sample-trust.crt sample-trust.key \
   --profile root-ca \
   --no-password \
   --not-after 43800h \

--- a/linkerd.io/content/2/tasks/installing-multicluster.md
+++ b/linkerd.io/content/2/tasks/installing-multicluster.md
@@ -253,7 +253,7 @@ field with your tool of choice.
 Now, you'll want to create a new trust anchor and issuer for the new cluster:
 
 ```bash
-step certificate create identity.linkerd.cluster.local root.crt root.key \
+step certificate create linkerd-trust-anchor root.crt root.key \
    --profile root-ca --no-password --insecure
 step certificate create identity.linkerd.cluster.local issuer.crt issuer.key \
   --profile intermediate-ca --not-after 8760h --no-password --insecure \

--- a/linkerd.io/content/2/tasks/installing-multicluster.md
+++ b/linkerd.io/content/2/tasks/installing-multicluster.md
@@ -253,7 +253,7 @@ field with your tool of choice.
 Now, you'll want to create a new trust anchor and issuer for the new cluster:
 
 ```bash
-step certificate create linkerd-trust-anchor root.crt root.key \
+step certificate create root.linkerd.cluster.local root.crt root.key \
    --profile root-ca --no-password --insecure
 step certificate create identity.linkerd.cluster.local issuer.crt issuer.key \
   --profile intermediate-ca --not-after 8760h --no-password --insecure \

--- a/linkerd.io/content/2/tasks/manually-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2/tasks/manually-rotating-control-plane-tls-credentials.md
@@ -105,7 +105,7 @@ anchor rotation steps.
 First, generate a new trust anchor certificate and private key:
 
 ```bash
-step certificate create identity.linkerd.cluster.local ca-new.crt ca-new.key --profile root-ca --no-password --insecure
+step certificate create root.linkerd.cluster.local ca-new.crt ca-new.key --profile root-ca --no-password --insecure
 ```
 
 Note that we use `--no-password --insecure` to avoid encrypting these files
@@ -217,7 +217,9 @@ linkerd-identity-data-plane
 To rotate the issuer certificate and key pair, first generate a new pair:
 
 ```bash
-step certificate create identity.linkerd.cluster.local issuer-new.crt issuer-new.key --ca ca-new.crt --ca-key ca-new.key --profile intermediate-ca --not-after 8760h --no-password --insecure
+step certificate create identity.linkerd.cluster.local issuer-new.crt issuer-new.key \
+--profile intermediate-ca --not-after 8760h --no-password --insecure \
+--ca ca-new.crt --ca-key ca-new.key
 ```
 
 Provided that the trust anchor has not expired and that, if recently rotated,
@@ -226,7 +228,7 @@ the previous section) it is now safe to rotate the identity issuer certificate
 by using the `upgrade` command again:
 
 ```bash
-linkerd upgrade  --identity-issuer-certificate-file=./issuer-new.crt --identity-issuer-key-file=./issuer-new.key | kubectl apply -f -
+linkerd upgrade --identity-issuer-certificate-file=./issuer-new.crt --identity-issuer-key-file=./issuer-new.key | kubectl apply -f -
 ```
 
 At this point Linkerd's `identity` control plane service should detect the

--- a/linkerd.io/content/2/tasks/multicluster.md
+++ b/linkerd.io/content/2/tasks/multicluster.md
@@ -70,7 +70,7 @@ certificates. If you prefer `openssl` instead, feel free to use that! To
 generate the trust anchor with step, you can run:
 
 ```bash
-step certificate create linkerd-trust-anchor root.crt root.key \
+step certificate create root.linkerd.cluster.local root.crt root.key \
   --profile root-ca --no-password --insecure
 ```
 

--- a/linkerd.io/content/2/tasks/multicluster.md
+++ b/linkerd.io/content/2/tasks/multicluster.md
@@ -70,7 +70,7 @@ certificates. If you prefer `openssl` instead, feel free to use that! To
 generate the trust anchor with step, you can run:
 
 ```bash
-step certificate create identity.linkerd.cluster.local root.crt root.key \
+step certificate create linkerd-trust-anchor root.crt root.key \
   --profile root-ca --no-password --insecure
 ```
 


### PR DESCRIPTION
Problem: The subject of the linkerd-trust-anchor CA certificate in 'Automatically Rotating Control Plane TLS Credentials' and 'Multi-cluster communication' is currently identity.linkerd.cluster.local which is the same as intermediate CA certificate linkerd-identity-issuer and I found this confusing.

Solution:  The subject/issuer of the trust anchor CA should be changed to reflect its purpose.

Fixes: #883

Signed-off-by: Keith Burdis <keith.burdis@gs.com>