### PR TITLE
Fix service name of trace collector in docs

### DIFF
--- a/linkerd.io/content/2.10/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.10/tasks/distributed-tracing.md
@@ -209,7 +209,7 @@ If using helm to install ingress-nginx, you can configure tracing by using:
 controller:
   config:
     enable-opentracing: "true"
-    zipkin-collector-host: linkerd-collector.linkerd
+    zipkin-collector-host: collector.linkerd-jaeger
 ```
 
 ### Client Library

--- a/linkerd.io/content/2.11/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.11/tasks/distributed-tracing.md
@@ -258,7 +258,7 @@ If using helm to install ingress-nginx, you can configure tracing by using:
 controller:
   config:
     enable-opentracing: "true"
-    zipkin-collector-host: linkerd-collector.linkerd
+    zipkin-collector-host: collector.linkerd-jaeger
 ```
 
 ### Client Library

--- a/linkerd.io/data/cli.yaml
+++ b/linkerd.io/data/cli.yaml
@@ -47,7 +47,7 @@ AnnotationsReference:
   Name: config.linkerd.io/disable-tap
 - Description: Inject a debug sidecar for data plane debugging
   Name: config.linkerd.io/enable-debug-sidecar
-- Description: Service name of the trace collector. E.g. `linkerd-collector.linkerd:55678`
+- Description: Service name of the trace collector. E.g. `collector.linkerd-jaeger:55678`
   Name: config.linkerd.io/trace-collector
 - Description: The trace collector's service account name. E.g., `tracing-service-account`.
     If not provided, it will be defaulted to `default`.


### PR DESCRIPTION
Replace linkerd-collector.linkerd to collector.linkerd-jaeger
Fixes #1249

Signed-off-by: FingerLiu <liupeng.dalian@gmail.com>