### PR TITLE
Twitter cards show large image summary for blog posts

### DIFF
--- a/linkerd.io/layouts/partials/meta.html
+++ b/linkerd.io/layouts/partials/meta.html
@@ -7,9 +7,7 @@
 {{ end }}
 
 <meta name="description" content="{{ partial "description.html" . }}" />
-<meta name="twitter:card" content="summary" />
-<meta name="twitter:site" content="@Linkerd" />
-<meta name="twitter:creator" content="@Linkerd" />
+{{ partial "twitter-cards.html" . }}
 <meta property="og:title" content="{{ .Title }}" />
 <meta property="og:description" content="{{ partial "description.html" . }}" />
 <meta property="og:type" content="website" />

--- a/linkerd.io/themes/buoyant/layouts/partials/twitter-cards.html
+++ b/linkerd.io/themes/buoyant/layouts/partials/twitter-cards.html
@@ -1,6 +1,6 @@
 {{ with .Params.thumbnail }}
   <meta name="twitter:card" content="summary_large_image"/>
-  <meta name="twitter:image" content="{{ . }}"/>
+  <meta name="twitter:image" content="{{ . | absURL }}"/>
 {{ else }}
   {{ $images := $.Resources.ByType "image" }}
   {{ $featured := index $images 0 }}
@@ -9,7 +9,7 @@
   {{ end }}
   {{ with $featured }}
     <meta name="twitter:card" content="summary_large_image"/>
-    <meta name="twitter:image" content="{{ $featured.Permalink }}"/>
+    <meta name="twitter:image" content="{{ $featured.Permalink | absURL }}"/>
   {{ else }}
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:image" content="{{ "images/logo-only-200h.png" | absURL }}"/>

--- a/linkerd.io/themes/buoyant/layouts/partials/twitter-cards.html
+++ b/linkerd.io/themes/buoyant/layouts/partials/twitter-cards.html
@@ -1,0 +1,29 @@
+{{ with .Params.thumbnail }}
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:image" content="{{ . }}"/>
+{{ else }}
+  {{ $images := $.Resources.ByType "image" }}
+  {{ $featured := index $images 0 }}
+  {{ if not $featured }}
+    {{ $featured = $images.GetMatch "{*cover*,*image*}" }}
+  {{ end }}
+  {{ with $featured }}
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:image" content="{{ $featured.Permalink }}"/>
+  {{ else }}
+    <meta name="twitter:card" content="summary"/>
+    <meta name="twitter:image" content="{{ "images/logo-only-200h.png" | absURL }}"/>
+  {{ end }}
+{{ end }}
+<meta name="twitter:title" content="{{ .Title }}"/>
+<meta name="twitter:description" content={{ partial "description.html" . }}/>
+{{ with .Site.Social.twitter -}}
+  <meta name="twitter:site" content="@{{ . }}"/>
+{{ end -}}
+{{ range .Site.Authors }}
+  {{ with .twitter -}}
+    <meta name="twitter:creator" content="@{{ . }}"/>
+  {{ end -}}
+{{ end -}}
+
+


### PR DESCRIPTION
Closes https://github.com/BuoyantIO/website/issues/241

**Home page card**
![image](https://user-images.githubusercontent.com/39129161/118458068-a61e1280-b6fa-11eb-82e3-2939dc311dbb.png)

**Blog card example**
![image](https://user-images.githubusercontent.com/39129161/118464182-dcf72700-b700-11eb-8515-09ed134a7c9f.png)

