### PR TITLE
chore: update markdown check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,7 +1,7 @@
 name: check
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - linkerd.io/**
 
@@ -11,10 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Markdown SEO Check
-        uses: zentered/markdown-seo-check@v1.1.2
+        uses: zentered/markdown-seo-check@v1.1.4
         with:
           includes: '/linkerd.io/content/**/*.md'
           max_title_length: 70


### PR DESCRIPTION
there were some breaking changes in @actions/github that I missed. `pull_request` should suffice here.