### PR TITLE
docs: typo gloval to global

### DIFF
--- a/linkerd.io/content/2.10/tasks/gitops.md
+++ b/linkerd.io/content/2.10/tasks/gitops.md
@@ -368,7 +368,7 @@ Now we are ready to install Linkerd. The decrypted trust anchor we just
 retrieved will be passed to the installation process using the
 `identityTrustAnchorsPEM` parameter.
 
-Prior to installing Linkerd, note that the `gloval.identityTrustAnchorsPEM`
+Prior to installing Linkerd, note that the `global.identityTrustAnchorsPEM`
 parameter is set to an "empty" certificate string:
 
 ```sh

--- a/linkerd.io/content/2.9/tasks/gitops.md
+++ b/linkerd.io/content/2.9/tasks/gitops.md
@@ -368,7 +368,7 @@ Now we are ready to install Linkerd. The decrypted trust anchor we just
 retrieved will be passed to the installation process using the
 `global.identityTrustAnchorsPEM` parameter.
 
-Prior to installing Linkerd, note that the `gloval.identityTrustAnchorsPEM`
+Prior to installing Linkerd, note that the `global.identityTrustAnchorsPEM`
 parameter is set to an "empty" certificate string:
 
 ```sh


### PR DESCRIPTION
## Description

Typo in documentation. Should be `global` instead of `gloval`.