### PR TITLE
Fix load balancing link

### DIFF
--- a/linkerd.io/content/2.10/tasks/using-ingress.md
+++ b/linkerd.io/content/2.10/tasks/using-ingress.md
@@ -10,7 +10,7 @@ can be run with your Ingress Controller.
 
 When the ingress controller is injected with the `linkerd.io/inject: enabled`
 annotation, the Linkerd proxy will honor load balancing decisions made by the
-ingress controller instead of applying [its own EWMA load balancing](https://linkerd.io../../features/load-balancing/).
+ingress controller instead of applying [its own EWMA load balancing](/features/load-balancing).
 This also means that the Linkerd proxy will not use Service Profiles for this
 traffic and therefore will not expose per-route metrics or do traffic splitting.
 

--- a/linkerd.io/content/2.9/tasks/using-ingress.md
+++ b/linkerd.io/content/2.9/tasks/using-ingress.md
@@ -10,7 +10,7 @@ can be run with your Ingress Controller.
 
 When the ingress controller is injected with the `linkerd.io/inject: enabled`
 annotation, the Linkerd proxy will honor load balancing decisions made by the
-ingress controller instead of applying [its own EWMA load balancing](https://linkerd.io../../features/load-balancing/).
+ingress controller instead of applying [its own EWMA load balancing](/features/load-balancing).
 This also means that the Linkerd proxy will not use Service Profiles for this
 traffic and therefore will not expose per-route metrics or do traffic splitting.
 


### PR DESCRIPTION
For both 2.9 and 2.10, the `its own EWMA load balancing` link within the https://linkerd.io/2.9/tasks/using-ingress/ and https://linkerd.io/2.10/tasks/using-ingress/ doc is dead.