### PR TITLE
Add `theme-color` headers

### DIFF
--- a/linkerd.io/layouts/partials/meta.html
+++ b/linkerd.io/layouts/partials/meta.html
@@ -1,6 +1,7 @@
 <meta charset="utf-8"/>
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<meta name="theme-color" content="#001e64" />
 
 {{ if eq .Section "1" }}
 <meta name="robots" content="noindex">


### PR DESCRIPTION
The `<meta name="theme-color" content="..." />` pragma is used by
browsers to configure how the window should be decorated.  See
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color

This change adds this directive to our meta.html template with a
hardcoded value that matches our header's background color. It seems
like we should be able to obtain this value from a template expression,
but I'm not sure how to do that.