### PR TITLE
more 2.10 upgrade doc tweaks

### DIFF
--- a/linkerd.io/content/2.10/tasks/upgrade.md
+++ b/linkerd.io/content/2.10/tasks/upgrade.md
@@ -190,9 +190,15 @@ channel in the [Linkerd slack](https://slack.linkerd.io/).
 
 ## Upgrade notice: stable-2.10.0
 
-There are two changes in the 2.10.0 release that may affect you. First, the
-handling of certain ports and protocols has changed. Please read through our
-[ports and protocols in 2.10 upgrade
+If you are currently running Linkerd 2.9.0, 2.9.1, 2.9.2, or 2.9.3 (but *not*
+2.9.4), and you *upgraded* to that release using the `--prune` flag (as opposed
+to installing it fresh), you will need to use the `linkerd repair` command as
+outlined in the [Linkerd 2.9.3 upgrade notes](#upgrade-notice-stable-2-9-3)
+before you can upgrade to Linkerd 2.10.
+
+Additionally, there are two changes in the 2.10.0 release that may affect you.
+First, the handling of certain ports and protocols has changed. Please read
+through our [ports and protocols in 2.10 upgrade
 guide](/2.10/tasks/upgrading-2.10-ports-and-protocols/) for the repercussions.
 
 Second, we've introduced [extensions](/2.10/tasks/extensions/) and moved the

--- a/linkerd.io/content/2.10/tasks/upgrade.md
+++ b/linkerd.io/content/2.10/tasks/upgrade.md
@@ -14,6 +14,7 @@ may contain important information you need to be aware of before commencing
 with the upgrade process:
 
 - [Upgrade notice: stable-2.10.0](#upgrade-notice-stable-2-10-0)
+- [Upgrade notice: stable-2.9.4](#upgrade-notice-stable-2-9-4)
 - [Upgrade notice: stable-2.9.3](#upgrade-notice-stable-2-9-3)
 - [Upgrade notice: stable-2.9.0](#upgrade-notice-stable-2-9-0)
 - [Upgrade notice: stable-2.8.0](#upgrade-notice-stable-2-8-0)
@@ -268,6 +269,10 @@ dropped, moving the config values underneath it into the root scope. Any values
 you had customized there will need to be migrated; in particular
 `identityTrustAnchorsPEM` in order to conserve the value you set during
 install."
+
+## Upgrade notice: stable-2.9.4
+
+See upgrade notes for 2.9.3 below.
 
 ## Upgrade notice: stable-2.9.3
 

--- a/linkerd.io/content/blog/announcing-linkerd-2-10.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-10.md
@@ -74,17 +74,17 @@ Extensions can come from anywhere, and because these extensions fit into
 Linkerd's CLI, they "feel" just like the rest of Linkerd.
 
 Read more in the full [blog post on Linkerd
-Extensions](https://linkerd.io/2021/03/01/linkerd-2.10-and-extensions/).
+Extensions](/2021/03/01/linkerd-2.10-and-extensions/).
 
 ## Seamless, secure multi-cluster for all TCP connections
 
 Multi-cluster support, [introduced in Linkerd
-2.8](https://linkerd.io/2020/06/09/announcing-linkerd-2.8/), allows Linkerd to
-connect Kubernetes services across cluster boundaries in a way that's secure,
-fully transparent to the application, and independent of the topology of the
-underlying network. However, this functionality was restricted to HTTP
-connections only—until now. With Linkerd 2.10, [Linkerd's multi-cluster
-feature](https://linkerd.io/2.10/features/multicluster/) now extends to all TCP
+2.8](/2020/06/09/announcing-linkerd-2.8/), allows Linkerd to connect Kubernetes
+services across cluster boundaries in a way that's secure, fully transparent to
+the application, and independent of the topology of the underlying network.
+However, this functionality was restricted to HTTP connections only—until now.
+With Linkerd 2.10, [Linkerd's multi-cluster
+feature](/2.10/features/multicluster/) now extends to all TCP
 connections, with the same guarantees of security and transparency that Linkerd
 provides for pod-to-pod communication.
 
@@ -105,7 +105,7 @@ transparent mTLS and instrumentation in situations where it was previously
 unable to handle.
 
 Read more in the full blog post on [opaque ports in
-Linkerd](https://linkerd.io/2021/02/23/protocol-detection-and-opaque-ports-in-linkerd/).
+Linkerd](/2021/02/23/protocol-detection-and-opaque-ports-in-linkerd/).
 
 ## And lots more!
 
@@ -144,7 +144,7 @@ Linkerd](https://www.cncf.io/blog/2021/02/19/how-a-4-billion-retailer-built-an-e
 **Giant Swarm**, **PlexTrac**, and **Mythical Games** have joined **HP**,
 **H-E-B**, **Microsoft**, **Clover Health**, **Mercedes Benz**, **Subspace**,
 and many more as recent adopters of Linkerd. The newly-formed [Linkerd Steering
-Committee](https://linkerd.io/2021/01/28/announcing-the-linkerd-steering-committee/),
+Committee](/2021/01/28/announcing-the-linkerd-steering-committee/),
 comprising production users who operate Linkerd at scale, is actively
 delivering feedback and guidance to maintainers. Finally, Linkerd was named
 [the Best Open Source DevOps Tool of
@@ -161,26 +161,23 @@ they resonate with you as well.
 ## Try it today!
 
 Ready to try Linkerd? Those of you who have been tracking the 2.x branch via
-our [weekly edge releases](https://linkerd.io/2.10/edge) will already have seen
-these features in action. Either way, you can download the stable 2.10 release
-by running:
+our [weekly edge releases](/2.10/edge) will already have seen these features in
+action. Either way, you can download the stable 2.10 release by running:
 
 `curl https://run.linkerd.io/install | sh`
 
 Using Helm? See our [guide to installing Linkerd with
-Helm](https://linkerd.io/2.10/tasks/install-helm/). Upgrading from an earlier
-release? We've got you covered: see our [Linkerd upgrade
-guide](https://linkerd.io/2.10/tasks/upgrade/) for how to use the `linkerd
-upgrade` command.
+Helm](/2.10/tasks/install-helm/). Upgrading from an earlier release? We've got
+you covered: see our [Linkerd upgrade guide](/2.10/tasks/upgrade/) for how to
+use the `linkerd upgrade` command.
 
 ## Linkerd is for everyone
 
 Linkerd is a community project and is hosted by the [Cloud Native Computing
 Foundation](https://cncf.io/). Linkerd is [committed to open
-governance.](https://linkerd.io/2019/10/03/linkerds-commitment-to-open-governance/)
-If you have feature requests, questions, or comments, we'd love to have you
-join our rapidly-growing community! Linkerd is hosted on
+governance.](/2019/10/03/linkerds-commitment-to-open-governance/) If you have
+feature requests, questions, or comments, we'd love to have you join our
+rapidly-growing community! Linkerd is hosted on
 [GitHub](https://github.com/linkerd/), and we have a thriving community on
 [Slack](https://slack.linkerd.io/), [Twitter](https://twitter.com/linkerd), and
-the [mailing lists](https://linkerd.io/2.10/get-involved/). Come and join the
-fun!
+the [mailing lists](/2.10/get-involved/). Come and join the fun!

--- a/linkerd.io/content/blog/announcing-linkerd-2-10.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-10.md
@@ -84,7 +84,7 @@ connect Kubernetes services across cluster boundaries in a way that's secure,
 fully transparent to the application, and independent of the topology of the
 underlying network. However, this functionality was restricted to HTTP
 connections only—until now. With Linkerd 2.10, [Linkerd's multi-cluster
-feature](https://linkerd.io/2/features/multicluster/) now extends to all TCP
+feature](https://linkerd.io/2.10/features/multicluster/) now extends to all TCP
 connections, with the same guarantees of security and transparency that Linkerd
 provides for pod-to-pod communication.
 
@@ -161,16 +161,16 @@ they resonate with you as well.
 ## Try it today!
 
 Ready to try Linkerd? Those of you who have been tracking the 2.x branch via
-our [weekly edge releases](https://linkerd.io/2/edge) will already have seen
+our [weekly edge releases](https://linkerd.io/2.10/edge) will already have seen
 these features in action. Either way, you can download the stable 2.10 release
 by running:
 
 `curl https://run.linkerd.io/install | sh`
 
 Using Helm? See our [guide to installing Linkerd with
-Helm](https://linkerd.io/2/tasks/install-helm/). Upgrading from an earlier
+Helm](https://linkerd.io/2.10/tasks/install-helm/). Upgrading from an earlier
 release? We've got you covered: see our [Linkerd upgrade
-guide](https://linkerd.io/2/tasks/upgrade/) for how to use the `linkerd
+guide](https://linkerd.io/2.10/tasks/upgrade/) for how to use the `linkerd
 upgrade` command.
 
 ## Linkerd is for everyone
@@ -182,4 +182,5 @@ If you have feature requests, questions, or comments, we'd love to have you
 join our rapidly-growing community! Linkerd is hosted on
 [GitHub](https://github.com/linkerd/), and we have a thriving community on
 [Slack](https://slack.linkerd.io/), [Twitter](https://twitter.com/linkerd), and
-the [mailing lists](https://linkerd.io/2/get-involved/). Come and join the fun!
+the [mailing lists](https://linkerd.io/2.10/get-involved/). Come and join the
+fun!

--- a/linkerd.io/content/blog/announcing-linkerd-2-10.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-10.md
@@ -161,8 +161,8 @@ they resonate with you as well.
 ## Try it today!
 
 Ready to try Linkerd? Those of you who have been tracking the 2.x branch via
-our [weekly edge releases](/2.10/edge) will already have seen these features in
-action. Either way, you can download the stable 2.10 release by running:
+our [weekly edge releases](/2.10/edge/) will already have seen these features
+in action. Either way, you can download the stable 2.10 release by running:
 
 `curl https://run.linkerd.io/install | sh`
 

--- a/linkerd.io/layouts/partials/docs.html
+++ b/linkerd.io/layouts/partials/docs.html
@@ -8,20 +8,34 @@
     </div>
     <div class="column has-background-white docs-content is-paddingless ">
       <div class="container blog-content-container">
-        <h1 class="title is-1 has-text-color">{{ .page.Title }}</h1>
-
         {{/*  {{ partial "breadcrumb.html" (dict "version" $docsVersion "ctx" .page) }}  */}}
 
         {{ if eq $docsVersion "1" }}
-          <div class="message-body">
-            <div><strong>Note</strong></div>
-        
-	    This documentation is for Linkerd 1.x, an older version with some
-            significant differences. You may want to see the
-            <a href="/2.10/overview/">Linkerd 2.x (current) documentation</a> instead.
-         </div>
-
+          <div class="message">
+            <div class="message-header">
+              This is not the latest version
+            </div>
+            <div class="message-body">
+	      This documentation is for Linkerd 1.x, an older version with some
+              significant differences. You may want to see the
+              <a href="/2.10/overview/">Linkerd 2.x (current) documentation</a> instead.
+            </div>
+           </div>
+        {{ else if ne $docsVersion "2.10" }}
+          <div class="message">
+            <div class="message-header">
+              This is not the latest version
+            </div>
+            <div class="message-body">
+	      This documentation is not for the latest version of Linkerd.
+	      You may want the <a href="/2.10/overview/">Linkerd 2.10 (current)
+              documentation</a> instead.
+            </div>
+          </div>
         {{ end }}
+
+        <h1 class="title is-1 has-text-color">{{ .page.Title }}</h1>
+
 
         <div class="language-markup">
           {{ if .page.Params.include_toc }}


### PR DESCRIPTION
- update blog post to point to 2.10 specific resources. /2/ points to the wrong thing.
- denote non-current versions of the docs
- use relative links in blog post for debugging
- add `linkerd repair` instructions for 2.10 upgrades
- add 2.9.4 pseudo-instructions