### PR TITLE
fix(faq): anchor links break with special characters in questions

### DIFF
--- a/linkerd.io/layouts/partials/faqs.html
+++ b/linkerd.io/layouts/partials/faqs.html
@@ -31,7 +31,7 @@
           <ul>
             {{ range .page.Params.faqs}}
               <li>
-                <a href="#{{ .question | urlize }}">{{ .question }}</a>
+                <a href="#{{ .question | anchorize }}">{{ .question }}</a>
               </li>
             {{ end}}
           </ul>


### PR DESCRIPTION
Signed-off-by: Patrick Heneise <patrick@zentered.co>