### PR TITLE
Fix multicluster tutorial and kustomize resources

### DIFF
--- a/linkerd.io/content/2.11/tasks/multicluster.md
+++ b/linkerd.io/content/2.11/tasks/multicluster.md
@@ -12,8 +12,8 @@ between services that live on different clusters.
 
 At a high level, you will:
 
-1. [Install Linkerd](#install-linkerd) on two clusters with a shared trust
-   anchor.
+1. [Install Linkerd and Linkerd Viz](#install-linkerd) on two clusters with a
+   shared trust anchor.
 1. [Prepare](#preparing-your-cluster) the clusters.
 1. [Link](#linking-the-clusters) the clusters.
 1. [Install](#installing-the-test-services) the demo.
@@ -42,16 +42,13 @@ At a high level, you will:
 - Elevated privileges on both clusters. We'll be creating service accounts and
   granting extended privileges, so you'll need to be able to do that on your
   test clusters.
-- Linkerd's `viz` extension should be installed in order to run `stat` commands,
-  view the Grafana or Linkerd dashboard and run the `linkerd multicluster gateways`
-  command.
 - Support for services of type `LoadBalancer` in the `east` cluster. Check out
   the documentation for your cluster provider or take a look at
   [inlets](https://blog.alexellis.io/ingress-for-your-local-kubernetes-cluster/).
   This is what the `west` cluster will use to communicate with `east` via the
   gateway.
 
-## Install Linkerd
+## Install Linkerd and Linkerd Viz
 
 {{< fig
     alt="install"
@@ -116,14 +113,23 @@ linkerd install \
     >(kubectl --context=east apply -f -)
 ```
 
+And then Linkerd Viz:
+
+```bash
+for ctx in west east; do
+  linkerd --context=${ctx} viz install | \
+    kubectl --context=${ctx} apply -f - || break
+done
+```
+
 The output from `install` will get applied to each cluster and come up! You can
 verify that everything has come up successfully with `check`.
 
 ```bash
 for ctx in west east; do
-  echo "Checking cluster: ${ctx} .........\n"
+  echo "Checking cluster: ${ctx} ........."
   linkerd --context=${ctx} check || break
-  echo "-------------\n"
+  echo "-------------"
 done
 ```
 
@@ -151,7 +157,7 @@ for ctx in west east; do
   echo "Installing on cluster: ${ctx} ........."
   linkerd --context=${ctx} multicluster install | \
     kubectl --context=${ctx} apply -f - || break
-  echo "-------------\n"
+  echo "-------------"
 done
 ```
 
@@ -175,7 +181,7 @@ for ctx in west east; do
   echo "Checking gateway on cluster: ${ctx} ........."
   kubectl --context=${ctx} -n linkerd-multicluster \
     rollout status deploy/linkerd-gateway || break
-  echo "-------------\n"
+  echo "-------------"
 done
 ```
 
@@ -185,9 +191,7 @@ running:
 ```bash
 for ctx in west east; do
   printf "Checking cluster: ${ctx} ........."
-  while [ "$(kubectl --context=${ctx} -n linkerd-multicluster get service \
-    -o 'custom-columns=:.status.loadBalancer.ingress[0].ip' \
-    --no-headers)" = "<none>" ]; do
+  while [ "$(kubectl --context=${ctx} -n linkerd-multicluster get service -o 'custom-columns=:.status.loadBalancer.ingress[0].ip' --no-headers)" = "<none>" ]; do
       printf '.'
       sleep 1
   done
@@ -271,10 +275,10 @@ can mirror. To add these to both clusters, you can run:
 for ctx in west east; do
   echo "Adding test services on cluster: ${ctx} ........."
   kubectl --context=${ctx} apply \
-    -k "github.com/linkerd/website/multicluster/${ctx}/"
+    -n test -k "github.com/linkerd/website/multicluster/${ctx}/"
   kubectl --context=${ctx} -n test \
     rollout status deploy/podinfo || break
-  echo "-------------\n"
+  echo "-------------"
 done
 ```
 
@@ -370,9 +374,8 @@ kubectl --context=west -n test exec -c nginx -it \
 You'll see the `greeting from east` message! Requests from the `frontend` pod
 running in `west` are being transparently forwarded to `east`. Assuming that
 you're still port forwarding from the previous step, you can also reach this
-from your browser at [http://localhost:8080/east](http://localhost:8080/east).
-Refresh a couple times and you'll be able to get metrics from `linkerd viz stat`
-as well.
+with `curl http://localhost:8080/east`.  Make that call a couple times and
+you'll be able to get metrics from `linkerd viz stat` as well.
 
 ```bash
 linkerd --context=west -n test viz stat --from deploy/frontend svc
@@ -404,8 +407,8 @@ linkerd --context=west -n test viz tap deploy/frontend | \
 
 `tls=true` tells you that the requests are being encrypted!
 
-{{< note >}} As `linkerd edges` works on concrete resources and cannot see two
-clusters at once, it is not currently able to show the edges between pods in
+{{< note >}} As `linkerd viz edges` works on concrete resources and cannot see
+two clusters at once, it is not currently able to show the edges between pods in
 `east` and `west`. This is the reason we're using `tap` to validate mTLS here.
 {{< /note >}}
 
@@ -506,7 +509,10 @@ There's even a dashboard! Run `linkerd viz dashboard` and send your browser to
 To cleanup the multicluster control plane, you can run:
 
 ```bash
+linkerd --context=west multicluster unlink --cluster-name east | 
+  kubectl --context=west delete -f -
 for ctx in west east; do
+  kubectl --context=${ctx} delete ns test
   linkerd --context=${ctx} multicluster uninstall | kubectl --context=${ctx} delete -f -
 done
 ```
@@ -515,6 +521,7 @@ If you'd also like to remove your Linkerd installation, run:
 
 ```bash
 for ctx in west east; do
+  linkerd --context=${ctx} viz uninstall | kubectl --context=${ctx} delete -f -
   linkerd --context=${ctx} uninstall | kubectl --context=${ctx} delete -f -
 done
 ```

--- a/multicluster/base/frontend.yml
+++ b/multicluster/base/frontend.yml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: frontend
-  namespace: test
 data:
  nginx.conf: |-
   pid /tmp/pid;
@@ -19,17 +18,18 @@ data:
       listen 8080;
       set $east "east";
       set $west "west";
+      resolver kube-dns.kube-system.svc.cluster.local;
 
       location / {
-        proxy_pass http://podinfo:9898;
+        proxy_pass http://podinfo.test.svc.cluster.local:9898/;
         proxy_http_version 1.1;
       }
       location /east {
-        proxy_pass http://podinfo-$east:9898;
+        proxy_pass http://podinfo-$east.test.svc.cluster.local:9898/;
         proxy_http_version 1.1;
       }
       location /west {
-        proxy_pass http://podinfo-$west:9898;
+        proxy_pass http://podinfo-$west.test.svc.cluster.local:9898/;
         proxy_http_version 1.1;
       }
     }
@@ -39,7 +39,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend
-  namespace: test
   labels:
     app: frontend
 spec:
@@ -69,8 +68,6 @@ spec:
             requests:
               cpu: 10m
               memory: 10Mi
-          securityContext:
-            runAsUser: 1337
         - image: buoyantio/slow_cooker:1.2.0
           name: internal
           env:
@@ -124,7 +121,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: frontend
-  namespace: test
 spec:
   ports:
   - name: service

--- a/multicluster/base/kustomization.yml
+++ b/multicluster/base/kustomization.yml
@@ -1,5 +1,5 @@
 bases:
-  - github.com/stefanprodan/podinfo/kustomize/?ref=4.0.2
+  - github.com/stefanprodan/podinfo/kustomize?ref=4.0.2
 
 resources:
   - frontend.yml

--- a/multicluster/base/patch.yml
+++ b/multicluster/base/patch.yml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: podinfo
-  namespace: test
 spec:
   replicas: 1
   template:
@@ -19,10 +18,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: podinfo
-  namespace: test
 ---
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: podinfo
-  namespace: test


### PR DESCRIPTION
Fixes linkerd/linkerd2#7504

Kustomize breaking changes and other upgrades made that tutorial obsolete. Fixed with:

- Removed namespaces from resources and patch, and instead use `kubectl -n test apply`
- Having vars in the nginx' location targets implies declaring a dns resolver. Also extended FQDN for services is required.
- The nginx container requires running as root to allow using apk to install cURL

Also improved the tutorial itself:

- Added instructions for installing viz
- Removed not-required line-feeds in `echo` statements
- http://localhost:8080/east requires cURL and doesn't work in the browser because of javascript reasons
- Added missing directives in cleanup steps