### PR TITLE
Add HTTPS to linkerd CLI install instructions

### DIFF
--- a/linkerd.io/content/2.10/getting-started/_index.md
+++ b/linkerd.io/content/2.10/getting-started/_index.md
@@ -58,7 +58,7 @@ allow you to interact with your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
-curl -sL run.linkerd.io/install | sh
+curl -sL https://run.linkerd.io/install | sh
 ```
 
 Be sure to follow the instructions to add it to your path.


### PR DESCRIPTION
Seems to be the only place in the docs where a plain HTTP link remains. It seems quite important to have HTTPS since the command is downloading a bash script and piping it to bash.