### PR TITLE
Set nginx service-upstream annotation as string

### DIFF
--- a/linkerd.io/content/2.10/tasks/using-ingress.md
+++ b/linkerd.io/content/2.10/tasks/using-ingress.md
@@ -80,7 +80,7 @@ mesh](https://buoyant.io/2021/05/24/emissary-and-linkerd-the-best-of-both-worlds
 
 Nginx can be meshed normally, but the
 [`nginx.ingress.kubernetes.io/service-upstream`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#service-upstream)
-annotation should be set to `true`. No further configuration is required.
+annotation should be set to `"true"`. No further configuration is required.
 
 ```yaml
 # apiVersion: networking.k8s.io/v1beta1 # for k8s < v1.19
@@ -90,7 +90,7 @@ metadata:
   name: emojivoto-web-ingress
   namespace: emojivoto
   annotations:
-    nginx.ingress.kubernetes.io/service-upstream: true
+    nginx.ingress.kubernetes.io/service-upstream: "true"
 spec:
   ingressClassName: nginx
   defaultBackend:

--- a/linkerd.io/content/2.11/tasks/using-ingress.md
+++ b/linkerd.io/content/2.11/tasks/using-ingress.md
@@ -80,7 +80,7 @@ mesh](https://buoyant.io/2021/05/24/emissary-and-linkerd-the-best-of-both-worlds
 
 Nginx can be meshed normally, but the
 [`nginx.ingress.kubernetes.io/service-upstream`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#service-upstream)
-annotation should be set to `true`. No further configuration is required.
+annotation should be set to `"true"`. No further configuration is required.
 
 ```yaml
 # apiVersion: networking.k8s.io/v1beta1 # for k8s < v1.19
@@ -90,7 +90,7 @@ metadata:
   name: emojivoto-web-ingress
   namespace: emojivoto
   annotations:
-    nginx.ingress.kubernetes.io/service-upstream: true
+    nginx.ingress.kubernetes.io/service-upstream: "true"
 spec:
   ingressClassName: nginx
   defaultBackend:


### PR DESCRIPTION
Currently the shown example of a Ingress resource with the service-upstream
annotation is invalid in that the annotations value is a boolean where only
string values are allowed.

This change updates the example to be valid.

Signed-off-by: Crevil <bjoern.soerensen@gmail.com>