### PR TITLE
Fix broken links

### DIFF
--- a/linkerd.io/content/2.10/features/ha.md
+++ b/linkerd.io/content/2.10/features/ha.md
@@ -123,7 +123,7 @@ Prometheus and Grafana.
 The Linkerd Viz extension provides a pre-configured Prometheus pod, but for
 production workloads we recommend setting up your own Prometheus instance. To
 scrape the data plane metrics, follow the instructions
-[here](https://linkerd.io../../tasks/external-prometheus/). This will provide you
+[here](../../tasks/external-prometheus/). This will provide you
 with more control over resource requirement, backup strategy and data retention.
 
 When planning for memory capacity to store Linkerd timeseries data, the usual

--- a/linkerd.io/content/2.10/tasks/installing-multicluster.md
+++ b/linkerd.io/content/2.10/tasks/installing-multicluster.md
@@ -360,4 +360,4 @@ The same functionality can also be done through Helm setting the
 
 Now that the multicluster components are installed, operations like linking, etc
 can be performed by using the linkerd CLI's multicluster sub-command as per the
-[multicluster task](../../features/multicluster).
+[multicluster task](../../features/multicluster/).

--- a/linkerd.io/content/2.10/tasks/installing-multicluster.md
+++ b/linkerd.io/content/2.10/tasks/installing-multicluster.md
@@ -360,4 +360,4 @@ The same functionality can also be done through Helm setting the
 
 Now that the multicluster components are installed, operations like linking, etc
 can be performed by using the linkerd CLI's multicluster sub-command as per the
-[multicluster task](https://linkerd.io../../features/multicluster).
+[multicluster task](../../features/multicluster).

--- a/linkerd.io/content/2.10/tasks/using-ingress.md
+++ b/linkerd.io/content/2.10/tasks/using-ingress.md
@@ -10,7 +10,7 @@ can be run with your Ingress Controller.
 
 When the ingress controller is injected with the `linkerd.io/inject: enabled`
 annotation, the Linkerd proxy will honor load balancing decisions made by the
-ingress controller instead of applying [its own EWMA load balancing](https://linkerd.io../../features/load-balancing/).
+ingress controller instead of applying [its own EWMA load balancing](../../features/load-balancing/).
 This also means that the Linkerd proxy will not use Service Profiles for this
 traffic and therefore will not expose per-route metrics or do traffic splitting.
 

--- a/linkerd.io/content/2.10/tasks/using-the-debug-container.md
+++ b/linkerd.io/content/2.10/tasks/using-the-debug-container.md
@@ -27,7 +27,7 @@ incoming and outgoing traffic with `tshark`, which can then be viewed with
 container and run commands directly.
 
 For instance, if you've gone through the [Linkerd Getting
-Started](https://linkerd.io../../getting-started/) guide and installed the
+Started](../../getting-started/) guide and installed the
 *emojivoto* application, and wish to debug traffic to the *voting* service, you
 could run:
 

--- a/linkerd.io/content/2.9/features/ha.md
+++ b/linkerd.io/content/2.9/features/ha.md
@@ -115,7 +115,7 @@ Prometheus and Grafana.
 
 For production workloads, we recommend setting up your own Prometheus instance
 to scrape the data plane metrics, following the instructions
-[here](https://linkerd.io../../tasks/external-prometheus/). This will provide you
+[here](../../tasks/external-prometheus/). This will provide you
 with more control over resource requirement, backup strategy and data retention.
 
 When planning for memory capacity to store Linkerd timeseries data, the usual

--- a/linkerd.io/content/2.9/tasks/installing-multicluster.md
+++ b/linkerd.io/content/2.9/tasks/installing-multicluster.md
@@ -358,4 +358,4 @@ The same functionality can also be done through Helm setting the
 
 Now that the multicluster components are installed, operations like linking, etc
 can be performed by using the linkerd CLI's multicluster sub-command as per the
-[multicluster task](https://linkerd.io../../features/multicluster).
+[multicluster task](../../features/multicluster).

--- a/linkerd.io/content/2.9/tasks/installing-multicluster.md
+++ b/linkerd.io/content/2.9/tasks/installing-multicluster.md
@@ -358,4 +358,4 @@ The same functionality can also be done through Helm setting the
 
 Now that the multicluster components are installed, operations like linking, etc
 can be performed by using the linkerd CLI's multicluster sub-command as per the
-[multicluster task](../../features/multicluster).
+[multicluster task](../../features/multicluster/).

--- a/linkerd.io/content/2.9/tasks/using-ingress.md
+++ b/linkerd.io/content/2.9/tasks/using-ingress.md
@@ -10,7 +10,7 @@ can be run with your Ingress Controller.
 
 When the ingress controller is injected with the `linkerd.io/inject: enabled`
 annotation, the Linkerd proxy will honor load balancing decisions made by the
-ingress controller instead of applying [its own EWMA load balancing](https://linkerd.io../../features/load-balancing/).
+ingress controller instead of applying [its own EWMA load balancing](../../features/load-balancing/).
 This also means that the Linkerd proxy will not use Service Profiles for this
 traffic and therefore will not expose per-route metrics or do traffic splitting.
 

--- a/linkerd.io/content/2.9/tasks/using-the-debug-container.md
+++ b/linkerd.io/content/2.9/tasks/using-the-debug-container.md
@@ -27,7 +27,7 @@ incoming and outgoing traffic with `tshark`, which can then be viewed with
 container and run commands directly.
 
 For instance, if you've gone through the [Linkerd Getting
-Started](https://linkerd.io../../getting-started/) guide and installed the
+Started](../../getting-started/) guide and installed the
 *emojivoto* application, and wish to debug traffic to the *voting* service, you
 could run:
 


### PR DESCRIPTION
Some links under the `2.9` and `2.10` directories were malformed: `https://linkerd.io../../<url>`

This change updates those links to be relative links: `../../<url>`

Signed-off-by: Charles Pretzer <charles@buoyant.io>