### PR TITLE
Update 3 homepage links to match the logos (#1103)

### DIFF
--- a/linkerd.io/content/_index.md
+++ b/linkerd.io/content/_index.md
@@ -61,13 +61,13 @@ companies:
 - image: "/uploads/logos/blue/offerup.png"
   link: https://offerup.com/
 - image: "/uploads/logos/blue/hp.png"
-  link: https://ask.com/
+  link: https://hp.com/
 - image: "/uploads/logos/blue/bigcommerce.png"
   link: https://www.bigcommerce.com/
 - image: "/uploads/logos/blue/cisco-webex.png"
-  link: https://www.xfinity.com/
+  link: https://www.webex.com/
 - image: "/uploads/logos/blue/clover-health.png"
-  link: https://www.ebay.com/
+  link: https://www.cloverhealth.com/
 - image: "/uploads/logos/blue/godaddy.png"
   link: https://godaddy.com/
 - image: "/uploads/logos/blue/heb.png"


### PR DESCRIPTION
The HP/Webex/Clover Health logos do not link to the respective company websites

This commit addresses this in the source material for the static site generation tool

Fixes #1103

Signed-off-by: Gavin Chappell <44392051+gchappell99@users.noreply.github.com>