### PR TITLE
Fix broken links in install scripts, add redirect

### DIFF
--- a/linkerd.io/content/2.10/tasks/_index.md
+++ b/linkerd.io/content/2.10/tasks/_index.md
@@ -1,6 +1,9 @@
 +++
 title = "Tasks"
 weight = 4
+aliases = [
+  "./next-steps/"
+]
 +++
 
 As a complement to the [Linkerd feature docs]({{% ref "../features" %}}) and

--- a/linkerd.io/content/2.10/tasks/exposing-dashboard.md
+++ b/linkerd.io/content/2.10/tasks/exposing-dashboard.md
@@ -1,6 +1,9 @@
 +++
 title = "Exposing the Dashboard"
 description = "Make it easy for others to access Linkerd and Grafana dashboards without the CLI."
+aliases = [
+  "../dns-rebinding/",
+]
 +++
 
 Instead of using `linkerd viz dashboard` every time you'd like to see what's

--- a/linkerd.io/content/2.10/tasks/securing-your-cluster.md
+++ b/linkerd.io/content/2.10/tasks/securing-your-cluster.md
@@ -1,6 +1,9 @@
 +++
 title = "Securing Your Cluster"
 description = "Best practices for securing your Linkerd installation."
+aliases = [
+  "../tap-rbac/",
+]
 +++
 
 Linkerd provides powerful introspection into your Kubernetes cluster and

--- a/linkerd.io/static/next-steps/index.html
+++ b/linkerd.io/static/next-steps/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=https://linkerd.io/2.10/tasks/">
+    <script type="text/javascript">
+    window.onload = function() {
+      window.location.href = window.location.origin + "/2.10/tasks/" + window.location.hash;
+    }
+    </script>
+    <title>Linkerd Tasks Redirection</title>
+  </head>
+  <body>
+    If you are not redirected automatically, follow this
+    <a href='https://linkerd.io/2.10/tasks/'>link</a>.
+  </body>
+</html>

--- a/run.linkerd.io/public/install
+++ b/run.linkerd.io/public/install
@@ -18,7 +18,7 @@ happyexit() {
   echo "  linkerd check                           # validate everything worked!"
   echo "  linkerd dashboard                       # launch the dashboard"
   echo ""
-  echo "Looking for more? Visit https://linkerd.io/2.10/next-steps"
+  echo "Looking for more? Visit https://linkerd.io/2/tasks"
   echo ""
   exit 0
 }

--- a/run.linkerd.io/public/install-edge
+++ b/run.linkerd.io/public/install-edge
@@ -23,7 +23,7 @@ happyexit() {
   echo "  linkerd viz check                         # validate the extension works!"
   echo "  linkerd viz dashboard                     # launch the dashboard"
   echo ""
-  echo "Looking for more? Visit https://linkerd.io/2.10/next-steps"
+  echo "Looking for more? Visit https://linkerd.io/2/tasks"
   echo ""
   exit 0
 }


### PR DESCRIPTION
The stable and edge install scripts were referencing a broken link:
https://linkerd.io/2.10/next-steps

Modify the scripts to instead reference:
https://linkerd.io/2/tasks

Also, introduce a redirect from `/next-steps` to `/tasks`.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>