### PR TITLE
add tls rotation to getting started suggestions

### DIFF
--- a/linkerd.io/content/2.10/getting-started/_index.md
+++ b/linkerd.io/content/2.10/getting-started/_index.md
@@ -311,6 +311,7 @@ Congratulations, you're now a Linkerd user! Here are some suggested next steps:
 
 - Use Linkerd to [debug the errors in *emojivoto*](../debugging-an-app/)
 - [Add your own service](../adding-your-service/) to Linkerd without downtime
+- Learn how to [automatically rotate control plane TLS credentials](../tasks/automatically-rotating-control-plane-tls-credentials/) or set a reminder to [do it manually](../tasks/manually-rotating-control-plane-tls-credentials/) before they expire
 - Learn more about [Linkerd's architecture](../reference/architecture/)
 - Hop into the #linkerd2 channel on [the Linkerd
   Slack](https://slack.linkerd.io)

--- a/linkerd.io/content/2.10/getting-started/_index.md
+++ b/linkerd.io/content/2.10/getting-started/_index.md
@@ -311,7 +311,11 @@ Congratulations, you're now a Linkerd user! Here are some suggested next steps:
 
 - Use Linkerd to [debug the errors in *emojivoto*](../debugging-an-app/)
 - [Add your own service](../adding-your-service/) to Linkerd without downtime
-- Learn how to [automatically rotate control plane TLS credentials](../tasks/automatically-rotating-control-plane-tls-credentials/) or set a reminder to [do it manually](../tasks/manually-rotating-control-plane-tls-credentials/) before they expire
+- Learn how to rotate control plane TLS credentials
+  [automatically](../tasks/automatically-rotating-control-plane-tls-credentials/)
+  or set a reminder to do it
+  [manually](../tasks/manually-rotating-control-plane-tls-credentials/)
+  before they expire
 - Learn more about [Linkerd's architecture](../reference/architecture/)
 - Hop into the #linkerd2 channel on [the Linkerd
   Slack](https://slack.linkerd.io)


### PR DESCRIPTION
The getting started page does not currently mention that the Control Plane TLS credentials will ultimately expire, leading to nasty surprises a year down the line.

Adding links to the relevant documentation on the getting started page should fix this.

Fixes https://github.com/linkerd/linkerd2/issues/6099
