### PR TITLE
Upgrade Ingress resources

### DIFF
--- a/linkerd.io/content/2.10/tasks/exposing-dashboard.md
+++ b/linkerd.io/content/2.10/tasks/exposing-dashboard.md
@@ -25,13 +25,13 @@ metadata:
 data:
   auth: YWRtaW46JGFwcjEkbjdDdTZnSGwkRTQ3b2dmN0NPOE5SWWpFakJPa1dNLgoK
 ---
-apiVersion: extensions/v1beta1
+# apiVersion: networking.k8s.io/v1beta1 # for k8s < v1.19
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: web-ingress
   namespace: linkerd-viz
   annotations:
-    kubernetes.io/ingress.class: 'nginx'
     nginx.ingress.kubernetes.io/upstream-vhost: $service_name.$namespace.svc.cluster.local:8084
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header Origin "";
@@ -41,13 +41,18 @@ metadata:
     nginx.ingress.kubernetes.io/auth-secret: web-ingress-auth
     nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required'
 spec:
+  ingressClassName: nginx
   rules:
-    - host: dashboard.example.com
-      http:
-        paths:
-          - backend:
-              serviceName: web
-              servicePort: 8084
+  - host: dashboard.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: web
+            port:
+              number: 8084
 ```
 
 This exposes the dashboard at `dashboard.example.com` and protects it with basic
@@ -91,13 +96,13 @@ such as, `client-id` `client-secret` and `cookie-secret`.
 Once setup, a sample ingress would be:
 
 ```yaml
-apiVersion: extensions/v1beta1
+# apiVersion: networking.k8s.io/v1beta1 # for k8s < v1.19
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: web
   namespace: linkerd-viz
   annotations:
-    kubernetes.io/ingress.class: 'nginx'
     nginx.ingress.kubernetes.io/upstream-vhost: $service_name.$namespace.svc.cluster.local:8084
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header Origin "";
@@ -106,13 +111,18 @@ metadata:
     nginx.ingress.kubernetes.io/auth-signin: https://$host/oauth2/start?rd=$escaped_request_uri
     nginx.ingress.kubernetes.io/auth-url: https://$host/oauth2/auth
 spec:
+  ingressClassName: nginx
   rules:
-    - host: linkerd.example.com
-      http:
-        paths:
-          - backend:
-              serviceName: web
-              servicePort: 8084
+  - host: linkerd.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: web
+            port:
+              number: 8084
 ```
 
 ## Traefik
@@ -129,24 +139,29 @@ metadata:
 data:
   auth: YWRtaW46JGFwcjEkbjdDdTZnSGwkRTQ3b2dmN0NPOE5SWWpFakJPa1dNLgoK
 ---
-apiVersion: extensions/v1beta1
+# apiVersion: networking.k8s.io/v1beta1 # for k8s < v1.19
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: web-ingress
   namespace: linkerd-viz
   annotations:
-    kubernetes.io/ingress.class: 'traefik'
     ingress.kubernetes.io/custom-request-headers: l5d-dst-override:web.linkerd-viz.svc.cluster.local:8084
     traefik.ingress.kubernetes.io/auth-type: basic
     traefik.ingress.kubernetes.io/auth-secret: web-ingress-auth
 spec:
+  ingressClassName: traefik
   rules:
-    - host: dashboard.example.com
-      http:
-        paths:
-          - backend:
-              serviceName: web
-              servicePort: 8084
+  - host: dashboard.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: web
+            port:
+              number: 8084
 ```
 
 This exposes the dashboard at `dashboard.example.com` and protects it with basic

--- a/linkerd.io/content/2.10/tasks/using-ingress.md
+++ b/linkerd.io/content/2.10/tasks/using-ingress.md
@@ -91,25 +91,30 @@ This uses `emojivoto` as an example, take a look at
 The sample ingress definition is:
 
 ```yaml
-apiVersion: extensions/v1beta1
+# apiVersion: networking.k8s.io/v1beta1 # for k8s < v1.19
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: web-ingress
   namespace: emojivoto
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
       grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
 
 spec:
+  ingressClassName: nginx
   rules:
   - host: example.com
     http:
       paths:
-      - backend:
-          serviceName: web-svc
-          servicePort: 80
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: web-svc
+            port:
+              number: 80
 ```
 
 The important annotation here is:
@@ -142,29 +147,36 @@ This sample ingress definition uses a single ingress for an application
 with multiple endpoints using different ports.
 
 ```yaml
-apiVersion: extensions/v1beta1
+# apiVersion: networking.k8s.io/v1beta1 # for k8s < v1.19
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: web-ingress
   namespace: emojivoto
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
       grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
 spec:
+  ingressClassName: nginx
   rules:
   - host: example.com
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: web-svc
-          servicePort: 80
+          service:
+            name: web-svc
+            port:
+              number: 80
       - path: /another-endpoint
+        pathType: Prefix
         backend:
-          serviceName: another-svc
-          servicePort: 8080
+          service:
+            name: another-svc
+            port:
+              number: 8080
 ```
 
 Nginx will add a `l5d-dst-override` header to instruct Linkerd what service
@@ -193,20 +205,23 @@ definition for that backend to ensure that the `l5d-dst-override` header
 is set. For example:
 
 ```yaml
-apiVersion: extensions/v1beta1
+# apiVersion: networking.k8s.io/v1beta1 # for k8s < v1.19
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: default-ingress
   namespace: backends
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
       grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
 spec:
-  backend:
-    serviceName: default-backend
-    servicePort: 80
+  ingressClassName: nginx
+  defaultBackend:
+    service:
+      name: default-backend
+      port:
+        number: 80
 ```
 
 {{< /note >}}
@@ -221,22 +236,27 @@ Kubernetes `Ingress` resource with the
 `ingress.kubernetes.io/custom-request-headers` like this:
 
 ```yaml
-apiVersion: extensions/v1beta1
+# apiVersion: networking.k8s.io/v1beta1 # for k8s < v1.19
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: web-ingress
   namespace: emojivoto
   annotations:
-    kubernetes.io/ingress.class: "traefik"
     ingress.kubernetes.io/custom-request-headers: l5d-dst-override:web-svc.emojivoto.svc.cluster.local:80
 spec:
+  ingressClassName: traefik
   rules:
   - host: example.com
     http:
       paths:
-      - backend:
-          serviceName: web-svc
-          servicePort: 80
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: web-svc
+            port:
+              number: 80
 ```
 
 The important annotation here is:
@@ -335,24 +355,29 @@ and TLS with a [Google-managed certificate](https://cloud.google.com/load-balanc
 The sample ingress definition is:
 
 ```yaml
-apiVersion: extensions/v1beta1
+# apiVersion: networking.k8s.io/v1beta1 # for k8s < v1.19
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: web-ingress
   namespace: emojivoto
   annotations:
-    kubernetes.io/ingress.class: "gce"
     ingress.kubernetes.io/custom-request-headers: "l5d-dst-override: web-svc.emojivoto.svc.cluster.local:80"
     ingress.gcp.kubernetes.io/pre-shared-cert: "managed-cert-name"
     kubernetes.io/ingress.global-static-ip-name: "static-ip-name"
 spec:
+  ingressClassName: gce
   rules:
   - host: example.com
     http:
       paths:
-      - backend:
-          serviceName: web-svc
-          servicePort: 80
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: web-svc
+            port:
+              number: 80
 ```
 
 To use this example definition, substitute `managed-cert-name` and
@@ -660,26 +685,33 @@ config:
     headers:
     - l5d-dst-override:$(headers.host).svc.cluster.local
 ---
-apiVersion: extensions/v1beta1
+# apiVersion: networking.k8s.io/v1beta1 # for k8s < v1.19
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: web-ingress
   namespace: emojivoto
   annotations:
-    kubernetes.io/ingress.class: "kong"
     konghq.com/plugins: set-l5d-header
 spec:
+  ingressClassName: kong
   rules:
-    - http:
-        paths:
-          - path: /api/vote
-            backend:
-              serviceName: web-svc
-              servicePort: http
-          - path: /api/list
-            backend:
-              serviceName: web-svc
-              servicePort: http
+  - http:
+      paths:
+      - path: /api/vote
+        pathType: Prefix
+        backend:
+          service:
+            name: web-svc
+            port:
+              number: http
+      - path: /api/list
+        pathType: Prefix
+        backend:
+          service:
+            name: web-svc
+            port:
+              name: http
 ```
 
 We are explicitly setting the `l5d-dst-override` in the `KongPlugin`. Using


### PR DESCRIPTION
Ref linkerd/linkerd2#6508

Ingress version `extensions/v1beta1` will disappear in k8s 1.22, so
this upgrades it to `networking.k8s.io/v1` alongside with other required
Ingress changes.