### PR TITLE
Update helm commands

### DIFF
--- a/linkerd.io/content/2.12/features/cni.md
+++ b/linkerd.io/content/2.12/features/cni.md
@@ -64,17 +64,11 @@ Install the CNI DaemonSet:
 
 ```bash
 # install the CNI plugin first
-helm install linkerd2-cni linkerd2/linkerd2-cni
+helm install linkerd-cni -n linkerd-cni --create-namespace linkerd/linkerd2-cni
 
 # ensure the plugin is installed and ready
 linkerd check --pre --linkerd-cni-enabled
 ```
-
-{{< note >}}
-For Helm versions < v3, `--name` flag has to specifically be passed.
-In Helm v3, It has been deprecated, and is the first argument as
- specified above.
-{{< /note >}}
 
 At that point you are ready to install Linkerd with CNI enabled.  Follow the
 [Installing Linkerd with Helm](../../tasks/install-helm/) instructions.

--- a/linkerd.io/content/2.12/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.12/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -210,24 +210,22 @@ kubectl get events --field-selector reason=IssuerUpdated -n linkerd
 
 ## Installing with Helm
 
-For Helm installation, rather than running `linkerd install`, set the
+For installing with Helm, first install the `linkerd-base` chart:
+
+```bash
+helm install linkerd-base -n linkerd --create-namespace linkerd/linkerd-base
+```
+
+Then install the `linkerd-control-plane` chart, setting the
 `identityTrustAnchorsPEM` to the value of `ca.crt` in the
 `linkerd-identity-issuer` Secret:
 
 ```bash
-helm install linkerd2 \
+helm install linkerd-control-plane -n linkerd
   --set-file identityTrustAnchorsPEM=ca.crt \
   --set identity.issuer.scheme=kubernetes.io/tls \
-  --set installNamespace=false \
-  linkerd/linkerd2 \
-  -n linkerd
+  linkerd/linkerd-control-plane
 ```
-
-{{< note >}}
-For Helm versions < v3, `--name` flag has to specifically be passed.
-In Helm v3, It has been deprecated, and is the first argument as
- specified above.
-{{< /note >}}
 
 See [Automatically Rotating Webhook TLS
 Credentials](../automatically-rotating-webhook-tls-credentials/) for how

--- a/linkerd.io/content/2.12/tasks/automatically-rotating-webhook-tls-credentials.md
+++ b/linkerd.io/content/2.12/tasks/automatically-rotating-webhook-tls-credentials.md
@@ -279,20 +279,23 @@ linkerd jaeger install
 A similar pattern can be used with Helm:
 
 ```bash
-helm install linkerd2 \
-  --set installNamespace=false \
+# first install the linkerd-base chart
+helm install linkerd-base \
   --set policyValidator.externalSecret=true \
   --set-file policyValidator.caBundle=ca.crt \
   --set proxyInjector.externalSecret=true \
   --set-file proxyInjector.caBundle=ca.crt \
   --set profileValidator.externalSecret=true \
   --set-file profileValidator.caBundle=ca.crt \
-  linkerd/linkerd2 \
+  linkerd/linkerd-base \
   -n linkerd
+
+# then install the linkerd-control-plane chart
+# (see note below)
+helm install linkerd-control-plane -n linkerd linkerd/linkerd-control-plane
 
 # ignore if not using the viz extension
 helm install linkerd-viz \
-  --set installNamespace=false \
   --set tap.externalSecret=true \
   --set-file tap.caBundle=ca.crt \
   --set tapInjector.externalSecret=true \
@@ -302,7 +305,6 @@ helm install linkerd-viz \
 
 # ignore if not using the jaeger extension
 helm install linkerd-jaeger \
-  --set installNamespace=false \
   --set webhook.externalSecret=true \
   --set-file webhook.caBundle=ca.crt \
   linkerd/linkerd-jaeger \
@@ -310,14 +312,9 @@ helm install linkerd-jaeger \
 ```
 
 {{< note >}}
-When installing Linkerd with Helm, you must also provide the issuer trust root
-and issuer credentials as described in [Installing Linkerd with Helm](../install-helm/).
-{{< /note >}}
-
-{{< note >}}
-For Helm versions < v3, `--name` flag has to specifically be passed.
-In Helm v3, It has been deprecated, and is the first argument as
- specified above.
+When installing the `linkerd-control-plane` chart, you must also provide the
+issuer trust root and issuer credentials as described in [Installing Linkerd
+with Helm](../install-helm/).
 {{< /note >}}
 
 See [Automatically Rotating Control Plane TLS

--- a/linkerd.io/content/2.12/tasks/generate-certificates.md
+++ b/linkerd.io/content/2.12/tasks/generate-certificates.md
@@ -35,7 +35,7 @@ step certificate create root.linkerd.cluster.local ca.crt ca.key \
 This generates the `ca.crt` and `ca.key` files. The `ca.crt` file is what you
 need to pass to the `--identity-trust-anchors-file` option when installing
 Linkerd with the CLI, and the `identityTrustAnchorsPEM` value when installing
-Linkerd with Helm.
+the `linkerd-control-plane` chart with Helm.
 
 Note we use `--no-password --insecure` to avoid encrypting those files with a
 passphrase.
@@ -68,19 +68,18 @@ linkerd install \
   | kubectl apply -f -
 ```
 
-Or when installing with Helm:
+Or when installing with Helm, first install the `linkerd-base` chart:
 
 ```bash
-helm install linkerd2 \
+helm install linkerd-base -n linkerd --create-namespace linkerd/linkerd-base
+```
+
+Then install the `linkerd-control-plane` chart:
+
+```bash
+helm install linkerd-control-plane -n linkerd \
   --set-file identityTrustAnchorsPEM=ca.crt \
   --set-file identity.issuer.tls.crtPEM=issuer.crt \
   --set-file identity.issuer.tls.keyPEM=issuer.key \
-  --set identity.issuer.crtExpiry=$(date -d '+8760 hour' +"%Y-%m-%dT%H:%M:%SZ") \
-  linkerd/linkerd2
+  linkerd/linkerd-control-plane
 ```
-
-{{< note >}}
-For Helm versions < v3, `--name` flag has to specifically be passed.
-In Helm v3, It has been deprecated, and is the first argument as
- specified above.
-{{< /note >}}

--- a/linkerd.io/content/2.12/tasks/installing-multicluster.md
+++ b/linkerd.io/content/2.12/tasks/installing-multicluster.md
@@ -314,14 +314,14 @@ pipeline.
 First, let's add the Linkerd's Helm repository by running
 
 ```bash
-# To add the repo for Linkerd2 stable releases:
+# To add the repo for Linkerd stable releases:
 helm repo add linkerd https://helm.linkerd.io/stable
 ```
 
 ### Helm multicluster install procedure
 
 ```bash
-helm install linkerd2-multicluster linkerd/linkerd2-multicluster
+helm install linkerd-multicluster -n linkerd-multicluster --create-namespace linkerd/linkerd-multicluster
 ```
 
 The chart values will be picked from the chart's `values.yaml` file.
@@ -355,7 +355,8 @@ The same functionality can also be done through Helm setting the
 `remoteMirrorServiceAccountName` value to a list.
 
 ```bash
- helm install linkerd2-mc-source linkerd/linkerd2-multicluster --set remoteMirrorServiceAccountName={source1\,source2\,source3} --kube-context target
+ helm install linkerd-mc-source linkerd/linkerd-multicluster -n linkerd-multicluster --create-namespace \
+   --set remoteMirrorServiceAccountName={source1\,source2\,source3} --kube-context target
 ```
 
 Now that the multicluster components are installed, operations like linking, etc

--- a/linkerd.io/content/2.12/tasks/manually-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.12/tasks/manually-rotating-control-plane-tls-credentials.md
@@ -140,7 +140,7 @@ linkerd upgrade --identity-trust-anchors-file=./bundle.crt | kubectl apply -f -
 or you can also use the `helm upgrade` command:
 
 ```bash
-helm upgrade linkerd2 --set-file identityTrustAnchorsPEM=./bundle.crt
+helm upgrade linkerd-control-plane --set-file identityTrustAnchorsPEM=./bundle.crt
 ```
 
 This will restart the proxies in the Linkerd control plane, and they will be
@@ -235,12 +235,9 @@ linkerd upgrade --identity-issuer-certificate-file=./issuer-new.crt --identity-i
 or
 
 ```bash
-exp=$(cat ca-new.crt | openssl x509 -noout -dates | grep "notAfter" | sed -e 's/notAfter=\(.*\)$/"\1"/' | TZ='GMT' xargs -I{} date -d {} +"%Y-%m-%dT%H:%M:%SZ")
-
-helm upgrade linkerd2
-  --set-file identity.issuer.tls.crtPEM=./issuer-new.crt
+helm upgrade linkerd-control-plane \
+  --set-file identity.issuer.tls.crtPEM=./issuer-new.crt \
   --set-file identity.issuer.tls.keyPEM=./issuer-new.key
-  --set identity.issuer.crtExpiry=$exp
 ```
 
 At this point Linkerd's `identity` control plane service should detect the


### PR DESCRIPTION
Followup to #1245, updating all the helm commands in various docs, catering for the new `linkerd-base` and `linkerd-control-plane` charts. Also got rid of old helm v2 references.