### PR TITLE
htmlEscape the FAQ text fields for the linked JSON schema

### DIFF
--- a/linkerd.io/themes/buoyant/layouts/partials/schema.html
+++ b/linkerd.io/themes/buoyant/layouts/partials/schema.html
@@ -73,10 +73,10 @@
         {{ range .Params.faqs }}
           {
             "@type": "Question",
-            "name": "{{.question}}",
+            "name": "{{ htmlEscape .question }}",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "{{.answer_schema}}"
+              "text": "{{ htmlEscape .answer_schema }}"
             }
           },
         {{ end }}


### PR DESCRIPTION
The FAQ fields in the linked JSON (`<script type="application/ld+json">`) schema had non-compliant JSON, so this change uses hugo's `htmlEscape` to render the characters in a JSON compliant format

Signed-off-by: Charles Pretzer <charles@buoyant.io>