### PR TITLE
Fix doc about disabling dashboard host header check

### DIFF
--- a/linkerd.io/content/2.10/tasks/exposing-dashboard.md
+++ b/linkerd.io/content/2.10/tasks/exposing-dashboard.md
@@ -240,8 +240,8 @@ spec:
             - -enforced-host=^dashboard\.example\.com$
 ```
 
-If you want to completely disable the `Host` header check, use an empty string
-for `-enforced-host`.
+If you want to completely disable the `Host` header check, simply use a
+catch-all regexp `.*` for `-enforced-host`.
 
 [nginx-auth]:
 https://github.com/kubernetes/ingress-nginx/blob/master/docs/examples/auth/basic/README.md


### PR DESCRIPTION
Fixes linkerd/linkerd2#6969

Using an empty string for `enforceHostRegexp` doesn't disable that
check; it just falls back to the default of checking against the default
`^(localhost|127\.0\.0\.1|web.linkerd-viz.svc.cluster.local|web.linkerd-viz.svc|\[::1\])(:\d+)?$`.
So we just fix the docs saying if you wanna disable this check , just
use a catch-all regex `.*`.