### PR TITLE
Correct checksum on installation

### DIFF
--- a/run.linkerd.io/public/install
+++ b/run.linkerd.io/public/install
@@ -34,7 +34,7 @@ validate_checksum() {
       checksum=$($checksumbin dgst -sha256 "${filename}" | sed -e 's/^.* //')
       ;;
     *shasum)
-      checksum=$($checksumbin -a256 "${filename}" | sed -e 's/^.* //')
+      checksum=$($checksumbin -a256 "${filename}" | sed -e 's/ .*$//')
       ;;
   esac
 

--- a/run.linkerd.io/public/install-edge
+++ b/run.linkerd.io/public/install-edge
@@ -39,7 +39,7 @@ validate_checksum() {
       checksum=$($checksumbin dgst -sha256 "${filename}" | sed -e 's/^.* //')
       ;;
     *shasum)
-      checksum=$($checksumbin -a256 "${filename}" | sed -e 's/^.* //')
+      checksum=$($checksumbin -a256 "${filename}" | sed -e 's/ .*$//')
       ;;
   esac
 


### PR DESCRIPTION
The program shasum generates output in the following
format: `hash filename` and current scripts was
considering the filename as the hash.

Changed the regex to strip the filename and keep the hash.

Fixes linkerd/linkerd2#7202