### PR TITLE
A few versioning improvements before branching off the 2.12 docs

### DIFF
--- a/linkerd.io/config.toml
+++ b/linkerd.io/config.toml
@@ -118,6 +118,7 @@ description = "Linkerd is an ultralight service mesh for Kubernetes. It gives yo
 images = [""]
 latest_release_date = "2020-06-10"
 latest_release_version = "1.7.4"
+latest_linkerd2_stable_version = "2.11"
 logo = "/images/identity/svg/linkerd_primary_color_white.svg"
 [permalinks]
 blog = "/:year/:month/:day/:slug/"

--- a/linkerd.io/content/2.11/reference/iptables.md
+++ b/linkerd.io/content/2.11/reference/iptables.md
@@ -39,7 +39,7 @@ The packet will arrive on the `PREROUTING` chain and will be immediately routed
 to the redirect chain. If its destination port matches any of the inbound ports
 to skip, then it will be forwarded directly to the application process,
 _bypassing the proxy_. The list of destination ports to check against can be
-[configured when installing Linkerd](/2.11/reference/cli/install/#). If the
+[configured when installing Linkerd](../cli/install/#). If the
 packet does not match any of the ports in the list, it will be redirected
 through the proxy. Redirection is done by changing the incoming packet's
 destination header, the target port will be replaced with `4143`, which is the

--- a/linkerd.io/content/2.11/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.11/tasks/distributed-tracing.md
@@ -206,6 +206,7 @@ on port 14250.
 The YAML file is merged with the [Helm values.yaml][helm-values] which shows
 other possible values that can be configured.
 
+<!-- markdownlint-disable MD034 -->
 [helm-values]: https://github.com/linkerd/linkerd2/blob/stable-{{% latest-linkerd2-stable-version %}}.0/jaeger/charts/linkerd-jaeger/values.yaml
 
 It is also possible to manually edit the OpenCensus configuration to have it

--- a/linkerd.io/content/2.11/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.11/tasks/distributed-tracing.md
@@ -206,7 +206,7 @@ on port 14250.
 The YAML file is merged with the [Helm values.yaml][helm-values] which shows
 other possible values that can be configured.
 
-[helm-values]: https://github.com/linkerd/linkerd2/blob/stable-2.11.0/jaeger/charts/linkerd-jaeger/values.yaml
+[helm-values]: https://github.com/linkerd/linkerd2/blob/stable-{{% latest-linkerd2-stable-version %}}.0/jaeger/charts/linkerd-jaeger/values.yaml
 
 It is also possible to manually edit the OpenCensus configuration to have it
 export to any backend which it supports. See the

--- a/linkerd.io/content/2.11/tasks/multicluster-using-statefulsets.md
+++ b/linkerd.io/content/2.11/tasks/multicluster-using-statefulsets.md
@@ -30,8 +30,8 @@ on how multi-cluster support for headless services work, check out
   local clusters.
 - [`smallstep/CLI`](https://github.com/smallstep/cli/releases) to generate
   certificates for Linkerd installation.
-- [`linkerd:stable-2.11.0`](https://github.com/linkerd/linkerd2/releases) to
-  install Linkerd.
+- [`A recent linkerd release`](https://github.com/linkerd/linkerd2/releases)
+  (2.11 or older).
 
 To help with cluster creation and installation, there is a demo repository
 available. Throughout the guide, we will be using the scripts from the

--- a/linkerd.io/content/_index.md
+++ b/linkerd.io/content/_index.md
@@ -9,7 +9,7 @@ top_hero:
   image: "/uploads/image-15.png"
   buttons:
   - caption: Get Started
-    url: "/2.11/getting-started/"
+    url: "/getting-started/"
   - caption: Get Involved
     url: "/community/get-involved/"
   image_on_the_right: false

--- a/linkerd.io/content/design-principles/_index.md
+++ b/linkerd.io/content/design-principles/_index.md
@@ -29,30 +29,32 @@ mean that Linkerd can't have powerful features, or that it has to have
 one-click wizards take care of everything for you. In fact, it means the
 opposite: every aspect of Linkerd's behavior should be explicit, clear,
 well-defined, bounded, understandable, and introspectable. For example,
-Linkerd's [control plane](/{{% latest-linkerd2-stable-version %}}/reference/architecture/#control-plane) is split
-into several operational components based on their functional boundaries
-("web”, "api”, etc.) These components aren't just exposed directly to you in
-the Linkerd dashboard and CLI, they run on the same data plane as your
-application does, allowing you to use the same tooling to inspect their
-behavior.
+Linkerd's [control plane](/{{% latest-linkerd2-stable-version
+%}}/reference/architecture/#control-plane) is split into several operational
+components based on their functional boundaries ("web”, "api”, etc.) These
+components aren't just exposed directly to you in the Linkerd dashboard and CLI,
+they run on the same data plane as your application does, allowing you to use
+the same tooling to inspect their behavior.
 
 _Minimize resource requirements_ means that Linkerd, and especially Linkerd's
-[data plane proxies](/{{% latest-linkerd2-stable-version %}}/reference/architecture/#data-plane), should consume the
-smallest amount of memory and CPU possible. On the control plane side, we've
-taken care to ensure that components scale gracefully in the presence of
-traffic. On the data plane side, we've build Linkerd's proxy (called simply
-"linkerd-proxy”) for performance, safety, and low resource consumption. Today,
-a single linkerd-proxy instance can proxy many thousands of requests per second
-in under 10mb of memory and a quarter of a core, all with a p99 tail latency of
-under 1ms. In the future, we can probably improve even that!
+[data plane proxies](/{{% latest-linkerd2-stable-version
+%}}/reference/architecture/#data-plane), should consume the smallest amount of
+memory and CPU possible. On the control plane side, we've taken care to ensure
+that components scale gracefully in the presence of traffic. On the data plane
+side, we've build Linkerd's proxy (called simply "linkerd-proxy”) for
+performance, safety, and low resource consumption. Today, a single linkerd-proxy
+instance can proxy many thousands of requests per second in under 10mb of memory
+and a quarter of a core, all with a p99 tail latency of under 1ms. In the
+future, we can probably improve even that!
 
 Finally, _just work_ means that adding Linkerd to a functioning Kubernetes
 application shouldn't break anything, and shouldn't even require configuration.
-(Of course, configuration will be necessary to customize Linkerd's
-behavior--but it shouldn't be necessary simply to get things working.) To do
-this, we've invested heavily in things like [automatic L7 protocol
-detection](/{{% latest-linkerd2-stable-version %}}/features/protocol-detection/), and [automatic re-routing of TCP
-traffic within a pod](/{{% latest-linkerd2-stable-version %}}/features/proxy-injection/).
+(Of course, configuration will be necessary to customize Linkerd's behavior--but
+it shouldn't be necessary simply to get things working.) To do this, we've
+invested heavily in things like [automatic L7 protocol detection](/{{%
+latest-linkerd2-stable-version %}}/features/protocol-detection/), and [automatic
+re-routing of TCP traffic within a pod](/{{% latest-linkerd2-stable-version
+%}}/features/proxy-injection/).
 
 Together, these three principles give us a framework for weighing product and
 engineering tradeoffs in Linkerd. We hope they're also useful for understanding

--- a/linkerd.io/content/design-principles/_index.md
+++ b/linkerd.io/content/design-principles/_index.md
@@ -29,7 +29,7 @@ mean that Linkerd can't have powerful features, or that it has to have
 one-click wizards take care of everything for you. In fact, it means the
 opposite: every aspect of Linkerd's behavior should be explicit, clear,
 well-defined, bounded, understandable, and introspectable. For example,
-Linkerd's [control plane](/2.11/reference/architecture/#control-plane) is split
+Linkerd's [control plane](/{{% latest-linkerd2-stable-version %}}/reference/architecture/#control-plane) is split
 into several operational components based on their functional boundaries
 ("web”, "api”, etc.) These components aren't just exposed directly to you in
 the Linkerd dashboard and CLI, they run on the same data plane as your
@@ -37,7 +37,7 @@ application does, allowing you to use the same tooling to inspect their
 behavior.
 
 _Minimize resource requirements_ means that Linkerd, and especially Linkerd's
-[data plane proxies](/2.11/reference/architecture/#data-plane), should consume the
+[data plane proxies](/{{% latest-linkerd2-stable-version %}}/reference/architecture/#data-plane), should consume the
 smallest amount of memory and CPU possible. On the control plane side, we've
 taken care to ensure that components scale gracefully in the presence of
 traffic. On the data plane side, we've build Linkerd's proxy (called simply
@@ -51,8 +51,8 @@ application shouldn't break anything, and shouldn't even require configuration.
 (Of course, configuration will be necessary to customize Linkerd's
 behavior--but it shouldn't be necessary simply to get things working.) To do
 this, we've invested heavily in things like [automatic L7 protocol
-detection](/2.11/features/protocol-detection/), and [automatic re-routing of TCP
-traffic within a pod](/2.11/features/proxy-injection/).
+detection](/{{% latest-linkerd2-stable-version %}}/features/protocol-detection/), and [automatic re-routing of TCP
+traffic within a pod](/{{% latest-linkerd2-stable-version %}}/features/proxy-injection/).
 
 Together, these three principles give us a framework for weighing product and
 engineering tradeoffs in Linkerd. We hope they're also useful for understanding

--- a/linkerd.io/content/gsoc.md
+++ b/linkerd.io/content/gsoc.md
@@ -174,7 +174,7 @@ started!
 ### Requirements
 
 All students are required to get to know Linkerd by completing this
-[Getting Started](https://linkerd.io/2.11/getting-started/) tutorial.
+[Getting Started](https://linkerd.io/getting-started/) tutorial.
 
 As part of the acceptance requirements, students **must** have at least one pull
 requests reviewed and merged in the [Linkerd2](https://github.com/linkerd/linkerd2)

--- a/linkerd.io/content/what-is-a-service-mesh/_index.md
+++ b/linkerd.io/content/what-is-a-service-mesh/_index.md
@@ -195,5 +195,5 @@ first service mesh project in 2017, [Linkerd is now in
 production](https://buoyant.io/case-studies/) at organizations like Microsoft,
 HP, and Nordstrom, and adoption shows no sign of slowing down. If you
 are using Kubernetes, Linkerd is fully open source and available to you today.
-[You're only minutes away](/2/getting-started/) from getting
+[You're only minutes away](/getting-started/) from getting
 concrete, hands-on experience with the service mesh!

--- a/linkerd.io/layouts/partials/docs.html
+++ b/linkerd.io/layouts/partials/docs.html
@@ -1,4 +1,4 @@
-{{ $latestVersion := "2.11" }}
+{{ $latestVersion := site.Params.latest_linkerd2_stable_version }}
 {{ $pathParts := split .page.File.Path "/" }}
 {{ $docsVersion := index $pathParts 0 }}
 {{ $latestDocsPath := delimit (append (after 1 $pathParts) (slice "" $latestVersion)) "/" }}

--- a/linkerd.io/layouts/shortcodes/latest-linkerd2-stable-version.html
+++ b/linkerd.io/layouts/shortcodes/latest-linkerd2-stable-version.html
@@ -1,0 +1,1 @@
+{{ site.Params.latest_linkerd2_stable_version -}}


### PR DESCRIPTION
- Added new site param `latest_linkerd2_stable_version`
- Used that in `layouts/partials/docs.html` instead of having to hard-code the version
- Created shortcode `latest-linkerd2-stable-version` using that setting
- Used shortcode in `design-principles/_index.md` and `tasks/distributed-tracing.md` instead of hard-coded version
- Removed hard-coded version in `gsoc.html` and instead take advantage of alias url
- Replaced versioned url with relative url in `reference/iptables.md`