### PR TITLE
fix: no empty seo messages in PRs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Markdown SEO Check
-        uses: zentered/markdown-seo-check@v1.1.1
+        uses: zentered/markdown-seo-check@v1.1.2
         with:
           includes: '/linkerd.io/content/**/*.md'
           max_title_length: 70


### PR DESCRIPTION
Signed-off-by: Patrick Heneise <patrick@zentered.co>

sorry, there was another issue with the action, it's fixed now. No more empty SEO messages from the bot.