### PR TITLE
add emojivoto policy manifest

### DIFF
--- a/run.linkerd.io/public/emojivoto-policy.yml
+++ b/run.linkerd.io/public/emojivoto-policy.yml
@@ -27,9 +27,7 @@ metadata:
 spec:
   # Allow all authenticated clients to access the (read-only) emoji service.
   server:
-    selector:
-      matchLabels:
-        app.kubernetes.io/part-of: emojivoto
+    name: emoji-grpc
   client:
     meshTLS:
       identities:

--- a/run.linkerd.io/public/emojivoto-policy.yml
+++ b/run.linkerd.io/public/emojivoto-policy.yml
@@ -1,0 +1,135 @@
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: Server
+metadata:
+  namespace: emojivoto
+  name: emoji-grpc
+  labels:
+    app.kubernetes.io/part-of: emojivoto
+    app.kubernetes.io/name: emoji
+    app.kubernetes.io/version: v11
+spec:
+  podSelector:
+    matchLabels:
+      app: emoji-svc
+  port: grpc
+  proxyProtocol: gRPC
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: ServerAuthorization
+metadata:
+  namespace: emojivoto
+  name: emoji-grpc
+  labels:
+    app.kubernetes.io/part-of: emojivoto
+    app.kubernetes.io/name: emoji
+    app.kubernetes.io/version: v11
+spec:
+  # Allow all authenticated clients to access the (read-only) emoji service.
+  server:
+    selector:
+      matchLabels:
+        app.kubernetes.io/part-of: emojivoto
+  client:
+    meshTLS:
+      identities:
+        - "*.emojivoto.serviceaccount.identity.*"
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: Server
+metadata:
+  namespace: emojivoto
+  name: prom
+  labels:
+    app.kubernetes.io/part-of: emojivoto
+    app.kubernetes.io/version: v11
+spec:
+  port: prom
+  podSelector:
+    matchExpressions:
+      - {key: app, operator: In, values: [emoji-svc, web-svc, voting-svc]}
+  proxyProtocol: HTTP/1
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: ServerAuthorization
+metadata:
+  namespace: emojivoto
+  name: prom-prometheus
+  labels:
+    app.kubernetes.io/part-of: emojivoto
+    app.kubernetes.io/version: v11
+spec:
+  server:
+    name: prom
+  client:
+    # allow any kind of prometheus scrapes i.e meshed and unmeshed
+    unauthenticated: true
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: Server
+metadata:
+  namespace: emojivoto
+  name: voting-grpc
+  labels:
+    app: voting-svc
+spec:
+  podSelector:
+    matchLabels:
+      app: voting-svc
+  port: grpc
+  proxyProtocol: gRPC
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: ServerAuthorization
+metadata:
+  namespace: emojivoto
+  name: voting-grpc
+  labels:
+    app.kubernetes.io/part-of: emojivoto
+    app.kubernetes.io/name: voting
+    app.kubernetes.io/version: v11
+spec:
+  server:
+    name: voting-grpc
+  # The voting service only allows requests from the web service.
+  client:
+    meshTLS:
+      serviceAccounts:
+        - name: web
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: Server
+metadata:
+  namespace: emojivoto
+  name: web-http
+  labels:
+    app.kubernetes.io/part-of: emojivoto
+    app.kubernetes.io/name: web
+    app.kubernetes.io/version: v11
+spec:
+  podSelector:
+    matchLabels:
+      app: web-svc
+  port: http
+  proxyProtocol: HTTP/1
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: ServerAuthorization
+metadata:
+  namespace: emojivoto
+  name: web-public
+  labels:
+    app.kubernetes.io/part-of: emojivoto
+    app.kubernetes.io/name: web
+    app.kubernetes.io/version: v11
+spec:
+  server:
+    name: web-http
+  # Allow all clients to access the web HTTP port without regard for
+  # authentication. If unauthenticated connections are permitted, there is no
+  # need to describe authenticated clients.
+  client:
+    unauthenticated: true
+    networks:
+      - cidr: 0.0.0.0/0
+      - cidr: ::/0

--- a/run.linkerd.io/public/emojivoto-policy.yml
+++ b/run.linkerd.io/public/emojivoto-policy.yml
@@ -33,7 +33,7 @@ spec:
   client:
     meshTLS:
       identities:
-        - "*.emojivoto.serviceaccount.identity.*"
+        - "*.emojivoto.serviceaccount.identity.linkerd.cluster.local"
 ---
 apiVersion: policy.linkerd.io/v1alpha1
 kind: Server


### PR DESCRIPTION
This PR adds a new file under `run.linkerd.io` to have a
`emojivoto` policy manifest, that is maintained and updated
based on the changes from `emojivoto.yml` manifest here.

This will make it possible to access the policy manifest from
`run.linkerd.io/emojivoto-policy.yml`

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>