### PR TITLE
Temporary stable version fix

### DIFF
--- a/bin/export-channel-versions
+++ b/bin/export-channel-versions
@@ -6,5 +6,6 @@ releases_url="https://api.github.com/repos/linkerd/linkerd2/releases"
 stable_tag_regex="\"tag_name\": \"stable-[0-9]+\.[0-9]+\.[0-9]\""
 edge_tag_regex="\"tag_name\": \"edge-[0-9]+\.[0-9]+\.[0-9]\""
 
-export L5D2_STABLE_VERSION=$(curl -s $releases_url | awk -v pattern="$stable_tag_regex" '$0 ~ pattern {gsub(/"/, "", $2); gsub(/,$/,""); print $2; exit}')
+#export L5D2_STABLE_VERSION=$(curl -s $releases_url | awk -v pattern="$stable_tag_regex" '$0 ~ pattern {gsub(/"/, "", $2); gsub(/,$/,""); print $2; exit}')
+export L5D2_STABLE_VERSION=stable-2.10.1
 export L5D2_EDGE_VERSION=$(curl -s $releases_url | awk -v pattern="$edge_tag_regex" '$0 ~ pattern {gsub(/"/, "", $2); gsub(/,$/,""); print $2; exit}')


### PR DESCRIPTION
Currently the site is showing the latest stable to be 2.9.5 because
that's the latest stable version by date in github. Correcting to 2.10.1
manually, till we fix this properly. Note this affects the result
retrieved in https://run.linkerd.io/install