### PR TITLE
add Buoyant training offering

### DIFF
--- a/linkerd.io/content/support-training.md
+++ b/linkerd.io/content/support-training.md
@@ -18,18 +18,17 @@ support:
       thumbnail: "/uploads/linux-foundation-logo.svg"
       title: The Linux Foundation
       url: https://www.edx.org/course/introduction-to-service-mesh-with-linkerd
-    - description: Introduction to Kubernetes | edx
-      thumbnail: "/uploads/linux-foundation-logo.svg"
-      title: The Linux Foundation
-      url: https://www.edx.org/course/introduction-to-kubernetes
+    - description: Hands-on, instructor-led service mesh training from the creators of the Linkerd
+      url: https://buoyant.io/linkerd-training/
+      title: Buoyant
+      thumbnail: "/uploads/buoyant_logo_icon-only_primary.svg"
   - title: 'Commercial support'
     entries:
-    - description: Buoyant is the original creator of Linkerd and provides support, training, and enterprise products.
+    - description: 24x7 oncall, training, architectural review, and more, straight from the creators of Linkerd.
       thumbnail: "/uploads/buoyant_logo_icon-only_primary.svg"
       title: Buoyant
       url: https://buoyant.io/linkerd-support/
-
-  bottom_description: Offering Linkerd support? Add your company!
+  bottom_description: Offering Linkerd support or training? Add your company!
   description: ''
   buttons:
   - caption: Edit this page

--- a/linkerd.io/layouts/partials/enterprise/support.html
+++ b/linkerd.io/layouts/partials/enterprise/support.html
@@ -6,7 +6,7 @@
     <div class="columns jobs-list is-multiline">
       {{ range .entries }}
       <div class="column is-half job-item">
-        <a class="has-text-color box-link" href="{{ .url }}">
+        <a class="has-text-color box-link" href="{{ .url }}" target="_blank">
           <div class="box">
             <article class="media">
               <div class="media-left">


### PR DESCRIPTION
* Add Buoyant training course signup to training & support page.
* Remove Kubernetes course. Not sure why that would be on a Linkerd page.
* target=_blank for external links

Signed-off-by: William Morgan <william@buoyant.io>