### PR TITLE
Update ArgoCD tutorial

### DIFF
--- a/linkerd.io/content/2.12/tasks/gitops.md
+++ b/linkerd.io/content/2.12/tasks/gitops.md
@@ -109,6 +109,12 @@ kubectl -n scm port-forward "${git_server}" 9418  &
 git push git-server master
 ```
 
+## Install the Argo CD CLI
+
+Before proceeding, install the Argo CD CLI in your local machine by following
+the [instructions](https://argo-cd.readthedocs.io/en/stable/cli_installation/)
+relevant to your OS.
+
 ## Deploy Argo CD
 
 Install Argo CD:
@@ -117,15 +123,17 @@ Install Argo CD:
 kubectl create ns argocd
 
 kubectl -n argocd apply -f \
-  https://raw.githubusercontent.com/argoproj/argo-cd/v1.6.1/manifests/install.yaml
+  https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
 ```
 
 Confirm that all the pods are ready:
 
 ```sh
-for deploy in "application-controller" "dex-server" "redis" "repo-server" "server"; \
+for deploy in "dex-server" "redis" "repo-server" "server"; \
   do kubectl -n argocd rollout status deploy/argocd-${deploy}; \
 done
+
+kubectl -n argocd rollout status statefulset/argocd-application-controller
 ```
 
 Use port-forward to access the Argo CD dashboard:
@@ -140,19 +148,14 @@ The Argo CD dashboard is now accessible at
 username and
 [password](https://argoproj.github.io/argo-cd/getting_started/#4-login-using-the-cli).
 
-{{< note >}}
-The default admin password is the auto-generated name of the Argo CD API server
-pod. You can use the `argocd account update-password` command to change it.
-{{< /note >}}
-
 Authenticate the Argo CD CLI:
 
 ```sh
-argocd_server=`kubectl -n argocd get pods -l app.kubernetes.io/name=argocd-server -o name | cut -d'/' -f 2`
+password=`kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d`
 
 argocd login 127.0.0.1:8080 \
   --username=admin \
-  --password="${argocd_server}" \
+  --password="${password}" \
   --insecure
 ```
 
@@ -183,8 +186,8 @@ On the dashboard:
 
 ### Deploy the applications
 
-Deploy the `main` application which serves as the "parent" application that of
-all the other applications:
+Deploy the `main` application which serves as the "parent" for all the other
+applications:
 
 ```sh
 kubectl apply -f gitops/main.yaml
@@ -285,16 +288,21 @@ trust anchor:
 step certificate inspect sample-trust.crt
 ```
 
-Create a `SealedSecret` resource to store the encrypted trust anchor:
+Before creating the `SealedSecret`, make sure you have installed the `kubeseal`
+utility, as instructed
+[here](https://github.com/bitnami-labs/sealed-secrets/releases)
+
+Now create the `SealedSecret` resource to store the encrypted trust anchor:
 
 ```sh
+kubectl create ns linkerd
 kubectl -n linkerd create secret tls linkerd-trust-anchor \
   --cert sample-trust.crt \
   --key sample-trust.key \
   --dry-run=client -oyaml | \
 kubeseal --controller-name=sealed-secrets -oyaml - | \
 kubectl patch -f - \
-  -p '{"spec": {"template": {"type":"kubernetes.io/tls", "metadata": {"labels": {"linkerd.io/control-plane-component":"identity", "linkerd.io/control-plane-ns":"linkerd"}, "annotations": {"linkerd.io/created-by":"linkerd/cli stable-2.8.1", "linkerd.io/identity-issuer-expiry":"2021-07-19T20:51:01Z"}}}}}' \
+  -p '{"spec": {"template": {"type":"kubernetes.io/tls", "metadata": {"labels": {"linkerd.io/control-plane-component":"identity", "linkerd.io/control-plane-ns":"linkerd"}, "annotations": {"linkerd.io/created-by":"linkerd/cli stable-2.12.0"}}}}}' \
   --dry-run=client \
   --type=merge \
   --local -oyaml > gitops/resources/linkerd/trust-anchor.yaml
@@ -372,11 +380,11 @@ Now we are ready to install Linkerd. The decrypted trust anchor we just
 retrieved will be passed to the installation process using the
 `identityTrustAnchorsPEM` parameter.
 
-Prior to installing Linkerd, note that the `global.identityTrustAnchorsPEM`
-parameter is set to an "empty" certificate string:
+Prior to installing Linkerd, note that the `identityTrustAnchorsPEM` parameter
+is set to an "empty" certificate string:
 
 ```sh
-argocd app get linkerd -ojson | \
+argocd app get linkerd-control-plane -ojson | \
   jq -r '.spec.source.helm.parameters[] | select(.name == "identityTrustAnchorsPEM") | .value'
 ```
 
@@ -388,16 +396,16 @@ We will override this parameter in the `linkerd` application with the value of
 `${trust_anchor}`.
 
 Locate the `identityTrustAnchorsPEM` variable in your local
-`gitops/argo-apps/linkerd.yaml` file, and set its `value` to that of
-`${trust_anchor}`.
+`gitops/argo-apps/linkerd-control-plane.yaml` file, and set its `value` to that
+of `${trust_anchor}`.
 
 Ensure that the multi-line string is indented correctly. E.g.,
 
 ```yaml
   source:
-    chart: linkerd2
+    chart: linkerd-control-plane
     repoURL: https://helm.linkerd.io/stable
-    targetRevision: 2.8.0
+    targetRevision: 2.12.0
     helm:
       parameters:
       - name: identityTrustAnchorsPEM
@@ -418,13 +426,13 @@ Ensure that the multi-line string is indented correctly. E.g.,
 Confirm that only one `spec.source.helm.parameters.value` field is changed:
 
 ```sh
-git diff gitops/argo-apps/linkerd.yaml
+git diff gitops/argo-apps/linkerd-control-plane.yaml
 ```
 
 Commit and push the changes to the Git server:
 
 ```sh
-git add gitops/argo-apps/linkerd.yaml
+git add gitops/argo-apps/linkerd-control-plane.yaml
 
 git commit -m "set identityTrustAnchorsPEM parameter"
 
@@ -440,7 +448,7 @@ argocd app sync main
 Confirm that the new trust anchor is picked up by the `linkerd` application:
 
 ```sh
-argocd app get linkerd -ojson | \
+argocd app get linkerd-control-plane -ojson | \
   jq -r '.spec.source.helm.parameters[] | select(.name == "identityTrustAnchorsPEM") | .value'
 ```
 
@@ -448,10 +456,11 @@ argocd app get linkerd -ojson | \
       title="Override mTLS trust anchor"
       src="/images/gitops/dashboard-trust-anchor-override.png" >}}
 
-Synchronize the `linkerd` application:
+Synchronize the `linkerd-base` and `linkerd-control-plane`applications:
 
 ```sh
-argocd app sync linkerd
+argocd app sync linkerd-base
+argocd app sync linkerd-control-plane
 ```
 
 Check that Linkerd is ready:
@@ -484,23 +493,25 @@ done
       title="Synchronize emojivoto"
       src="/images/gitops/dashboard-emojivoto-sync.png" >}}
 
-### Upgrade Linkerd to 2.8.1
+### Upgrade Linkerd to 2.12.1
 
-Use your editor to change the `spec.source.targetRevision` field to `2.8.1` in
-the `gitops/argo-apps/linkerd.yaml` file:
+(Assuming 2.12.1 has already been released ;-) )
+
+Use your editor to change the `spec.source.targetRevision` field to `2.12.1` in
+the `gitops/argo-apps/linkerd-control-plane.yaml` file:
 
 Confirm that only the `targetRevision` field is changed:
 
 ```sh
-git diff gitops/argo-apps/linkerd.yaml
+git diff gitops/argo-apps/linkerd-control-plane.yaml
 ```
 
 Commit and push this change to the Git server:
 
 ```sh
-git add gitops/argo-apps/linkerd.yaml
+git add gitops/argo-apps/linkerd-control-plane.yaml
 
-git commit -m "upgrade Linkerd to 2.8.1"
+git commit -m "upgrade Linkerd to 2.12.1"
 
 git push git-server master
 ```
@@ -511,10 +522,10 @@ Synchronize the `main` application:
 argocd app sync main
 ```
 
-Synchronize the `linkerd` application:
+Synchronize the `linkerd-control-plane` application:
 
 ```sh
-argocd app sync linkerd
+argocd app sync linkerd-control-plane
 ```
 
 Confirm that the upgrade completed successfully:

--- a/linkerd.io/content/2.12/tasks/gitops.md
+++ b/linkerd.io/content/2.12/tasks/gitops.md
@@ -456,10 +456,10 @@ argocd app get linkerd-control-plane -ojson | \
       title="Override mTLS trust anchor"
       src="/images/gitops/dashboard-trust-anchor-override.png" >}}
 
-Synchronize the `linkerd-base` and `linkerd-control-plane`applications:
+Synchronize the `linkerd-crds` and `linkerd-control-plane`applications:
 
 ```sh
-argocd app sync linkerd-base
+argocd app sync linkerd-crds
 argocd app sync linkerd-control-plane
 ```
 


### PR DESCRIPTION
It now takes into account the upcoming change in linkerd 2.12.0 where we
replace the `linkerd2` helm chart with the `linkerd-crds` and
`linkerd-control-plane` charts.

Other updates:
- Added instructions to install the ArgoCD CLI
- Updated ArgoCD version and point to location for the latest stable
  manifest
- Update ArgoCD password retrieval mechanism
- Added instructions to install the `kubeseal` CLI utility

The `linkerd/linkerd-examples` repo this tutorial uses has also been updated in linkerd/linkerd-examples#267