### PR TITLE
blog: fix volumeMount in tokens blog post

### DIFF
--- a/linkerd.io/content/blog/linkerd-service-account-tokens.md
+++ b/linkerd.io/content/blog/linkerd-service-account-tokens.md
@@ -202,8 +202,8 @@ spec:
   containers:
   ...
     volumeMounts:
-    - mountPath: /var/run/linkerd/identity/end-entity
-      name: linkerd-identity-end-entity
+    - name: linkerd-identity-token
+      mountPath: /var/run/secrets/kubernetes.io/serviceaccount
   ...
   volumes:
   - name: linkerd-identity-token


### PR DESCRIPTION
The wrong volumeMount was used in the example. This
PR fixes that to use the right one.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>