### PR TITLE
Update the edge install script to download M1 CLI

### DIFF
--- a/run.linkerd.io/public/install-edge
+++ b/run.linkerd.io/public/install-edge
@@ -59,6 +59,18 @@ case $OS in
     OS=windows.exe
     ;;
   Darwin)
+    case $arch in
+      x86_64)
+        cli_arch=""
+        ;;
+      arm64)
+        cli_arch=$arch
+        ;;
+      *)
+        echo "There is no linkerd $OS support for $arch. Please open an issue with your platform details."
+        exit 1
+        ;;
+    esac
     ;;
   Linux)
     case $arch in


### PR DESCRIPTION
With the addition of linkerd/linkerd2#5907, users with the new MacOS M1
arch need to be able to easily install the CLI. This change modifies the
edge bash script to detect the new arch and install the correct image.

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>