### PR TITLE
fix: separate seo check with pr_target trigger, add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Fetch and update latest `github-actions` pkgs
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+      time: '00:00'
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,24 @@
+name: check
+
+ on:
+   pull_request_target:
+     paths:
+       - linkerd.io/**
+
+ jobs:
+   linkerd_io:
+     name: check source files
+     runs-on: ubuntu-latest
+     steps:
+       - uses: actions/checkout@v2
+         with:
+           ref: ${{ github.event.pull_request.head.sha }}
+       - name: Markdown SEO Check
+         uses: zentered/markdown-seo-check@v1.1.0
+         with:
+           includes: '/linkerd.io/content/**/*.md'
+           max_title_length: 70
+           max_description_length: 150
+           max_slug_length: 100
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,24 +1,24 @@
 name: check
 
- on:
-   pull_request_target:
-     paths:
-       - linkerd.io/**
+on:
+  pull_request_target:
+    paths:
+      - linkerd.io/**
 
- jobs:
-   linkerd_io:
-     name: check source files
-     runs-on: ubuntu-latest
-     steps:
-       - uses: actions/checkout@v2
-         with:
-           ref: ${{ github.event.pull_request.head.sha }}
-       - name: Markdown SEO Check
-         uses: zentered/markdown-seo-check@v1.1.0
-         with:
-           includes: '/linkerd.io/content/**/*.md'
-           max_title_length: 70
-           max_description_length: 150
-           max_slug_length: 100
-         env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+jobs:
+  linkerd_io:
+    name: check source files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Markdown SEO Check
+        uses: zentered/markdown-seo-check@v1.1.0
+        with:
+          includes: '/linkerd.io/content/**/*.md'
+          max_title_length: 70
+          max_description_length: 150
+          max_slug_length: 100
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,12 +22,3 @@ jobs:
       - name: Lint html and check for dead links
         run: |
           make check
-
-      - name: Markdown SEO Check
-        uses: zentered/markdown-seo-check@v1.0.0
-        with:
-          max_title_length: 70
-          max_description_length: 150
-          max_slug_length: 100
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This fixes some issues with the SEO Check:

- added TOML support
- added support for `+++` delims
- fixed fail status

Also adds a dependabot config for automated version updates on GitHub Actions.

Signed-off-by: Patrick Heneise <patrick@zentered.co>