### PR TITLE
Simplify emojivoto policy example

### DIFF
--- a/run.linkerd.io/public/emojivoto-policy.yml
+++ b/run.linkerd.io/public/emojivoto-policy.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: policy.linkerd.io/v1alpha1
+apiVersion: policy.linkerd.io/v1beta1
 kind: Server
 metadata:
   namespace: emojivoto
@@ -16,7 +16,7 @@ spec:
   port: grpc
   proxyProtocol: gRPC
 ---
-apiVersion: policy.linkerd.io/v1alpha1
+apiVersion: policy.linkerd.io/v1beta1
 kind: Server
 metadata:
   namespace: emojivoto
@@ -33,7 +33,7 @@ spec:
         values: [emoji-svc, web-svc, voting-svc]
   proxyProtocol: HTTP/1
 ---
-apiVersion: policy.linkerd.io/v1alpha1
+apiVersion: policy.linkerd.io/v1beta1
 kind: ServerAuthorization
 metadata:
   namespace: emojivoto
@@ -48,7 +48,7 @@ spec:
     # allow any kind of prometheus scrapes i.e meshed and unmeshed
     unauthenticated: true
 ---
-apiVersion: policy.linkerd.io/v1alpha1
+apiVersion: policy.linkerd.io/v1beta1
 kind: Server
 metadata:
   namespace: emojivoto
@@ -63,7 +63,7 @@ spec:
   port: grpc
   proxyProtocol: gRPC
 ---
-apiVersion: policy.linkerd.io/v1alpha1
+apiVersion: policy.linkerd.io/v1beta1
 kind: ServerAuthorization
 metadata:
   namespace: emojivoto
@@ -83,7 +83,7 @@ spec:
       serviceAccounts:
         - name: web
 ---
-apiVersion: policy.linkerd.io/v1alpha1
+apiVersion: policy.linkerd.io/v1beta1
 kind: Server
 metadata:
   namespace: emojivoto
@@ -99,7 +99,7 @@ spec:
   port: http
   proxyProtocol: HTTP/1
 ---
-apiVersion: policy.linkerd.io/v1alpha1
+apiVersion: policy.linkerd.io/v1beta1
 kind: ServerAuthorization
 metadata:
   namespace: emojivoto

--- a/run.linkerd.io/public/emojivoto-policy.yml
+++ b/run.linkerd.io/public/emojivoto-policy.yml
@@ -8,30 +8,13 @@ metadata:
     app.kubernetes.io/part-of: emojivoto
     app.kubernetes.io/name: emoji
     app.kubernetes.io/version: v11
+    emojivoto/api: internal-grpc
 spec:
   podSelector:
     matchLabels:
       app: emoji-svc
   port: grpc
   proxyProtocol: gRPC
----
-apiVersion: policy.linkerd.io/v1alpha1
-kind: ServerAuthorization
-metadata:
-  namespace: emojivoto
-  name: emoji-grpc
-  labels:
-    app.kubernetes.io/part-of: emojivoto
-    app.kubernetes.io/name: emoji
-    app.kubernetes.io/version: v11
-spec:
-  # Allow all authenticated clients to access the (read-only) emoji service.
-  server:
-    name: emoji-grpc
-  client:
-    meshTLS:
-      identities:
-        - "*.emojivoto.serviceaccount.identity.linkerd.cluster.local"
 ---
 apiVersion: policy.linkerd.io/v1alpha1
 kind: Server
@@ -45,7 +28,9 @@ spec:
   port: prom
   podSelector:
     matchExpressions:
-      - {key: app, operator: In, values: [emoji-svc, web-svc, voting-svc]}
+      - key: app
+        operator: In
+        values: [emoji-svc, web-svc, voting-svc]
   proxyProtocol: HTTP/1
 ---
 apiVersion: policy.linkerd.io/v1alpha1
@@ -70,6 +55,7 @@ metadata:
   name: voting-grpc
   labels:
     app: voting-svc
+    emojivoto/api: internal-grpc
 spec:
   podSelector:
     matchLabels:
@@ -81,15 +67,17 @@ apiVersion: policy.linkerd.io/v1alpha1
 kind: ServerAuthorization
 metadata:
   namespace: emojivoto
-  name: voting-grpc
+  name: internal-grpc
   labels:
     app.kubernetes.io/part-of: emojivoto
-    app.kubernetes.io/name: voting
     app.kubernetes.io/version: v11
 spec:
+  # Matches all servers marked as `internal-grpc` (emoji and voting) and allows authenticated
+  # requests only from the web service.
   server:
-    name: voting-grpc
-  # The voting service only allows requests from the web service.
+    selector:
+      matchLabels:
+        emojivoto/api: internal-grpc
   client:
     meshTLS:
       serviceAccounts:


### PR DESCRIPTION
The example emojivoto policy was intially written to exercise a variety
of policy functionality, but isn't actually how we'd write policies for
emojivoto. Furthermore, because it uses an identity glob, it cannot work
in clusters with custom domains.

In order to make the example more representative of how policy would
actually be applied, this change unifies the emoji and voting
authorizations to a single authorization, `internal-grpc`, that selects
both the voting and emoji server by selector.