### PR TITLE
Remove references to logs command

### DIFF
--- a/linkerd.io/content/2/tasks/troubleshooting.md
+++ b/linkerd.io/content/2/tasks/troubleshooting.md
@@ -556,7 +556,7 @@ linkerd-controller-7bb8ff5967-zg265   4/4       Running   0          40m
 Check the controller's logs with:
 
 ```bash
-linkerd logs --control-plane-component controller
+kubectl logs -n linkerd linkerd-controller-7bb8ff5967-zg265 public-api
 ```
 
 ### √ can initialize the client {#l5d-existence-client}
@@ -922,7 +922,7 @@ Example failure:
 Check the logs on the control-plane's public API:
 
 ```bash
-linkerd logs --control-plane-component controller --container public-api
+kubectl logs -n linkerd linkerd-controller-b8c4c48c8-pflc9 public-api
 ```
 
 ### √ [kubernetes] control plane can talk to Kubernetes {#l5d-api-k8s}
@@ -937,7 +937,7 @@ Example failure:
 Check the logs on the control-plane's public API:
 
 ```bash
-linkerd logs --control-plane-component controller --container public-api
+kubectl logs -n linkerd linkerd-controller-b8c4c48c8-pflc9 public-api
 ```
 
 ### √ [prometheus] control plane can talk to Prometheus {#l5d-api-prom}
@@ -963,13 +963,13 @@ kubectl -n linkerd get all | grep prometheus
 Check the Prometheus logs:
 
 ```bash
-linkerd logs --control-plane-component prometheus
+kubectl logs -n linkerd linkerd-prometheus-74d66f86f6-6t6dh prometheus
 ```
 
 Check the logs on the control-plane's public API:
 
 ```bash
-linkerd logs --control-plane-component controller --container public-api
+kubectl logs -n linkerd linkerd-controller-b8c4c48c8-pflc9 public-api
 ```
 
 ### √ tap api service is running {#l5d-tap-api}

--- a/linkerd.io/data/cli.yaml
+++ b/linkerd.io/data/cli.yaml
@@ -992,55 +992,6 @@ CLIReference:
   SeeAlso: null
   Synopsis: |
     Output Kubernetes configs to install Linkerd Service Profiles
-- Description: Tail logs from containers in the Linkerd control plane.
-  Example: |2
-      # Tail logs from all containers in the prometheus control plane component
-      linkerd logs --control-plane-component prometheus
-
-      # Tail logs from the linkerd-proxy container in the grafana control plane component
-      linkerd logs --control-plane-component grafana --container linkerd-proxy
-
-      # Tail logs from the linkerd-proxy container in the controller component beginning with the last two lines
-      linkerd logs --control-plane-component controller --container linkerd-proxy --tail 2
-
-      # Tail logs from the linkerd-proxy container in the controller component showing timestamps for each line
-      linkerd logs --control-plane-component controller --container linkerd-proxy --timestamps
-  InheritedOptions: null
-  Name: logs
-  Options:
-  - DefaultValue: ""
-    Name: container
-    Shorthand: c
-    Usage: |
-      Tail logs from the specified container. Options are 'public-api', 'destination', 'tap', 'prometheus', 'grafana' or 'linkerd-proxy'
-  - DefaultValue: ""
-    Name: control-plane-component
-    Shorthand: ""
-    Usage: |
-      Tail logs from the specified control plane component. Default value (empty string) causes this command to tail logs from all resources marked with the 'linkerd.io/control-plane-component' label selector
-  - DefaultValue: ""
-    Name: help
-    Shorthand: h
-    Usage: help for logs
-  - DefaultValue: ""
-    Name: no-color
-    Shorthand: "n"
-    Usage: Disable colorized output
-  - DefaultValue: ""
-    Name: since
-    Shorthand: s
-    Usage: Duration of how far back logs should be retrieved
-  - DefaultValue: ""
-    Name: tail
-    Shorthand: ""
-    Usage: |
-      Last number of log lines to show for a given container. -1 does not show previous log lines
-  - DefaultValue: ""
-    Name: timestamps
-    Shorthand: t
-    Usage: Print timestamps for each given log line
-  SeeAlso: null
-  Synopsis: Tail logs from containers in the Linkerd control plane
 - Description: |-
     Fetch metrics directly from Linkerd proxies.
 


### PR DESCRIPTION
The `logs` command was removed in linkerd/linkerd2#5203.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>