### PR TITLE
Auto-rotating Webhook TLS Credentials: Changed the --config flag in code snippet to be --values instead

### DIFF
--- a/linkerd.io/content/2.10/tasks/automatically-rotating-webhook-tls-credentials.md
+++ b/linkerd.io/content/2.10/tasks/automatically-rotating-webhook-tls-credentials.md
@@ -265,13 +265,13 @@ EOF
 Now we can install Linkerd using these config files:
 
 ```bash
-linkerd install --config=config.yml | kubectl apply -f -
+linkerd install --values=config.yml | kubectl apply -f -
 
 # ignore if not using the viz extension
-linkerd viz install --config=config-viz.yml | kubectl apply -f -
+linkerd viz install --values=config-viz.yml | kubectl apply -f -
 
 # ignore if not using the jaeger extension
-linkerd jaeger install --config=config-jaeger.yml | kubectl apply -f -
+linkerd jaeger install --values=config-jaeger.yml | kubectl apply -f -
 ```
 
 ## Installing with Helm


### PR DESCRIPTION
This PR updates the code snippet in the guide on how to configure automatic rotation of webhook TLS credentials to use the `--values` flag instead of the `--config` flag, which is no longer available.

Signed-off-by: Emanuel Winblad <winblad@me.com>