### PR TITLE
Fix double forward slash issue in extensions json

### DIFF
--- a/linkerd.io/layouts/extensions/list.json.json
+++ b/linkerd.io/layouts/extensions/list.json.json
@@ -1,5 +1,5 @@
 {{ $data := (index site.Data "extension-list") -}}
-{{ $baseURL := site.BaseURL }}
+{{ $baseURL := (strings.TrimSuffix "/" site.BaseURL) }}
 {
   "data": [
     {{ range $index, $ext := $data.Extensions -}}


### PR DESCRIPTION
This change fixes an issue where the screenshot link for the
extensions/index.json endpoint would contain a double forward slash.
This was caused by the `list.json.json` adding a forward slash
regardless of whether the base URL did or did not already contain a
forward slash. This change now premptively strips a forward slash from
the base URL if it exists and then formats the screenshot URL correctly.

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>