### PR TITLE
chore: bump seo action to be less chatty on PRs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Markdown SEO Check
-        uses: zentered/markdown-seo-check@v1.1.0
+        uses: zentered/markdown-seo-check@v1.1.1
         with:
           includes: '/linkerd.io/content/**/*.md'
           max_title_length: 70


### PR DESCRIPTION
updated the action to only comment on PRs when relevant files were modified.

Signed-off-by: Patrick Heneise <patrick@zentered.co>