### PR TITLE
Rollback to markdown seo v1.1.2

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Markdown SEO Check
-        uses: zentered/markdown-seo-check@v1.1.4
+        uses: zentered/markdown-seo-check@v1.1.2
         with:
           includes: '/linkerd.io/content/**/*.md'
           max_title_length: 70


### PR DESCRIPTION
* Update check.yml action to use [markdown-seo-check](https://github.com/zentered/markdown-seo-check) v1.1.2

Signed-off-by: Charles Pretzer <charles@buoyant.io>