### PR TITLE
Improve ingress docs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Markdown SEO Check
-        uses: zentered/markdown-seo-check@v1.1.3
+        uses: zentered/markdown-seo-check@v1.1.2
         with:
           includes: '/linkerd.io/content/**/*.md'
           max_title_length: 70

--- a/linkerd.io/content/2.10/tasks/using-ingress.md
+++ b/linkerd.io/content/2.10/tasks/using-ingress.md
@@ -458,7 +458,7 @@ spec:
 
 #### Emissary Proxy Mode
 
-By [default], Emissary uses Kubernetes DNS and [service-level discovery](https://www.getambassador.io/docs/emissary/latest/topics/running/resolvers/#kubernetes-service-level-discovery).
+By default, Emissary uses Kubernetes DNS and [service-level discovery](https://www.getambassador.io/docs/emissary/latest/topics/running/resolvers/#kubernetes-service-level-discovery).
 So, the `linkerd.io/inject` annotation can be set to `enabled` and all the
 ServiceProfile, TrafficSplit, and per-route functionality will be available. It
 is not necessary to use `ingress` mode, unless the service discovery behavior

--- a/linkerd.io/content/2.10/tasks/using-ingress.md
+++ b/linkerd.io/content/2.10/tasks/using-ingress.md
@@ -22,27 +22,14 @@ traffic and therefore will not expose per-route metrics or do traffic splitting.
 If your Ingress controller is injected with no extra configuration specific to
 ingress, the Linkerd proxy runs in the default mode.
 
-It's important to note that some ingresses, either by default or by
-configuration, can change the way that they make load balancing decisions. For
-example, the [nginx ingress controller](https://kubernetes.github.io/ingress-nginx/)
-controller includes the [`nginx.ingress.kubernetes.io/service-upstream`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#service-upstream)
-annotation. The default `false` value of this annotation adds an entry for each
-kubernetes endpoint of a pod to the `upstream` block in the nginx configuration,
-thereby informing nginx to load balance requests directly to the endpoints of a
-service.
+{{< note >}}
+Some ingresses, either by default or by configuration, can change the way that
+they make load balancing decisions.
 
-Setting this annotation to `true` configures the ingress controller to add
-_only_ the cluster IP and port of the Service resource as the single entry to
-the `upstream` block in the nginx configuration. As a result, the load balancing
-decisions are offloaded to the Linkerd proxy. With this configuration, the
-ServiceProfile and per-route metrics functionality _will_ be available with the
-annotation `linkerd.io/inject: enabled`.
-
-The `nginx.ingress.kubernetes.io/service-upstream` annotation is unique to the
-nginx ingress controller, so be sure to check the documentation for your ingress
-controller of choice. If the ingress does not use the cluster IP and port of the
-Service, then read through the next section to learn how `Proxy Ingress Mode`
-works
+The nginx ingress controller and Emissary Ingress are two options that offer
+this functionality. See the [Nginx]({{< ref "#nginx-proxy-mode-configuration" >}})
+and [Emissary]({{< ref "#emissary-proxy-mode">}}) sections below for more info
+{{< /note >}}
 
 ### Proxy Ingress Mode
 
@@ -253,6 +240,28 @@ spec:
 
 {{< /note >}}
 
+#### Nginx proxy mode configuration
+
+The [nginx ingress controller](https://kubernetes.github.io/ingress-nginx/)
+includes the [`nginx.ingress.kubernetes.io/service-upstream`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#service-upstream)
+annotation. The default `false` value of this annotation adds an entry for each
+kubernetes endpoint of a pod to the `upstream` block in the nginx configuration,
+thereby informing nginx to load balance requests directly to the endpoints of a
+service.
+
+Setting this annotation to `true` configures the ingress controller to add
+_only_ the cluster IP and port of the Service resource as the single entry to
+the `upstream` block in the nginx configuration. As a result, the load balancing
+decisions are offloaded to the Linkerd proxy. With this configuration, the
+ServiceProfile and per-route metrics functionality _will_ be available with the
+annotation `linkerd.io/inject: enabled`.
+
+The `nginx.ingress.kubernetes.io/service-upstream` annotation is unique to the
+nginx ingress controller, so be sure to check the documentation for your ingress
+controller of choice. If the ingress does not use the cluster IP and port of the
+Service, then read through the next section to learn how `Proxy Ingress Mode`
+works.
+
 ### Traefik
 
 This uses `emojivoto` as an example, take a look at
@@ -415,7 +424,7 @@ The managed certificate will take about 30-60 minutes to provision, but the
 status of the ingress should be healthy within a few minutes. Once the managed
 certificate is provisioned, the ingress should be visible to the Internet.
 
-### Ambassador
+### Ambassador (aka Emissary)
 
 This uses `emojivoto` as an example, take a look at
 [getting started](../../getting-started/) for a refresher on how to install it.
@@ -482,6 +491,15 @@ You can then use this IP with curl:
 ```bash
 curl -H "Host: example.com" http://external-ip
 ```
+
+#### Emissary Proxy Mode
+
+By [default](https://www.getambassador.io/docs/emissary/latest/topics/running/resolvers/#kubernetes-service-level-discovery),
+the Emissary ingress uses Kubernetes DNS and service-level discovery. So, the
+`linkerd.io:inject` annotation can be set to `enabled` and all the
+ServiceProfile, TrafficSplit, and per-route functionality will be available. It
+is not necessary to use `ingress` mode, unless the service discovery behavior
+of Emissary has been changed from the default.
 
 {{< note >}}
 You can also find a more detailed guide for using Linkerd with Emissary Ingress,

--- a/linkerd.io/content/2.9/tasks/using-ingress.md
+++ b/linkerd.io/content/2.9/tasks/using-ingress.md
@@ -11,6 +11,12 @@ can be run with your Ingress Controller.
 The Linkerd proxy offers two modes of operation in order to handle some of the
 more subtle behaviors of load balancing in ingress controllers.
 
+Be sure to check the documentation for your ingress controller of choice to
+understand how it resolves endpoints for load balancing. If the ingress uses
+the cluster IP and port of the Service, you can use the Default Mode described
+below. Otherwise, read through the `Proxy Ingress Mode` section to understand
+how it works.
+
 ### Default Mode
 
 When the ingress controller is injected with the `linkerd.io/inject: enabled`
@@ -241,12 +247,6 @@ decisions are offloaded to the Linkerd proxy. With this configuration, the
 ServiceProfile and per-route metrics functionality _will_ be available with the
 annotation `linkerd.io/inject: enabled`.
 
-The `nginx.ingress.kubernetes.io/service-upstream` annotation is unique to the
-nginx ingress controller, so be sure to check the documentation for your ingress
-controller of choice. If the ingress does not use the cluster IP and port of the
-Service, then read through the next section to learn how `Proxy Ingress Mode`
-works.
-
 ### Traefik
 
 This uses `emojivoto` as an example, take a look at
@@ -404,7 +404,7 @@ certificate is provisioned, the ingress should be visible to the Internet.
 This uses `emojivoto` as an example, take a look at
 [getting started](../../getting-started/) for a refresher on how to install it.
 
-Ambassador does not use `Ingress` resources, instead relying on `Service`. The
+Emissary does not use `Ingress` resources, instead relying on `Service`. The
 sample service definition is:
 
 ```yaml
@@ -422,7 +422,6 @@ metadata:
       service: http://web-svc.emojivoto.svc.cluster.local:80
       host: example.com
       prefix: /
-      add_linkerd_headers: true
 spec:
   selector:
     app: web-svc
@@ -432,23 +431,16 @@ spec:
     targetPort: http
 ```
 
-The important annotation here is:
+#### Emissary Proxy Mode
 
-```yaml
-      add_linkerd_headers: true
-```
-
-Ambassador will add a `l5d-dst-override` header to instruct Linkerd what service
-the request is destined for. This will contain both the Kubernetes service
-FQDN (`web-svc.emojivoto.svc.cluster.local`) *and* the destination
-`servicePort`.
-
-{{< note >}}
-To make this global, add `add_linkerd_headers` to your `Module` configuration.
-{{< /note >}}
+By [default], Emissary uses Kubernetes DNS and [service-level discovery](https://www.getambassador.io/docs/emissary/latest/topics/running/resolvers/#kubernetes-service-level-discovery).
+So, the `linkerd.io/inject` annotation can be set to `enabled` and all the
+ServiceProfile, TrafficSplit, and per-route functionality will be available. It
+is not necessary to use `ingress` mode, unless the service discovery behavior
+of Emissary has been changed from the default.
 
 To test this, you'll want to get the external IP address for your controller. If
-you installed Ambassador via helm, you can get that IP address by running:
+you installed Emissary via helm, you can get that IP address by running:
 
 ```bash
 kubectl get svc --all-namespaces \
@@ -466,15 +458,6 @@ You can then use this IP with curl:
 ```bash
 curl -H "Host: example.com" http://external-ip
 ```
-
-#### Emissary Proxy Mode
-
-By [default](https://www.getambassador.io/docs/emissary/latest/topics/running/resolvers/#kubernetes-service-level-discovery),
-the Emissary ingress uses Kubernetes DNS and service-level discovery. So, the
-`linkerd.io:inject` annotation can be set to `enabled` and all the
-ServiceProfile, TrafficSplit, and per-route functionality will be available. It
-is not necessary to use `ingress` mode, unless the service discovery behavior
-of Emissary has been changed from the default.
 
 {{< note >}}
 You can also find a more detailed guide for using Linkerd with Emissary Ingress,

--- a/linkerd.io/content/2.9/tasks/using-ingress.md
+++ b/linkerd.io/content/2.9/tasks/using-ingress.md
@@ -6,7 +6,12 @@ description = "Linkerd works alongside your ingress controller of choice."
 As of Linkerd version 2.9, there are two ways in which the Linkerd proxy
 can be run with your Ingress Controller.
 
-## Default Mode
+## Proxy Modes
+
+The Linkerd proxy offers two modes of operation in order to handle some of the
+more subtle behaviors of load balancing in ingress controllers.
+
+### Default Mode
 
 When the ingress controller is injected with the `linkerd.io/inject: enabled`
 annotation, the Linkerd proxy will honor load balancing decisions made by the
@@ -17,7 +22,29 @@ traffic and therefore will not expose per-route metrics or do traffic splitting.
 If your Ingress controller is injected with no extra configuration specific to
 ingress, the Linkerd proxy runs in the default mode.
 
-## Proxy Ingress Mode
+t's important to note that some ingresses, either by default or by
+configuration, can change the way that they make load balancing decisions. For
+example, the [nginx ingress controller](https://kubernetes.github.io/ingress-nginx/)
+controller includes the [`nginx.ingress.kubernetes.io/service-upstream`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#service-upstream)
+annotation. The default `false` value of this annotation adds an entry for each
+kubernetes endpoint of a pod to the `upstream` block in the nginx configuration,
+thereby informing nginx to load balance requests directly to the endpoints of a
+service.
+
+Setting this annotation to `true` configures the ingress controller to add
+_only_ the cluster IP and port of the Service resource as the single entry to
+the `upstream` block in the nginx configuration. As a result, the load balancing
+decisions are offloaded to the Linkerd proxy. With this configuration, the
+ServiceProfile and per-route metrics functionality _will_ be available with the
+annotation `linkerd.io/inject: enabled`.
+
+The `nginx.ingress.kubernetes.io/service-upstream` annotation is unique to the
+nginx ingress controller, so be sure to check the documentation for your ingress
+controller of choice. If the ingress does not use the cluster IP and port of the
+Service, then read through the next section to learn how `Proxy Ingress Mode`
+works.
+
+### Proxy Ingress Mode
 
 If you want Linkerd functionality like Service Profiles, Traffic Splits, etc,
 there is additional configuration required to make the Ingress controller's Linkerd

--- a/linkerd.io/content/2.9/tasks/using-ingress.md
+++ b/linkerd.io/content/2.9/tasks/using-ingress.md
@@ -433,7 +433,7 @@ spec:
 
 #### Emissary Proxy Mode
 
-By [default], Emissary uses Kubernetes DNS and [service-level discovery](https://www.getambassador.io/docs/emissary/latest/topics/running/resolvers/#kubernetes-service-level-discovery).
+By default, Emissary uses Kubernetes DNS and [service-level discovery](https://www.getambassador.io/docs/emissary/latest/topics/running/resolvers/#kubernetes-service-level-discovery).
 So, the `linkerd.io/inject` annotation can be set to `enabled` and all the
 ServiceProfile, TrafficSplit, and per-route functionality will be available. It
 is not necessary to use `ingress` mode, unless the service discovery behavior

--- a/linkerd.io/content/2.9/tasks/using-ingress.md
+++ b/linkerd.io/content/2.9/tasks/using-ingress.md
@@ -22,27 +22,14 @@ traffic and therefore will not expose per-route metrics or do traffic splitting.
 If your Ingress controller is injected with no extra configuration specific to
 ingress, the Linkerd proxy runs in the default mode.
 
-t's important to note that some ingresses, either by default or by
-configuration, can change the way that they make load balancing decisions. For
-example, the [nginx ingress controller](https://kubernetes.github.io/ingress-nginx/)
-controller includes the [`nginx.ingress.kubernetes.io/service-upstream`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#service-upstream)
-annotation. The default `false` value of this annotation adds an entry for each
-kubernetes endpoint of a pod to the `upstream` block in the nginx configuration,
-thereby informing nginx to load balance requests directly to the endpoints of a
-service.
+{{< note >}}
+Some ingresses, either by default or by configuration, can change the way that
+they make load balancing decisions.
 
-Setting this annotation to `true` configures the ingress controller to add
-_only_ the cluster IP and port of the Service resource as the single entry to
-the `upstream` block in the nginx configuration. As a result, the load balancing
-decisions are offloaded to the Linkerd proxy. With this configuration, the
-ServiceProfile and per-route metrics functionality _will_ be available with the
-annotation `linkerd.io/inject: enabled`.
-
-The `nginx.ingress.kubernetes.io/service-upstream` annotation is unique to the
-nginx ingress controller, so be sure to check the documentation for your ingress
-controller of choice. If the ingress does not use the cluster IP and port of the
-Service, then read through the next section to learn how `Proxy Ingress Mode`
-works.
+The nginx ingress controller and Emissary Ingress are two options that offer
+this functionality. See the [Nginx]({{< ref "#nginx-proxy-mode-configuration" >}})
+and [Emissary]({{< ref "#emissary-proxy-mode">}}) sections below for more info
+{{< /note >}}
 
 ### Proxy Ingress Mode
 
@@ -238,6 +225,28 @@ spec:
 
 {{< /note >}}
 
+#### Nginx proxy mode configuration
+
+The [nginx ingress controller](https://kubernetes.github.io/ingress-nginx/)
+includes the [`nginx.ingress.kubernetes.io/service-upstream`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#service-upstream)
+annotation. The default `false` value of this annotation adds an entry for each
+kubernetes endpoint of a pod to the `upstream` block in the nginx configuration,
+thereby informing nginx to load balance requests directly to the endpoints of a
+service.
+
+Setting this annotation to `true` configures the ingress controller to add
+_only_ the cluster IP and port of the Service resource as the single entry to
+the `upstream` block in the nginx configuration. As a result, the load balancing
+decisions are offloaded to the Linkerd proxy. With this configuration, the
+ServiceProfile and per-route metrics functionality _will_ be available with the
+annotation `linkerd.io/inject: enabled`.
+
+The `nginx.ingress.kubernetes.io/service-upstream` annotation is unique to the
+nginx ingress controller, so be sure to check the documentation for your ingress
+controller of choice. If the ingress does not use the cluster IP and port of the
+Service, then read through the next section to learn how `Proxy Ingress Mode`
+works.
+
 ### Traefik
 
 This uses `emojivoto` as an example, take a look at
@@ -390,7 +399,7 @@ The managed certificate will take about 30-60 minutes to provision, but the
 status of the ingress should be healthy within a few minutes. Once the managed
 certificate is provisioned, the ingress should be visible to the Internet.
 
-### Ambassador
+### Ambassador (aka Emissary)
 
 This uses `emojivoto` as an example, take a look at
 [getting started](../../getting-started/) for a refresher on how to install it.
@@ -457,6 +466,20 @@ You can then use this IP with curl:
 ```bash
 curl -H "Host: example.com" http://external-ip
 ```
+
+#### Emissary Proxy Mode
+
+By [default](https://www.getambassador.io/docs/emissary/latest/topics/running/resolvers/#kubernetes-service-level-discovery),
+the Emissary ingress uses Kubernetes DNS and service-level discovery. So, the
+`linkerd.io:inject` annotation can be set to `enabled` and all the
+ServiceProfile, TrafficSplit, and per-route functionality will be available. It
+is not necessary to use `ingress` mode, unless the service discovery behavior
+of Emissary has been changed from the default.
+
+{{< note >}}
+You can also find a more detailed guide for using Linkerd with Emissary Ingress,
+AKA Ambassador, from the folks over at Buoyant [here](https://buoyant.io/2021/05/24/emissary-and-linkerd-the-best-of-both-worlds/).
+{{< /note >}}
 
 ### Gloo
 


### PR DESCRIPTION
Fixes #1030 

* Added documentation describing the `nginx.ingress.kubernetes.io/service-upstream` annotation
* Added section advising users to review available configuration for their ingress controller before recommending `Proxy Ingress Mode`
* Cleaned up Kong formatting

Signed-off-by: Charles Pretzer <charles@buoyant.io>