### PR TITLE
Add aliases for moved subcommands

### DIFF
--- a/linkerd.io/content/2.10/reference/cli/diagnostics.md
+++ b/linkerd.io/content/2.10/reference/cli/diagnostics.md
@@ -1,5 +1,10 @@
 +++
 title = "diagnostics"
+aliases = [
+  "endpoints",
+  "install-sp",
+  "metrics"
+]
 +++
 
 {{< cli-2-10/description "diagnostics" >}}

--- a/linkerd.io/content/2.10/reference/cli/endpoints.md
+++ b/linkerd.io/content/2.10/reference/cli/endpoints.md
@@ -1,9 +1,0 @@
-+++
-title = "endpoints"
-+++
-
-{{< cli-2-10/description "endpoints" >}}
-
-{{< cli-2-10/examples "endpoints" >}}
-
-{{< cli-2-10/flags "endpoints" >}}

--- a/linkerd.io/content/2.10/reference/cli/viz.md
+++ b/linkerd.io/content/2.10/reference/cli/viz.md
@@ -1,5 +1,13 @@
 +++
 title = "viz"
+aliases = [
+  "dashboard",
+  "edges",
+  "routes",
+  "stat",
+  "tap",
+  "top"
+]
 +++
 
 {{< cli-2-10/description "viz" >}}


### PR DESCRIPTION
Add aliases to the `diagnostics` and `viz` CLI reference pages to
account for the subcommands that were moved and are now housed under
there.  Also deletes the `endpoints.md` file whose info was also moved
under `diagnostics`.