### PR TITLE
Fix Helm example commands

### DIFF
--- a/linkerd.io/content/2.11/features/cni.md
+++ b/linkerd.io/content/2.11/features/cni.md
@@ -57,7 +57,7 @@ First ensure that your Helm local cache is updated:
 
 ```bash
 helm repo update
-helm search linkerd2-cni
+helm search repo linkerd2-cni
 ```
 
 Install the CNI DaemonSet:

--- a/linkerd.io/content/2.11/tasks/install-helm.md
+++ b/linkerd.io/content/2.11/tasks/install-helm.md
@@ -119,7 +119,7 @@ Make sure your local Helm repos are updated:
 ```bash
 helm repo update
 
-helm search linkerd2 -v {{% latestversion %}}
+helm search repo linkerd2
 NAME                    CHART VERSION          APP VERSION            DESCRIPTION
 linkerd/linkerd2        <chart-semver-version> {{% latestversion %}}    Linkerd gives you observability, reliability, and securit...
 ```


### PR DESCRIPTION
The `helm search` command is deprecated in favor of `helm search repo`.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>