### PR TITLE
Fix typo of yq arguments ("Manually Rotating Control Plane TLS Credentials" page)

### DIFF
--- a/linkerd.io/content/2/tasks/manually-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2/tasks/manually-rotating-control-plane-tls-credentials.md
@@ -127,7 +127,7 @@ kubectl -n linkerd get cm linkerd-config -o=jsonpath='{.data.global}' \
 
 # For Linkerd >= 2.9.0:
 kubectl -n linkerd get cm linkerd-config -o=jsonpath='{.data.values}' \
-  | yq r - global.identityTrustAnchorsPEM > original-trust.crt
+  | yq -r .global.identityTrustAnchorsPEM > original-trust.crt
 
 step certificate bundle ca-new.crt original-trust.crt bundle.crt
 rm original-trust.crt


### PR DESCRIPTION
Signed-off-by: Takumi Sue <u630868b@alumni.osaka-u.ac.jp>