### PR TITLE
Update link in proxy blog

### DIFF
--- a/linkerd.io/content/blog/under-the-hood-of-linkerd-s-state-of-the-art-rust-proxy-linkerd2-proxy.md
+++ b/linkerd.io/content/blog/under-the-hood-of-linkerd-s-state-of-the-art-rust-proxy-linkerd2-proxy.md
@@ -287,8 +287,8 @@ _power of two choices_ (P2C) load balancing. In this approach, we instead make
 each load balancing decision by picking the less loaded of two randomly-chosen
 available endpoints. Although it may seem counterintuitive, this has been
 [mathematically
-proven](https://www.eecs.harvard.edu/\~michaelm/postscripts/mythesis.pdf) to be
-at least as effective at scale as always picking the least loaded, and it
+proven](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.57.4019&rep=rep1&type=pdf)
+to be at least as effective at scale as always picking the least loaded, and it
 [avoids the problem of multiple load balancers all sending traffic to the least
 loaded replica, overloading
 it](https://www.nginx.com/blog/nginx-power-of-two-choices-load-balancing-algorithm/).


### PR DESCRIPTION
A link appears to have been permanently removed, so I replaced it with one from Google Scholar

Signed-off-by: Charles Pretzer <charles@buoyant.io>