### PR TITLE
Add conduit.io to excluded htmltest domains

### DIFF
--- a/linkerd.io/.htmltest.yml
+++ b/linkerd.io/.htmltest.yml
@@ -1,6 +1,6 @@
 IgnoreURLs:
   - .*localhost.*
-  - https://conduit.io/*
+  - http(.?):\/\/(.*\.)?conduit.io\/*
   - https://expedia.com
   - https://www.expedia.com
   - https://ticketmaster.com

--- a/linkerd.io/.htmltest.yml
+++ b/linkerd.io/.htmltest.yml
@@ -1,5 +1,6 @@
 IgnoreURLs:
   - .*localhost.*
+  - https://conduit.io/*
   - https://expedia.com
   - https://www.expedia.com
   - https://ticketmaster.com


### PR DESCRIPTION
https://conduit.io is no longer serving linkerd related content and the htmltest link checks are failing.

Addiing conduit.io to the list of excluded domains is a temporary fix until I can clean up all the conduit.io links.

Signed-off-by: Charles Pretzer <charles@buoyant.io>