### PR TITLE
Disable CheckExternal link checking

### DIFF
--- a/linkerd.io/.htmltest.yml
+++ b/linkerd.io/.htmltest.yml
@@ -1,3 +1,5 @@
+# IgnoreURLs is not necessary because we disable CheckExternal.  However, let's
+# keep this list in case we enable CheckExternal in the future.
 IgnoreURLs:
   - .*localhost.*
   - http(.?):\/\/(.*\.)?conduit.io\/*
@@ -28,3 +30,4 @@ HTTPConcurrencyLimit: 4
 ExternalTimeout: 25
 HTTPHeaders: {"Accept":"*/*","Range":"bytes=0-","User-Agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:84.0) Gecko/20100101 Firefox/84.0"}
 CheckInternalHash: false
+CheckExternal: false


### PR DESCRIPTION
External link checks are extremely flaky.

Signed-off-by: Alex Leong <alex@buoyant.io>