### PR TITLE
Marketing tags cleanup

### DIFF
--- a/linkerd.io/layouts/partials/meta.html
+++ b/linkerd.io/layouts/partials/meta.html
@@ -23,12 +23,3 @@
 <link rel="canonical" href="{{ . }}" />
 {{ end }}
 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-  ga('create', 'UA-60040560-2', 'auto');
-  ga('send', 'pageview');
-</script>
-

--- a/linkerd.io/themes/buoyant/layouts/_default/baseof.html
+++ b/linkerd.io/themes/buoyant/layouts/_default/baseof.html
@@ -10,7 +10,7 @@
 <body class="has-background-grey-light">
   {{ if not .Site.IsServer }}
   <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KHF5SSN" height="0" width="0"
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PXBDGKJ" height="0" width="0"
       style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
   {{ end }}

--- a/linkerd.io/themes/buoyant/layouts/partials/head.html
+++ b/linkerd.io/themes/buoyant/layouts/partials/head.html
@@ -23,14 +23,11 @@
 
 {{ if not .Site.IsServer }}
 <!-- Google Tag Manager -->
-<script>(function (w, d, s, l, i) {
-    w[l] = w[l] || []; w[l].push({
-      'gtm.start':
-        new Date().getTime(), event: 'gtm.js'
-    }); var f = d.getElementsByTagName(s)[0],
-      j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
-        'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
-  })(window, document, 'script', 'dataLayer', 'GTM-KHF5SSN');</script>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-PXBDGKJ');</script>
 <!-- End Google Tag Manager -->
 
 <script>


### PR DESCRIPTION
- Removed Universal Analytics tag `UA-60040560-2`
- Replaced Google Tag Manager tag `GTM-KHF5SSN` with `GTM-PXBDGKJ` which
  is solely for linkerd.io and is not shared with buoyant.io. Also note
  this new tag will add the tag `UA-60040560-2` automatically.