### PR TITLE
[2.10] Update CLI commands that were moved to Viz

### DIFF
--- a/linkerd.io/content/2/features/dashboard.md
+++ b/linkerd.io/content/2/features/dashboard.md
@@ -6,13 +6,19 @@ description = "Linkerd provides a web dashboard, as well as pre-configured Grafa
 In addition to its [command-line interface](/2/cli/), Linkerd provides a web
 dashboard and pre-configured Grafana dashboards.
 
+To access this functionality, you need to have installed the Viz extension:
+
+```bash
+linkerd viz install | kubectl apply -f -
+```
+
 ## Linkerd Dashboard
 
 The Linkerd dashboard provides a high level view of what is happening with your
 services in real time. It can be used to view the "golden" metrics (success
 rate, requests/second and latency), visualize service dependencies and
 understand the health of specific service routes. One way to pull it up is by
-running `linkerd dashboard` from the command line.
+running `linkerd viz dashboard` from the command line.
 
 {{< fig src="/images/architecture/stat.png" title="Top Line Metrics">}}
 

--- a/linkerd.io/content/2/tasks/adding-your-service.md
+++ b/linkerd.io/content/2/tasks/adding-your-service.md
@@ -45,10 +45,11 @@ in the correct places, then applies it to the cluster.
 
 Once your services have been added to the mesh, you will be able to query
 Linkerd for traffic metrics about them, e.g. by using [`linkerd
-stat`](/2/reference/cli/stat/):
+stat`](/2/reference/cli/stat/) (make sure you have installed the Viz extension
+beforehand):
 
 ```bash
-linkerd stat deployments -n MYNAMESPACE
+linkerd viz stat deployments -n MYNAMESPACE
 ```
 
 Note that it may take several seconds for these metrics to appear once the data

--- a/linkerd.io/content/2/tasks/adding-your-service.md
+++ b/linkerd.io/content/2/tasks/adding-your-service.md
@@ -45,7 +45,7 @@ in the correct places, then applies it to the cluster.
 
 Once your services have been added to the mesh, you will be able to query
 Linkerd for traffic metrics about them, e.g. by using [`linkerd
-stat`](/2/reference/cli/stat/) (make sure you have installed the Viz extension
+viz stat`](/2/reference/cli/stat/) (make sure you have installed the Viz extension
 beforehand):
 
 ```bash

--- a/linkerd.io/content/2/tasks/books.md
+++ b/linkerd.io/content/2/tasks/books.md
@@ -273,7 +273,7 @@ As you can see:
 - `rt_route` contains the name of the route
 
 These metrics are part of the [`linkerd viz routes`](/2/reference/cli/routes/)
-command instead of [`linkerd biz stat`](/2/reference/cli/stat/). To see the
+command instead of [`linkerd viz stat`](/2/reference/cli/stat/). To see the
 metrics that have accumulated so far, run:
 
 ```bash

--- a/linkerd.io/content/2/tasks/books.md
+++ b/linkerd.io/content/2/tasks/books.md
@@ -23,9 +23,9 @@ topology looks like this:
 
 ## Prerequisites
 
-To use this guide, you'll need to have Linkerd installed on your cluster.
-Follow the [Installing Linkerd Guide](/2/tasks/install/) if you haven't already
-done this.
+To use this guide, you'll need to have Linkerd and its Viz extension installed
+on your cluster.  Follow the [Installing Linkerd Guide](/2/tasks/install/) if
+you haven't already done this.
 
 ## Install the app
 
@@ -105,7 +105,7 @@ Let's use Linkerd to discover the root cause of this app's failures. To check
 out the Linkerd dashboard, run:
 
 ```bash
-linkerd dashboard &
+linkerd viz dashboard &
 ```
 
 {{< fig src="/images/books/dashboard.png" title="Dashboard" >}}
@@ -251,12 +251,12 @@ curl -sL https://run.linkerd.io/booksapp/books.swagger \
   | kubectl -n booksapp apply -f -
 ```
 
-Verifying that this all works is easy when you use `linkerd tap`. Each live
+Verifying that this all works is easy when you use `linkerd viz tap`. Each live
 request will show up with what `:authority` or `Host` header is being seen as
 well as the `:path` and `rt_route` being used. Run:
 
 ```bash
-linkerd -n booksapp tap deploy/webapp -o wide | grep req
+linkerd viz tap -n booksapp deploy/webapp -o wide | grep req
 ```
 
 This will watch all the live requests flowing through `webapp` and look
@@ -272,12 +272,12 @@ As you can see:
 - `:path` correctly matches
 - `rt_route` contains the name of the route
 
-These metrics are part of the [`linkerd routes`](/2/reference/cli/routes/)
-command instead of [`linkerd stat`](/2/reference/cli/stat/). To see the metrics
-that have accumulated so far, run:
+These metrics are part of the [`linkerd viz routes`](/2/reference/cli/routes/)
+command instead of [`linkerd biz stat`](/2/reference/cli/stat/). To see the
+metrics that have accumulated so far, run:
 
 ```bash
-linkerd -n booksapp routes svc/webapp
+linkerd viz -n booksapp routes svc/webapp
 ```
 
 This will output a table of all the routes observed and their golden metrics.
@@ -288,7 +288,7 @@ Profiles can be used to observe *outgoing* requests as well as *incoming*
 requests. To do that, run:
 
 ```bash
-linkerd -n booksapp routes deploy/webapp --to svc/books
+linkerd viz -n booksapp routes deploy/webapp --to svc/books
 ```
 
 This will show all requests and routes that originate in the `webapp` deployment
@@ -317,7 +317,7 @@ In this application, the success rate of requests from the `books` deployment to
 the `authors` service is poor. To see these metrics, run:
 
 ```bash
-linkerd -n booksapp routes deploy/books --to svc/authors
+linkerd viz -n booksapp routes deploy/books --to svc/authors
 ```
 
 The output should look like:
@@ -360,7 +360,7 @@ this route automatically. We see a nearly immediate improvement in success rate
 by running:
 
 ```bash
-linkerd -n booksapp routes deploy/books --to svc/authors -o wide
+linkerd viz -n booksapp routes deploy/books --to svc/authors -o wide
 ```
 
 This should look like:
@@ -396,7 +396,7 @@ To get started, let's take a look at the current latency for requests from
 `webapp` to the `books` service:
 
 ```bash
-linkerd -n booksapp routes deploy/webapp --to svc/books
+linkerd viz -n booksapp routes deploy/webapp --to svc/books
 ```
 
 This should look something like:
@@ -441,7 +441,7 @@ time a REST client would wait for a response.
 Run `routes` to see what has changed:
 
 ```bash
-linkerd -n booksapp routes deploy/webapp --to svc/books -o wide
+linkerd viz -n booksapp routes deploy/webapp --to svc/books -o wide
 ```
 
 With timeouts happening now, the metrics will change:

--- a/linkerd.io/content/2/tasks/canary-release.md
+++ b/linkerd.io/content/2/tasks/canary-release.md
@@ -23,7 +23,8 @@ allowing for fully-automated, metrics-aware canary deployments.
 
 ## Prerequisites
 
-- To use this guide, you'll need to have Linkerd installed on your cluster.
+- To use this guide, you'll need to have Linkerd installed on your cluster,
+  along with its Viz extension.
   Follow the [Installing Linkerd Guide](/2/tasks/install/) if you haven't
   already done this.
 - The installation of Flagger depends on `kubectl` 1.14 or newer.
@@ -251,12 +252,13 @@ metrics show the backends receiving traffic in real time and measure the success
 rate, latencies and throughput. From the CLI, you can watch this by running:
 
 ```bash
-watch linkerd -n test stat deploy --from deploy/load
+watch linkerd viz -n test stat deploy --from deploy/load
 ```
 
 For something a little more visual, you can use the dashboard. Start it by
-running `linkerd dashboard` and then look at the detail page for the [podinfo
-traffic split](http://localhost:50750/namespaces/test/trafficsplits/podinfo).
+running `linkerd viz dashboard` and then look at the detail page for the
+[podinfo traffic
+split](http://localhost:50750/namespaces/test/trafficsplits/podinfo).
 
 {{< fig src="/images/canary/traffic-split.png"
         title="Dashboard" >}}

--- a/linkerd.io/content/2/tasks/exporting-metrics.md
+++ b/linkerd.io/content/2/tasks/exporting-metrics.md
@@ -13,7 +13,7 @@ By design, Linkerd only keeps metrics data for a short, fixed window of time
 you, you will probably want to export it into a full-fledged metrics store.
 
 Internally, Linkerd stores its metrics in a Prometheus instance that runs as
-part of the control plane.  There are several basic approaches to exporting
+part of the Viz extension.  There are several basic approaches to exporting
 metrics data from Linkerd:
 
 - [Federating data to your own Prometheus cluster](#federation)
@@ -27,9 +27,9 @@ If you are using Prometheus as your own metrics store, we recommend taking
 advantage of Prometheus's *federation* API, which is designed exactly for the
 use case of copying data from one Prometheus to another.
 
-Simply add the following item to your `scrape_configs` in your Prometheus
-config file (replace `{{.Namespace}}` with the namespace where Linkerd is
-running):
+Simply add the following item to your `scrape_configs` in your Prometheus config
+file (replace `{{.Namespace}}` with the namespace where the Linkerd Viz
+extension is running):
 
 ```yaml
 - job_name: 'linkerd'

--- a/linkerd.io/content/2/tasks/exposing-dashboard.md
+++ b/linkerd.io/content/2/tasks/exposing-dashboard.md
@@ -3,8 +3,9 @@ title = "Exposing the Dashboard"
 description = "Make it easy for others to access Linkerd and Grafana dashboards without the CLI."
 +++
 
-Instead of using `linkerd dashboard` every time you'd like to see what's going
-on, you can expose the dashboard via an ingress. This will also expose Grafana.
+Instead of using `linkerd viz dashboard` every time you'd like to see what's
+going on, you can expose the dashboard via an ingress. This will also expose
+Grafana.
 
 {{< pagetoc >}}
 
@@ -20,7 +21,7 @@ kind: Secret
 type: Opaque
 metadata:
   name: web-ingress-auth
-  namespace: linkerd
+  namespace: linkerd-viz
 data:
   auth: YWRtaW46JGFwcjEkbjdDdTZnSGwkRTQ3b2dmN0NPOE5SWWpFakJPa1dNLgoK
 ---
@@ -28,7 +29,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: web-ingress
-  namespace: linkerd
+  namespace: linkerd-viz
   annotations:
     kubernetes.io/ingress.class: 'nginx'
     nginx.ingress.kubernetes.io/upstream-vhost: $service_name.$namespace.svc.cluster.local:8084
@@ -94,7 +95,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: linkerd-web
-  namespace: linkerd
+  namespace: linkerd-viz
   annotations:
     kubernetes.io/ingress.class: 'nginx'
     nginx.ingress.kubernetes.io/upstream-vhost: $service_name.$namespace.svc.cluster.local:8084
@@ -124,7 +125,7 @@ kind: Secret
 type: Opaque
 metadata:
   name: web-ingress-auth
-  namespace: linkerd
+  namespace: linkerd-viz
 data:
   auth: YWRtaW46JGFwcjEkbjdDdTZnSGwkRTQ3b2dmN0NPOE5SWWpFakJPa1dNLgoK
 ---
@@ -132,7 +133,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: web-ingress
-  namespace: linkerd
+  namespace: linkerd-viz
   annotations:
     kubernetes.io/ingress.class: 'traefik'
     ingress.kubernetes.io/custom-request-headers: l5d-dst-override:linkerd-web.linkerd.svc.cluster.local:8084
@@ -169,8 +170,8 @@ The below annotation exposes the dashboard at `dashboard.example.com`.
       name: linkerd-web-mapping
       host: dashboard.example.com
       prefix: /
-      host_rewrite: linkerd-web.linkerd.svc.cluster.local:8084
-      service: linkerd-web.linkerd.svc.cluster.local:8084
+      host_rewrite: linkerd-web.linkerd-viz.svc.cluster.local:8084
+      service: linkerd-web.linkerd-viz.svc.cluster.local:8084
 ```
 
 ## DNS Rebinding Protection
@@ -212,7 +213,7 @@ spec:
         - name: web
           args:
             - -api-addr=linkerd-controller-api.linkerd.svc.cluster.local:8085
-            - -grafana-addr=linkerd-grafana.linkerd.svc.cluster.local:3000
+            - -grafana-addr=linkerd-grafana.linkerd-viz.svc.cluster.local:3000
             - -controller-namespace=linkerd
             - -log-level=info
             - -enforced-host=^dashboard\.example\.com$

--- a/linkerd.io/content/2/tasks/exposing-dashboard.md
+++ b/linkerd.io/content/2/tasks/exposing-dashboard.md
@@ -170,7 +170,7 @@ The below annotation exposes the dashboard at `dashboard.example.com`.
       name: linkerd-web-mapping
       host: dashboard.example.com
       prefix: /
-      host_rewrite: linkerd-web.linkerd-viz.svc.cluster.local:8084
+      host_rewrite: web.linkerd-viz.svc.cluster.local:8084
       service: linkerd-web.linkerd-viz.svc.cluster.local:8084
 ```
 

--- a/linkerd.io/content/2/tasks/exposing-dashboard.md
+++ b/linkerd.io/content/2/tasks/exposing-dashboard.md
@@ -213,7 +213,7 @@ spec:
         - name: web
           args:
             - -api-addr=linkerd-controller-api.linkerd.svc.cluster.local:8085
-            - -grafana-addr=linkerd-grafana.linkerd-viz.svc.cluster.local:3000
+            - -grafana-addr=grafana.linkerd-viz.svc.cluster.local:3000
             - -controller-namespace=linkerd
             - -log-level=info
             - -enforced-host=^dashboard\.example\.com$

--- a/linkerd.io/content/2/tasks/fault-injection.md
+++ b/linkerd.io/content/2/tasks/fault-injection.md
@@ -25,9 +25,9 @@ engineering lifestyle, fault injection could even be used in production.
 
 ## Prerequisites
 
-To use this guide, you'll need to have Linkerd installed on your cluster.
-Follow the [Installing Linkerd Guide](/2/tasks/install/) if you haven't already
-done this.
+To use this guide, you'll need to have Linkerd installed on your cluster, along
+with its Viz extension. Follow the [Installing Linkerd Guide](/2/tasks/install/)
+if you haven't already done this.
 
 ## Setup the service
 
@@ -54,7 +54,7 @@ After a little while, the stats will show 100% success rate. You can verify this
 by running:
 
 ```bash
-linkerd -n booksapp stat deploy
+linkerd viz -n booksapp stat deploy
 ```
 
 The output will end up looking at little like:
@@ -166,7 +166,7 @@ what this looks like by running `stat` and filtering explicitly to just the
 requests from `webapp`:
 
 ```bash
-linkerd -n booksapp routes deploy/webapp --to service/books
+linkerd viz -n booksapp routes deploy/webapp --to service/books
 ```
 
 Unlike the previous `stat` command which only looks at the requests received by

--- a/linkerd.io/content/2/tasks/getting-per-route-metrics.md
+++ b/linkerd.io/content/2/tasks/getting-per-route-metrics.md
@@ -11,10 +11,10 @@ associate a specific request to a specific route.
 For a tutorial that shows this functionality off, check out the
 [books demo](/2/tasks/books/#service-profiles).
 
-You can view per-route metrics in the CLI by running `linkerd routes`:
+You can view per-route metrics in the CLI by running `linkerd viz routes`:
 
 ```bash
-$ linkerd routes svc/webapp
+$ linkerd viz routes svc/webapp
 ROUTE                       SERVICE   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
 GET /                        webapp   100.00%   0.6rps          25ms          30ms          30ms
 GET /authors/{id}            webapp   100.00%   0.6rps          22ms          29ms          30ms
@@ -34,7 +34,7 @@ specified in your service profile will end up there.
 It is also possible to look the metrics up by other resource types, such as:
 
 ```bash
-$ linkerd routes deploy/webapp
+$ linkerd viz routes deploy/webapp
 ROUTE                          SERVICE   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
 [DEFAULT]                   kubernetes     0.00%   0.0rps           0ms           0ms           0ms
 GET /                           webapp   100.00%   0.5rps          27ms          38ms          40ms
@@ -53,7 +53,7 @@ Then, it is possible to filter all the way down to requests going from a
 specific resource to other services:
 
 ```bash
-$ linkerd routes deploy/webapp --to svc/books
+$ linkerd viz routes deploy/webapp --to svc/books
 ROUTE                     SERVICE   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
 DELETE /books/{id}.json     books   100.00%   0.5rps          18ms          29ms          30ms
 GET /books.json             books   100.00%   1.1rps           7ms          12ms          18ms
@@ -66,11 +66,11 @@ PUT /books/{id}.json        books    41.98%   1.4rps          73ms          97ms
 ## Troubleshooting
 
 If you're not seeing any metrics, there are two likely culprits. In both cases,
-`linkerd tap` can be used to understand the problem. For the resource that
+`linkerd viz tap` can be used to understand the problem. For the resource that
 the service points to, run:
 
 ```bash
-linkerd tap deploy/webapp -o wide | grep req
+linkerd viz tap deploy/webapp -o wide | grep req
 ```
 
 A sample output is:

--- a/linkerd.io/content/2/tasks/securing-your-cluster.md
+++ b/linkerd.io/content/2/tasks/securing-your-cluster.md
@@ -9,13 +9,13 @@ best practices to enable this introspection in a secure way.
 
 ## Tap
 
-The default Linkerd installation includes Tap support. This feature is available
+Linkerd's Viz extension  includes Tap support. This feature is available
 via the following commands:
 
-- [`linkerd tap`](/2/reference/cli/tap/)
-- [`linkerd top`](/2/reference/cli/top/)
-- [`linkerd profile --tap`](/2/reference/cli/profile/)
-- [`linkerd dashboard`](/2/reference/cli/dashboard/)
+- [`linkerd viz tap`](/2/reference/cli/tap/)
+- [`linkerd viz top`](/2/reference/cli/top/)
+- [`linkerd viz profile --tap`](/2/reference/cli/profile/)
+- [`linkerd viz dashboard`](/2/reference/cli/dashboard/)
 
 Depending on your RBAC setup, you may need to perform additional steps to enable
 your user(s) to perform Tap actions.
@@ -51,7 +51,7 @@ kubectl auth can-i watch deployments.tap.linkerd.io -n emojivoto --as $(whoami)
 You can also use the Linkerd CLI's `--as` flag to confirm:
 
 ```bash
-$ linkerd tap -n linkerd deploy/linkerd-controller --as $(whoami)
+$ linkerd viz tap -n linkerd deploy/linkerd-controller --as $(whoami)
 Error: HTTP error, status Code [403] (deployments.tap.linkerd.io "linkerd-controller" is forbidden: User "siggy" cannot watch resource "deployments/tap" in API group "tap.linkerd.io" in the namespace "linkerd")
 ...
 ```
@@ -194,10 +194,10 @@ Subjects:
 ```
 
 If you would like to restrict the Linkerd dashboard's tap access. You may
-install Linkerd with the `--restrict-dashboard-privileges` flag:
+install Linkerd viz with the `--set dashboard.restrictPrivileges` flag:
 
 ```bash
-linkerd install --restrict-dashboard-privileges
+linkerd viz install --set dashboard.restrictPrivileges
 ```
 
 This will omit the `linkerd-linkerd-web-admin` ClusterRoleBinding. If you have

--- a/linkerd.io/content/2/tasks/securing-your-service.md
+++ b/linkerd.io/content/2/tasks/securing-your-service.md
@@ -21,14 +21,14 @@ documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configur
 for more.
 {{< /note >}}
 
-## Validating mTLS with `linkerd edges`
+## Validating mTLS with `linkerd viz edges`
 
 To validate that mTLS is working, you can view a summary of the TCP
 connections between services that are managed by Linkerd using the [`linkerd
 edges`](/2/reference/cli/edges/) command.  For example:
 
 ```bash
-linkerd -n linkerd edges deployment
+linkerd viz -n linkerd edges deployment
 ```
 
 The output will look like:
@@ -46,7 +46,7 @@ documentation](/2/features/automatic-mtls/) for more on what these identities
 mean.) If there were a problem automatically upgrading the connection with
 mTLS, the `MSG` field would contain the reason why.
 
-## Validating mTLS with `linkerd tap`
+## Validating mTLS with `linkerd viz tap`
 
 Instead of relying on an aggregate, it is also possible to watch the requests
 and responses in real time to understand what is getting mTLS'd. We can use the
@@ -54,7 +54,7 @@ and responses in real time to understand what is getting mTLS'd. We can use the
 For example:
 
 ```bash
-linkerd -n linkerd tap deploy
+linkerd viz -n linkerd tap deploy
 ```
 
 Looking at the control plane specifically, there will be two main types of output.

--- a/linkerd.io/content/2/tasks/setting-up-service-profiles.md
+++ b/linkerd.io/content/2/tasks/setting-up-service-profiles.md
@@ -69,7 +69,7 @@ annotation. To manually verify if the requests are being associated correctly,
 run `tap` on your own deployment:
 
 ```bash
-linkerd tap -o wide <target> | grep req
+linkerd viz tap -o wide <target> | grep req
 ```
 
 The output will stream the requests that `deploy/webapp` is receiving in real
@@ -83,7 +83,7 @@ Conversely, if `rt_route` is not present, a request has *not* been associated
 with any route. Try running:
 
 ```bash
-linkerd tap -o wide <target> | grep req | grep -v rt_route
+linkerd viz tap -o wide <target> | grep req | grep -v rt_route
 ```
 
 ## Swagger
@@ -125,7 +125,7 @@ and is a great way to understand what service profiles can do for you. To start
 this generation process, you can use the `--tap` flag:
 
 ```bash
-linkerd profile -n emojivoto web-svc --tap deploy/web --tap-duration 10s
+linkerd viz profile -n emojivoto web-svc --tap deploy/web --tap-duration 10s
 ```
 
 This generates a service profile from the traffic observed to


### PR DESCRIPTION
Put `viz` in the CLI commands that were moved to the Viz extension, and add instructions on how to install Viz there where required. Also use Helm configs there where the flags are no longer supported, and updated then viz namespace in some resource yamls .

I didn't do a thorough follow-up on the instructions for each doc that was updated, so I'm not yet marking them as completed in #5867