### PR TITLE
Add minimum supported version

### DIFF
--- a/linkerd.io/content/2.11/tasks/upgrade.md
+++ b/linkerd.io/content/2.11/tasks/upgrade.md
@@ -192,11 +192,11 @@ channel in the [Linkerd slack](https://slack.linkerd.io/).
 
 ## Upgrade notice: stable-2.11.0
 
-There are two breaking changes in the 2.11.0 release: pods in `ingress` no
-longer support non-HTTP traffic to meshed workloads; and the proxy no longer
-forwards traffic to ports that are bound only to localhost. Additionally, users
-of the multi-cluster extension will need to re-link their cluster after
-upgrading.
+The minimum Kubernetes version supported is `v1.17.0`. There are two breaking
+changes in the 2.11.0 release: pods in `ingress` no longer support non-HTTP
+traffic to meshed workloads; and the proxy no longer forwards traffic to ports
+that are bound only to localhost. Additionally, users of the multi-cluster
+extension will need to re-link their cluster after upgrading.
 
 ### Control plane changes
 


### PR DESCRIPTION
In `2.11` we are making use of the downstream API to get pod IPs. This feature is supported in k8s `v1.17.x +`, added a line to the upgrade breaking changes to let users know.

Signed-off-by: Matei David <matei@buoyant.io>