### PR TITLE
emojivoto: Update docker repo to docker.l5d.io

### DIFF
--- a/run.linkerd.io/public/emojivoto-daemonset.yml
+++ b/run.linkerd.io/public/emojivoto-daemonset.yml
@@ -93,7 +93,7 @@ spec:
           value: "8080"
         - name: PROM_PORT
           value: "8801"
-        image: buoyantio/emojivoto-emoji-svc:v11
+        image: docker.l5d.io/buoyantio/emojivoto-emoji-svc:v11
         name: emoji-svc
         ports:
         - containerPort: 8080
@@ -131,7 +131,7 @@ spec:
         env:
         - name: WEB_HOST
           value: web-svc.emojivoto:80
-        image: buoyantio/emojivoto-web:v11
+        image: docker.l5d.io/buoyantio/emojivoto-web:v11
         name: vote-bot
         resources:
           requests:
@@ -163,7 +163,7 @@ spec:
           value: "8080"
         - name: PROM_PORT
           value: "8801"
-        image: buoyantio/emojivoto-voting-svc:v11
+        image: docker.l5d.io/buoyantio/emojivoto-voting-svc:v11
         name: voting-svc
         ports:
         - containerPort: 8080
@@ -205,7 +205,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v11
+        image: docker.l5d.io/buoyantio/emojivoto-web:v11
         name: web-svc
         ports:
         - containerPort: 8080

--- a/run.linkerd.io/public/emojivoto-statefulset.yml
+++ b/run.linkerd.io/public/emojivoto-statefulset.yml
@@ -95,7 +95,7 @@ spec:
           value: "8080"
         - name: PROM_PORT
           value: "8801"
-        image: buoyantio/emojivoto-emoji-svc:v11
+        image: docker.l5d.io/buoyantio/emojivoto-emoji-svc:v11
         name: emoji-svc
         ports:
         - containerPort: 8080
@@ -135,7 +135,7 @@ spec:
         env:
         - name: WEB_HOST
           value: web-svc.emojivoto:80
-        image: buoyantio/emojivoto-web:v11
+        image: docker.l5d.io/buoyantio/emojivoto-web:v11
         name: vote-bot
         resources:
           requests:
@@ -169,7 +169,7 @@ spec:
           value: "8080"
         - name: PROM_PORT
           value: "8801"
-        image: buoyantio/emojivoto-voting-svc:v11
+        image: docker.l5d.io/buoyantio/emojivoto-voting-svc:v11
         name: voting-svc
         ports:
         - containerPort: 8080
@@ -213,7 +213,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v11
+        image: docker.l5d.io/buoyantio/emojivoto-web:v11
         name: web-svc
         ports:
         - containerPort: 8080

--- a/run.linkerd.io/public/emojivoto.yml
+++ b/run.linkerd.io/public/emojivoto.yml
@@ -94,7 +94,7 @@ spec:
           value: "8080"
         - name: PROM_PORT
           value: "8801"
-        image: buoyantio/emojivoto-emoji-svc:v11
+        image: docker.l5d.io/buoyantio/emojivoto-emoji-svc:v11
         name: emoji-svc
         ports:
         - containerPort: 8080
@@ -133,7 +133,7 @@ spec:
         env:
         - name: WEB_HOST
           value: web-svc.emojivoto:80
-        image: buoyantio/emojivoto-web:v11
+        image: docker.l5d.io/buoyantio/emojivoto-web:v11
         name: vote-bot
         resources:
           requests:
@@ -166,7 +166,7 @@ spec:
           value: "8080"
         - name: PROM_PORT
           value: "8801"
-        image: buoyantio/emojivoto-voting-svc:v11
+        image: docker.l5d.io/buoyantio/emojivoto-voting-svc:v11
         name: voting-svc
         ports:
         - containerPort: 8080
@@ -209,7 +209,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v11
+        image: docker.l5d.io/buoyantio/emojivoto-web:v11
         name: web-svc
         ports:
         - containerPort: 8080


### PR DESCRIPTION
I've setup scarf.sh to front our emojivoto images. This change updates
emojivoto's dmeo kubernetes manifests to refer to the new custom repo
location.