### PR TITLE
Update Contour instructions

### DIFF
--- a/linkerd.io/content/2.10/tasks/using-ingress.md
+++ b/linkerd.io/content/2.10/tasks/using-ingress.md
@@ -545,19 +545,18 @@ should open the Books application.
 Contour doesn't support setting the `l5d-dst-override` header automatically.
 The following example uses the
 [Contour getting started](https://projectcontour.io/getting-started/) documentation
-to demonstrate how to set the required header manually:
+to demonstrate how to set the required header manually.
 
-First, inject Linkerd into your Contour installation:
-
-```bash
-linkerd inject https://projectcontour.io/quickstart/contour.yaml | kubectl apply -f -
-```
-
-Envoy will not auto mount the service account token.
-To fix this you need to set `automountServiceAccountToken: true`.
-Optionally you can create a dedicated service account to avoid using the `default`.
+The Envoy DaemonSet doesn't auto-mount the service account token, which is
+required for the Linkerd proxy to do mTLS between pods. So first we need to
+install Contour uninjected, patch the DaemonSet with
+`automountServiceAccountToken: true`, and then inject it.  Optionally you can
+create a dedicated service account to avoid using the `default` one.
 
 ```bash
+# install Contour
+kubectl apply -f https://projectcontour.io/quickstart/contour.yaml
+
 # create a service account (optional)
 kubectl apply -f - << EOF
 apiVersion: v1
@@ -572,6 +571,12 @@ kubectl patch daemonset envoy -n projectcontour --type json -p='[{"op": "add", "
 
 # auto mount the service account token (required)
 kubectl patch daemonset envoy -n projectcontour --type json -p='[{"op": "replace", "path": "/spec/template/spec/automountServiceAccountToken", "value": true}]'
+
+# inject linkerd first into the DaemonSet
+kubectl -n projectcontour get daemonset -oyaml | linkerd inject - | kubectl apply -f -
+
+# inject linkerd into the Deployment
+kubectl -n projectcontour get deployment -oyaml | linkerd inject - | kubectl apply -f -
 ```
 
 Verify your Contour and Envoy installation has a running Linkerd sidecar.
@@ -598,10 +603,9 @@ spec:
         value: kuard.default.svc.cluster.local:80
     services:
     - name: kuard
-      namespace: default
       port: 80
   virtualhost:
-    fqdn: 127.0.0.1.xip.io
+    fqdn: 127.0.0.1.nip.io
 ```
 
 Notice the `l5d-dst-override` header is explicitly set to the target `service`.
@@ -610,8 +614,16 @@ Finally, you can test your working service mesh:
 
 ```bash
 kubectl port-forward svc/envoy -n projectcontour 3200:80
-http://127.0.0.1.xip.io:3200
+http://127.0.0.1.nip.io:3200
 ```
+
+{{< note >}}
+If you are injecting the Envoy DaemonSet using [proxy ingress mode]({{<ref
+"#proxy-ingress-mode" >}}) then make sure to annotate the pod spec with
+`config.linkerd.io/skip-outbound-ports: 8001`. The Envoy pod will try to connect
+to the Contour pod at port 8001 through TLS, which is not supported under this
+ingress mode, so you need to have the proxy skip that outbound port.
+{{< /note >}}
 
 {{< note >}}
 If you are using Contour with [flagger](https://github.com/weaveworks/flagger)


### PR DESCRIPTION
Fixes linkerd/linkerd2#6237

- Since a few releases ago, `linkerd inject` will fail outright if
`automountServiceAccountToken` is not `true`. Reshuffled the instructions to
account for that.
- Added note about adding the
`config.linkerd.io/skip-outbound-ports: 8001` annotation when in ingress mode.
- Removed the `spec.routes.services.namespace` field from the sample
`HTTPProxy` resource, which doesn't appear in the resource API doc.
- Replaced `127.0.0.1.xip.io` with `127.0.0.1.nip.io` as the former is down.