### PR TITLE
Require TLS when using curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,14 @@ RUN apt-get update \
   && export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" \
   && echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" \
     | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
-  && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+  && curl --proto '=https' --tlsv1.3 -sSfL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
     | apt-key add - \
   && apt-get update \
   && apt-get install -y --no-install-recommends google-cloud-sdk \
   && wget https://github.com/gohugoio/hugo/releases/download/v0.61.0/hugo_extended_0.61.0_Linux-64bit.deb \
   && dpkg -i hugo*.deb \
   && rm hugo*.deb \
-  && curl https://htmltest.wjdp.uk | bash \
+  && curl --proto '=https' --tlsv1.3 -sSfL https://htmltest.wjdp.uk | bash \
   && mv bin/htmltest /usr/local/bin \
   && npm install -g markdownlint-cli \
   && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,14 @@ RUN apt-get update \
   && export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" \
   && echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" \
     | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
-  && curl --proto '=https' --tlsv1.3 -sSfL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+  && curl --proto '=https' --tlsv1.2 -sSfL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
     | apt-key add - \
   && apt-get update \
   && apt-get install -y --no-install-recommends google-cloud-sdk \
   && wget https://github.com/gohugoio/hugo/releases/download/v0.61.0/hugo_extended_0.61.0_Linux-64bit.deb \
   && dpkg -i hugo*.deb \
   && rm hugo*.deb \
-  && curl --proto '=https' --tlsv1.3 -sSfL https://htmltest.wjdp.uk | bash \
+  && curl --proto '=https' --tlsv1.2 -sSfL https://htmltest.wjdp.uk | bash \
   && mv bin/htmltest /usr/local/bin \
   && npm install -g markdownlint-cli \
   && rm -rf /var/lib/apt/lists/*

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ endif
 check: build-linkerd.io
 	@# Check linkerd.io for valid links and standards
 ifndef HAS_HTMLTEST
-	@printf "Install htmltest first. curl --proto '=https' --tlsv1.3 -sSfL https://htmltest.wjdp.uk | bash\n"; exit 1
+	@printf "Install htmltest first. curl --proto '=https' --tlsv1.2 -sSfL https://htmltest.wjdp.uk | bash\n"; exit 1
 endif
 	cd tmp/linkerd.io && htmltest
 

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ endif
 check: build-linkerd.io
 	@# Check linkerd.io for valid links and standards
 ifndef HAS_HTMLTEST
-	@printf "Install htmltest first. curl https://htmltest.wjdp.uk | bash\n"; exit 1
+	@printf "Install htmltest first. curl --proto '=https' --tlsv1.3 -sSfL https://htmltest.wjdp.uk | bash\n"; exit 1
 endif
 	cd tmp/linkerd.io && htmltest
 

--- a/linkerd.io/content/2.10/getting-started/_index.md
+++ b/linkerd.io/content/2.10/getting-started/_index.md
@@ -58,7 +58,7 @@ allow you to interact with your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Be sure to follow the instructions to add it to your path.
@@ -140,7 +140,7 @@ linkerd viz install | kubectl apply -f - # install the on-cluster metrics stack
 To install the buoyant-cloud extension, run:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://buoyant.cloud/install | sh # get the installer
+curl --proto '=https' --tlsv1.2 -sSfL https://buoyant.cloud/install | sh # get the installer
 linkerd buoyant install | kubectl apply -f - # connect to the hosted metrics stack
 ```
 
@@ -192,7 +192,7 @@ users to vote on their favorite emojis.
 Install *emojivoto* into the `emojivoto` namespace by running:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/emojivoto.yml | kubectl apply -f -
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/emojivoto.yml | kubectl apply -f -
 ```
 
 Before we mesh it, let's take a look at the app. If you're using [Docker

--- a/linkerd.io/content/2.10/getting-started/_index.md
+++ b/linkerd.io/content/2.10/getting-started/_index.md
@@ -58,7 +58,7 @@ allow you to interact with your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
-curl -sL run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Be sure to follow the instructions to add it to your path.
@@ -140,7 +140,7 @@ linkerd viz install | kubectl apply -f - # install the on-cluster metrics stack
 To install the buoyant-cloud extension, run:
 
 ```bash
-curl -sL buoyant.cloud/install | sh # get the installer
+curl --proto '=https' --tlsv1.3 -sSfL https://buoyant.cloud/install | sh # get the installer
 linkerd buoyant install | kubectl apply -f - # connect to the hosted metrics stack
 ```
 
@@ -192,7 +192,7 @@ users to vote on their favorite emojis.
 Install *emojivoto* into the `emojivoto` namespace by running:
 
 ```bash
-curl -sL run.linkerd.io/emojivoto.yml | kubectl apply -f -
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/emojivoto.yml | kubectl apply -f -
 ```
 
 Before we mesh it, let's take a look at the app. If you're using [Docker

--- a/linkerd.io/content/2.10/tasks/books.md
+++ b/linkerd.io/content/2.10/tasks/books.md
@@ -34,7 +34,7 @@ terminal, run:
 
 ```bash
 kubectl create ns booksapp && \
-  curl -sL https://run.linkerd.io/booksapp.yml \
+  curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp.yml \
   | kubectl -n booksapp apply -f -
 ```
 
@@ -167,7 +167,7 @@ demo has published specs for each of its services. You can create a service
 profile for `webapp` by running:
 
 ```bash
-curl -sL https://run.linkerd.io/booksapp/webapp.swagger \
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp/webapp.swagger \
   | linkerd -n booksapp profile --open-api - webapp \
   | kubectl -n booksapp apply -f -
 ```
@@ -243,10 +243,10 @@ For this demo, the method is appended to the route regex.
 To get profiles for `authors` and `books`, you can run:
 
 ```bash
-curl -sL https://run.linkerd.io/booksapp/authors.swagger \
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp/authors.swagger \
   | linkerd -n booksapp profile --open-api - authors \
   | kubectl -n booksapp apply -f -
-curl -sL https://run.linkerd.io/booksapp/books.swagger \
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp/books.swagger \
   | linkerd -n booksapp profile --open-api - books \
   | kubectl -n booksapp apply -f -
 ```
@@ -466,7 +466,7 @@ the effective success rate for our route has dropped below 100%.
 To remove the books app and the booksapp namespace from your cluster, run:
 
 ```bash
-curl -sL https://run.linkerd.io/booksapp.yml \
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp.yml \
   | kubectl -n booksapp delete -f - \
   && kubectl delete ns booksapp
 ```

--- a/linkerd.io/content/2.10/tasks/books.md
+++ b/linkerd.io/content/2.10/tasks/books.md
@@ -34,7 +34,7 @@ terminal, run:
 
 ```bash
 kubectl create ns booksapp && \
-  curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp.yml \
+  curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/booksapp.yml \
   | kubectl -n booksapp apply -f -
 ```
 
@@ -167,7 +167,7 @@ demo has published specs for each of its services. You can create a service
 profile for `webapp` by running:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp/webapp.swagger \
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/booksapp/webapp.swagger \
   | linkerd -n booksapp profile --open-api - webapp \
   | kubectl -n booksapp apply -f -
 ```
@@ -243,10 +243,10 @@ For this demo, the method is appended to the route regex.
 To get profiles for `authors` and `books`, you can run:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp/authors.swagger \
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/booksapp/authors.swagger \
   | linkerd -n booksapp profile --open-api - authors \
   | kubectl -n booksapp apply -f -
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp/books.swagger \
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/booksapp/books.swagger \
   | linkerd -n booksapp profile --open-api - books \
   | kubectl -n booksapp apply -f -
 ```
@@ -466,7 +466,7 @@ the effective success rate for our route has dropped below 100%.
 To remove the books app and the booksapp namespace from your cluster, run:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp.yml \
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/booksapp.yml \
   | kubectl -n booksapp delete -f - \
   && kubectl delete ns booksapp
 ```

--- a/linkerd.io/content/2.10/tasks/extensions.md
+++ b/linkerd.io/content/2.10/tasks/extensions.md
@@ -43,7 +43,7 @@ extension, but doesn't require it. To install this extension, run:
 
 ```bash
 ## optional
-curl --proto '=https' --tlsv1.3 -sSfL https://buoyant.cloud/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://buoyant.cloud/install | sh
 linkerd buoyant install | kubectl apply -f - # hosted metrics dashboard
 ```
 

--- a/linkerd.io/content/2.10/tasks/extensions.md
+++ b/linkerd.io/content/2.10/tasks/extensions.md
@@ -43,7 +43,7 @@ extension, but doesn't require it. To install this extension, run:
 
 ```bash
 ## optional
-curl -sL buoyant.cloud/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://buoyant.cloud/install | sh
 linkerd buoyant install | kubectl apply -f - # hosted metrics dashboard
 ```
 

--- a/linkerd.io/content/2.10/tasks/linkerd-smi.md
+++ b/linkerd.io/content/2.10/tasks/linkerd-smi.md
@@ -38,7 +38,7 @@ a `TrafficSplit` specification, to perform Traffic Splitting across services.
 Install the SMI extension CLI binary by running:
 
 ```bash
-curl -sL https://linkerd.github.io/linkerd-smi/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://linkerd.github.io/linkerd-smi/install | sh
 ```
 
 Alternatively, you can download the CLI directly via the [releases page](https://github.com/linkerd/linkerd-smi/releases).

--- a/linkerd.io/content/2.10/tasks/linkerd-smi.md
+++ b/linkerd.io/content/2.10/tasks/linkerd-smi.md
@@ -38,7 +38,7 @@ a `TrafficSplit` specification, to perform Traffic Splitting across services.
 Install the SMI extension CLI binary by running:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://linkerd.github.io/linkerd-smi/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://linkerd.github.io/linkerd-smi/install | sh
 ```
 
 Alternatively, you can download the CLI directly via the [releases page](https://github.com/linkerd/linkerd-smi/releases).

--- a/linkerd.io/content/2.10/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.10/tasks/troubleshooting.md
@@ -2027,7 +2027,7 @@ linkerd-buoyant check
 To install the CLI:
 
 ```bash
-curl https://buoyant.cloud/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://buoyant.cloud/install | sh
 ```
 
 ### √ linkerd-buoyant can determine the latest version
@@ -2042,7 +2042,7 @@ Ensure you can connect to the Linkerd Buoyant version check endpoint from the
 environment the `linkerd` cli is running:
 
 ```bash
-$ curl https://buoyant.cloud/version.json
+$ curl --proto '=https' --tlsv1.3 -sSfL https://buoyant.cloud/version.json
 {"linkerd-buoyant":"v0.4.4"}
 ```
 
@@ -2057,7 +2057,7 @@ $ curl https://buoyant.cloud/version.json
 To update to the latest version of the `linkerd-buoyant` CLI:
 
 ```bash
-curl https://buoyant.cloud/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://buoyant.cloud/install | sh
 ```
 
 ### √ buoyant-cloud Namespace exists

--- a/linkerd.io/content/2.10/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.10/tasks/troubleshooting.md
@@ -2027,7 +2027,7 @@ linkerd-buoyant check
 To install the CLI:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://buoyant.cloud/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://buoyant.cloud/install | sh
 ```
 
 ### √ linkerd-buoyant can determine the latest version
@@ -2042,7 +2042,7 @@ Ensure you can connect to the Linkerd Buoyant version check endpoint from the
 environment the `linkerd` cli is running:
 
 ```bash
-$ curl --proto '=https' --tlsv1.3 -sSfL https://buoyant.cloud/version.json
+$ curl --proto '=https' --tlsv1.2 -sSfL https://buoyant.cloud/version.json
 {"linkerd-buoyant":"v0.4.4"}
 ```
 
@@ -2057,7 +2057,7 @@ $ curl --proto '=https' --tlsv1.3 -sSfL https://buoyant.cloud/version.json
 To update to the latest version of the `linkerd-buoyant` CLI:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://buoyant.cloud/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://buoyant.cloud/install | sh
 ```
 
 ### √ buoyant-cloud Namespace exists

--- a/linkerd.io/content/2.10/tasks/upgrade.md
+++ b/linkerd.io/content/2.10/tasks/upgrade.md
@@ -42,7 +42,7 @@ free to skip to the [Helm section](#with-helm).
 To upgrade the CLI locally, run:
 
 ```bash
-curl -sL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Alternatively, you can download the CLI directly via the
@@ -465,7 +465,7 @@ are retained.
 
 ```bash
 # get the latest stable CLI
-curl -sL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 {{< note >}} The linkerd cli installer installs the CLI binary into a
@@ -532,7 +532,7 @@ are retained.
 
 ```bash
 # get the latest stable CLI
-curl -sL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 For Kubernetes 1.12+:
@@ -634,7 +634,7 @@ kubectl -n linkerd delete deploy/linkerd-ca
 
 ```bash
 # get the latest stable
-curl -sL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 
 # upgrade the control plane
 linkerd upgrade | kubectl apply --prune -l linkerd.io/control-plane-ns=linkerd -f -
@@ -727,7 +727,7 @@ information on disk, such as using tools like
 
 ```bash
 # get the latest stable
-curl -sL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 
 # Install stable control plane, using flags previously supplied during
 # installation.
@@ -787,7 +787,7 @@ these instructions for anywhere that uses the linkerd CLI.
 To upgrade the CLI locally, run:
 
 ```bash
-curl -sL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Alternatively, you can download the CLI directly via the

--- a/linkerd.io/content/2.10/tasks/upgrade.md
+++ b/linkerd.io/content/2.10/tasks/upgrade.md
@@ -42,7 +42,7 @@ free to skip to the [Helm section](#with-helm).
 To upgrade the CLI locally, run:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Alternatively, you can download the CLI directly via the
@@ -465,7 +465,7 @@ are retained.
 
 ```bash
 # get the latest stable CLI
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 {{< note >}} The linkerd cli installer installs the CLI binary into a
@@ -532,7 +532,7 @@ are retained.
 
 ```bash
 # get the latest stable CLI
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 For Kubernetes 1.12+:
@@ -634,7 +634,7 @@ kubectl -n linkerd delete deploy/linkerd-ca
 
 ```bash
 # get the latest stable
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 
 # upgrade the control plane
 linkerd upgrade | kubectl apply --prune -l linkerd.io/control-plane-ns=linkerd -f -
@@ -727,7 +727,7 @@ information on disk, such as using tools like
 
 ```bash
 # get the latest stable
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 
 # Install stable control plane, using flags previously supplied during
 # installation.
@@ -787,7 +787,7 @@ these instructions for anywhere that uses the linkerd CLI.
 To upgrade the CLI locally, run:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Alternatively, you can download the CLI directly via the

--- a/linkerd.io/content/2.10/tasks/validating-your-traffic.md
+++ b/linkerd.io/content/2.10/tasks/validating-your-traffic.md
@@ -106,7 +106,7 @@ service mesh itself. For example, with our [*emojivoto* demo
 application](../../getting-started/), we can add the debug sidecar by running:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/emojivoto.yml \
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/emojivoto.yml \
   | linkerd inject --enable-debug-sidecar - \
   | kubectl apply -f -
 ```

--- a/linkerd.io/content/2.10/tasks/validating-your-traffic.md
+++ b/linkerd.io/content/2.10/tasks/validating-your-traffic.md
@@ -106,7 +106,7 @@ service mesh itself. For example, with our [*emojivoto* demo
 application](../../getting-started/), we can add the debug sidecar by running:
 
 ```bash
-curl -sL https://run.linkerd.io/emojivoto.yml \
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/emojivoto.yml \
   | linkerd inject --enable-debug-sidecar - \
   | kubectl apply -f -
 ```

--- a/linkerd.io/content/2.11/getting-started/_index.md
+++ b/linkerd.io/content/2.11/getting-started/_index.md
@@ -58,7 +58,7 @@ your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Be sure to follow the instructions to add it to your path.
@@ -134,7 +134,7 @@ allow the user to vote on their favorite emojis.
 Install Emojivoto into the `emojivoto` namespace by running:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/emojivoto.yml \
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/emojivoto.yml \
   | kubectl apply -f -
 ```
 
@@ -218,7 +218,7 @@ linkerd viz install | kubectl apply -f - # install the on-cluster metrics stack
 To install the buoyant-cloud extension, run:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://buoyant.cloud/install | sh # get the installer
+curl --proto '=https' --tlsv1.2 -sSfL https://buoyant.cloud/install | sh # get the installer
 linkerd buoyant install | kubectl apply -f - # connect to the hosted metrics stack
 ```
 

--- a/linkerd.io/content/2.11/getting-started/_index.md
+++ b/linkerd.io/content/2.11/getting-started/_index.md
@@ -58,7 +58,7 @@ your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
-curl -fsL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Be sure to follow the instructions to add it to your path.
@@ -134,7 +134,7 @@ allow the user to vote on their favorite emojis.
 Install Emojivoto into the `emojivoto` namespace by running:
 
 ```bash
-curl -fsL https://run.linkerd.io/emojivoto.yml | kubectl apply -f -
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/emojivoto.yml | kubectl apply -f -
 ```
 
 This command installs Emojivoto onto your cluster, but Linkerd hasn't been
@@ -217,7 +217,7 @@ linkerd viz install | kubectl apply -f - # install the on-cluster metrics stack
 To install the buoyant-cloud extension, run:
 
 ```bash
-curl -fsL https://buoyant.cloud/install | sh # get the installer
+curl --proto '=https' --tlsv1.3 -sSfL https://buoyant.cloud/install | sh # get the installer
 linkerd buoyant install | kubectl apply -f - # connect to the hosted metrics stack
 ```
 

--- a/linkerd.io/content/2.11/getting-started/_index.md
+++ b/linkerd.io/content/2.11/getting-started/_index.md
@@ -134,7 +134,8 @@ allow the user to vote on their favorite emojis.
 Install Emojivoto into the `emojivoto` namespace by running:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/emojivoto.yml | kubectl apply -f -
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/emojivoto.yml \
+  | kubectl apply -f -
 ```
 
 This command installs Emojivoto onto your cluster, but Linkerd hasn't been

--- a/linkerd.io/content/2.11/tasks/books.md
+++ b/linkerd.io/content/2.11/tasks/books.md
@@ -34,7 +34,7 @@ terminal, run:
 
 ```bash
 kubectl create ns booksapp && \
-  curl -sL https://run.linkerd.io/booksapp.yml \
+  curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/booksapp.yml \
   | kubectl -n booksapp apply -f -
 ```
 
@@ -167,7 +167,7 @@ demo has published specs for each of its services. You can create a service
 profile for `webapp` by running:
 
 ```bash
-curl -sL https://run.linkerd.io/booksapp/webapp.swagger \
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/booksapp/webapp.swagger \
   | linkerd -n booksapp profile --open-api - webapp \
   | kubectl -n booksapp apply -f -
 ```
@@ -243,10 +243,10 @@ For this demo, the method is appended to the route regex.
 To get profiles for `authors` and `books`, you can run:
 
 ```bash
-curl -sL https://run.linkerd.io/booksapp/authors.swagger \
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/booksapp/authors.swagger \
   | linkerd -n booksapp profile --open-api - authors \
   | kubectl -n booksapp apply -f -
-curl -sL https://run.linkerd.io/booksapp/books.swagger \
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/booksapp/books.swagger \
   | linkerd -n booksapp profile --open-api - books \
   | kubectl -n booksapp apply -f -
 ```
@@ -466,7 +466,7 @@ the effective success rate for our route has dropped below 100%.
 To remove the books app and the booksapp namespace from your cluster, run:
 
 ```bash
-curl -sL https://run.linkerd.io/booksapp.yml \
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/booksapp.yml \
   | kubectl -n booksapp delete -f - \
   && kubectl delete ns booksapp
 ```

--- a/linkerd.io/content/2.11/tasks/extensions.md
+++ b/linkerd.io/content/2.11/tasks/extensions.md
@@ -43,7 +43,7 @@ extension, but doesn't require it. To install this extension, run:
 
 ```bash
 ## optional
-curl -sL buoyant.cloud/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL buoyant.cloud/install | sh
 linkerd buoyant install | kubectl apply -f - # hosted metrics dashboard
 ```
 

--- a/linkerd.io/content/2.11/tasks/linkerd-smi.md
+++ b/linkerd.io/content/2.11/tasks/linkerd-smi.md
@@ -38,7 +38,7 @@ a `TrafficSplit` specification, to perform Traffic Splitting across services.
 Install the SMI extension CLI binary by running:
 
 ```bash
-curl -sL https://linkerd.github.io/linkerd-smi/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://linkerd.github.io/linkerd-smi/install | sh
 ```
 
 Alternatively, you can download the CLI directly via the [releases page](https://github.com/linkerd/linkerd-smi/releases).

--- a/linkerd.io/content/2.11/tasks/upgrade.md
+++ b/linkerd.io/content/2.11/tasks/upgrade.md
@@ -43,7 +43,7 @@ free to skip to the [Helm section](#with-helm).
 To upgrade the CLI locally, run:
 
 ```bash
-curl -sL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Alternatively, you can download the CLI directly via the
@@ -549,7 +549,7 @@ are retained.
 
 ```bash
 # get the latest stable CLI
-curl -sL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 {{< note >}} The linkerd cli installer installs the CLI binary into a
@@ -616,7 +616,7 @@ are retained.
 
 ```bash
 # get the latest stable CLI
-curl -sL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 For Kubernetes 1.12+:
@@ -718,7 +718,7 @@ kubectl -n linkerd delete deploy/linkerd-ca
 
 ```bash
 # get the latest stable
-curl -sL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 
 # upgrade the control plane
 linkerd upgrade | kubectl apply --prune -l linkerd.io/control-plane-ns=linkerd -f -
@@ -811,7 +811,7 @@ information on disk, such as using tools like
 
 ```bash
 # get the latest stable
-curl -sL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 
 # Install stable control plane, using flags previously supplied during
 # installation.
@@ -871,7 +871,7 @@ these instructions for anywhere that uses the linkerd CLI.
 To upgrade the CLI locally, run:
 
 ```bash
-curl -sL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Alternatively, you can download the CLI directly via the

--- a/linkerd.io/content/2.11/tasks/validating-your-traffic.md
+++ b/linkerd.io/content/2.11/tasks/validating-your-traffic.md
@@ -106,7 +106,7 @@ service mesh itself. For example, with our [*emojivoto* demo
 application](../../getting-started/), we can add the debug sidecar by running:
 
 ```bash
-curl -sL https://run.linkerd.io/emojivoto.yml \
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/emojivoto.yml \
   | linkerd inject --enable-debug-sidecar - \
   | kubectl apply -f -
 ```

--- a/linkerd.io/content/2.9/getting-started/_index.md
+++ b/linkerd.io/content/2.9/getting-started/_index.md
@@ -54,7 +54,7 @@ Linkerd, including installing the control plane onto your Kubernetes cluster.
 To install the CLI manually, run:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Alternatively, you can download the CLI directly via the
@@ -178,7 +178,7 @@ users to vote on their favorite emojis.
 Install *emojivoto* into the `emojivoto` namespace by running:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/emojivoto.yml \
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/emojivoto.yml \
   | kubectl apply -f -
 ```
 

--- a/linkerd.io/content/2.9/getting-started/_index.md
+++ b/linkerd.io/content/2.9/getting-started/_index.md
@@ -54,7 +54,7 @@ Linkerd, including installing the control plane onto your Kubernetes cluster.
 To install the CLI manually, run:
 
 ```bash
-curl -sL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Alternatively, you can download the CLI directly via the
@@ -178,7 +178,7 @@ users to vote on their favorite emojis.
 Install *emojivoto* into the `emojivoto` namespace by running:
 
 ```bash
-curl -sL https://run.linkerd.io/emojivoto.yml \
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/emojivoto.yml \
   | kubectl apply -f -
 ```
 

--- a/linkerd.io/content/2.9/tasks/books.md
+++ b/linkerd.io/content/2.9/tasks/books.md
@@ -34,7 +34,7 @@ terminal, run:
 
 ```bash
 kubectl create ns booksapp && \
-  curl -sL https://run.linkerd.io/booksapp.yml \
+  curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp.yml \
   | kubectl -n booksapp apply -f -
 ```
 
@@ -167,7 +167,7 @@ demo has published specs for each of its services. You can create a service
 profile for `webapp` by running:
 
 ```bash
-curl -sL https://run.linkerd.io/booksapp/webapp.swagger \
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp/webapp.swagger \
   | linkerd -n booksapp profile --open-api - webapp \
   | kubectl -n booksapp apply -f -
 ```
@@ -243,10 +243,10 @@ For this demo, the method is appended to the route regex.
 To get profiles for `authors` and `books`, you can run:
 
 ```bash
-curl -sL https://run.linkerd.io/booksapp/authors.swagger \
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp/authors.swagger \
   | linkerd -n booksapp profile --open-api - authors \
   | kubectl -n booksapp apply -f -
-curl -sL https://run.linkerd.io/booksapp/books.swagger \
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp/books.swagger \
   | linkerd -n booksapp profile --open-api - books \
   | kubectl -n booksapp apply -f -
 ```
@@ -466,7 +466,7 @@ the effective success rate for our route has dropped below 100%.
 To remove the books app and the booksapp namespace from your cluster, run:
 
 ```bash
-curl -sL https://run.linkerd.io/booksapp.yml \
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp.yml \
   | kubectl -n booksapp delete -f - \
   && kubectl delete ns booksapp
 ```

--- a/linkerd.io/content/2.9/tasks/books.md
+++ b/linkerd.io/content/2.9/tasks/books.md
@@ -34,7 +34,7 @@ terminal, run:
 
 ```bash
 kubectl create ns booksapp && \
-  curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp.yml \
+  curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/booksapp.yml \
   | kubectl -n booksapp apply -f -
 ```
 
@@ -167,7 +167,7 @@ demo has published specs for each of its services. You can create a service
 profile for `webapp` by running:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp/webapp.swagger \
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/booksapp/webapp.swagger \
   | linkerd -n booksapp profile --open-api - webapp \
   | kubectl -n booksapp apply -f -
 ```
@@ -243,10 +243,10 @@ For this demo, the method is appended to the route regex.
 To get profiles for `authors` and `books`, you can run:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp/authors.swagger \
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/booksapp/authors.swagger \
   | linkerd -n booksapp profile --open-api - authors \
   | kubectl -n booksapp apply -f -
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp/books.swagger \
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/booksapp/books.swagger \
   | linkerd -n booksapp profile --open-api - books \
   | kubectl -n booksapp apply -f -
 ```
@@ -466,7 +466,7 @@ the effective success rate for our route has dropped below 100%.
 To remove the books app and the booksapp namespace from your cluster, run:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp.yml \
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/booksapp.yml \
   | kubectl -n booksapp delete -f - \
   && kubectl delete ns booksapp
 ```

--- a/linkerd.io/content/2.9/tasks/securing-your-service.md
+++ b/linkerd.io/content/2.9/tasks/securing-your-service.md
@@ -94,7 +94,7 @@ service mesh itself. For example, with our [*emojivoto* demo
 application](../../getting-started/), we can add the debug sidecar by running:
 
 ```bash
-curl -sL https://run.linkerd.io/emojivoto.yml \
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/emojivoto.yml \
   | linkerd inject --enable-debug-sidecar - \
   | kubectl apply -f -
 ```

--- a/linkerd.io/content/2.9/tasks/securing-your-service.md
+++ b/linkerd.io/content/2.9/tasks/securing-your-service.md
@@ -94,7 +94,7 @@ service mesh itself. For example, with our [*emojivoto* demo
 application](../../getting-started/), we can add the debug sidecar by running:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/emojivoto.yml \
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/emojivoto.yml \
   | linkerd inject --enable-debug-sidecar - \
   | kubectl apply -f -
 ```

--- a/linkerd.io/content/2.9/tasks/upgrade.md
+++ b/linkerd.io/content/2.9/tasks/upgrade.md
@@ -38,7 +38,7 @@ free to skip to the [Helm section](#with-helm).
 To upgrade the CLI locally, run:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Alternatively, you can download the CLI directly via the
@@ -375,7 +375,7 @@ are retained.
 
 ```bash
 # get the latest stable CLI
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 {{< note >}} The linkerd cli installer installs the CLI binary into a
@@ -442,7 +442,7 @@ are retained.
 
 ```bash
 # get the latest stable CLI
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 For Kubernetes 1.12+:
@@ -544,7 +544,7 @@ kubectl -n linkerd delete deploy/linkerd-ca
 
 ```bash
 # get the latest stable
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 
 # upgrade the control plane
 linkerd upgrade | kubectl apply --prune -l linkerd.io/control-plane-ns=linkerd -f -
@@ -637,7 +637,7 @@ information on disk, such as using tools like
 
 ```bash
 # get the latest stable
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 
 # Install stable control plane, using flags previously supplied during
 # installation.
@@ -697,7 +697,7 @@ these instructions for anywhere that uses the linkerd CLI.
 To upgrade the CLI locally, run:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Alternatively, you can download the CLI directly via the

--- a/linkerd.io/content/2.9/tasks/upgrade.md
+++ b/linkerd.io/content/2.9/tasks/upgrade.md
@@ -38,7 +38,7 @@ free to skip to the [Helm section](#with-helm).
 To upgrade the CLI locally, run:
 
 ```bash
-curl -sL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Alternatively, you can download the CLI directly via the
@@ -375,7 +375,7 @@ are retained.
 
 ```bash
 # get the latest stable CLI
-curl -sL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 {{< note >}} The linkerd cli installer installs the CLI binary into a
@@ -442,7 +442,7 @@ are retained.
 
 ```bash
 # get the latest stable CLI
-curl -sL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 For Kubernetes 1.12+:
@@ -544,7 +544,7 @@ kubectl -n linkerd delete deploy/linkerd-ca
 
 ```bash
 # get the latest stable
-curl -sL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 
 # upgrade the control plane
 linkerd upgrade | kubectl apply --prune -l linkerd.io/control-plane-ns=linkerd -f -
@@ -637,7 +637,7 @@ information on disk, such as using tools like
 
 ```bash
 # get the latest stable
-curl -sL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 
 # Install stable control plane, using flags previously supplied during
 # installation.
@@ -697,7 +697,7 @@ these instructions for anywhere that uses the linkerd CLI.
 To upgrade the CLI locally, run:
 
 ```bash
-curl -sL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Alternatively, you can download the CLI directly via the

--- a/linkerd.io/content/blog/announcing-linkerd-2-0.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-0.md
@@ -17,7 +17,7 @@ On behalf of the Linkerd maintainers, I’m happy to announce that Linkerd 2.0 i
 You can try Linkerd 2.0 on a Kubernetes 1.9+ cluster in 60 seconds by running:
 
 ```bash
-curl https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 (Or check out the full [Getting Started Guide](https://linkerd.io/2/getting-started/).)

--- a/linkerd.io/content/blog/announcing-linkerd-2-0.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-0.md
@@ -17,7 +17,7 @@ On behalf of the Linkerd maintainers, I’m happy to announce that Linkerd 2.0 i
 You can try Linkerd 2.0 on a Kubernetes 1.9+ cluster in 60 seconds by running:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 (Or check out the full [Getting Started Guide](https://linkerd.io/2/getting-started/).)

--- a/linkerd.io/content/blog/announcing-linkerd-2-1.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-1.md
@@ -15,7 +15,7 @@ Today we're very happy to announce the release of [Linkerd 2.1](https://github.c
 Those of you who have been tracking the 2.x branch via our [weekly edge releases](https://linkerd.io/2/edge/) will already have seen these these features in action. For the rest of you, you can download the stable 2.1 release by running:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install
 ```
 
 ## Per-route metrics

--- a/linkerd.io/content/blog/announcing-linkerd-2-1.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-1.md
@@ -15,7 +15,7 @@ Today we're very happy to announce the release of [Linkerd 2.1](https://github.c
 Those of you who have been tracking the 2.x branch via our [weekly edge releases](https://linkerd.io/2/edge/) will already have seen these these features in action. For the rest of you, you can download the stable 2.1 release by running:
 
 ```bash
-curl https://run.linkerd.io/install
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install
 ```
 
 ## Per-route metrics

--- a/linkerd.io/content/blog/announcing-linkerd-2-10.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-10.md
@@ -164,7 +164,7 @@ Ready to try Linkerd? Those of you who have been tracking the 2.x branch via
 our [weekly edge releases](/edge/) will already have seen these features
 in action. Either way, you can download the stable 2.10 release by running:
 
-`curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh`
+`curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh`
 
 Using Helm? See our [guide to installing Linkerd with
 Helm](/2.10/tasks/install-helm/). Upgrading from an earlier release? We've got

--- a/linkerd.io/content/blog/announcing-linkerd-2-10.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-10.md
@@ -164,7 +164,7 @@ Ready to try Linkerd? Those of you who have been tracking the 2.x branch via
 our [weekly edge releases](/edge/) will already have seen these features
 in action. Either way, you can download the stable 2.10 release by running:
 
-`curl https://run.linkerd.io/install | sh`
+`curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh`
 
 Using Helm? See our [guide to installing Linkerd with
 Helm](/2.10/tasks/install-helm/). Upgrading from an earlier release? We've got

--- a/linkerd.io/content/blog/announcing-linkerd-2-2.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-2.md
@@ -18,7 +18,7 @@ This release includes contributions from folks at Attest, Buoyant, Mesosphere, M
 Those of you who have been tracking the 2.x branch via our [weekly edge releases](https://linkerd.io/2/edge/) will already have seen these these features in action. Either way, you can download the stable 2.2 release by running:
 
 ```bash
-curl https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 With that, on to the features!

--- a/linkerd.io/content/blog/announcing-linkerd-2-2.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-2.md
@@ -18,7 +18,7 @@ This release includes contributions from folks at Attest, Buoyant, Mesosphere, M
 Those of you who have been tracking the 2.x branch via our [weekly edge releases](https://linkerd.io/2/edge/) will already have seen these these features in action. Either way, you can download the stable 2.2 release by running:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 With that, on to the features!

--- a/linkerd.io/content/blog/announcing-linkerd-2-3.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-3.md
@@ -34,7 +34,7 @@ This release represents a major step forward in Linkerd's security roadmap. In a
 Ready to try it? Those of you who have been tracking the 2.x branch via our [weekly edge releases](https://linkerd.io/2/edge) will already have seen these features in action. Either way, you can download the stable 2.3 release by running:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Finally, we'd be remiss if we didn't point out that this approach has been deeply inspired by our friends at [Smallstep](https://smallstep.com/), [Cloudflare](https://www.cloudflare.com/), [Let's Encrypt](https://letsencrypt.org/), [Mozilla](https://www.mozilla.org/), and other amazing organizations that strive to make the Internet secure by default.

--- a/linkerd.io/content/blog/announcing-linkerd-2-3.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-3.md
@@ -34,7 +34,7 @@ This release represents a major step forward in Linkerd's security roadmap. In a
 Ready to try it? Those of you who have been tracking the 2.x branch via our [weekly edge releases](https://linkerd.io/2/edge) will already have seen these features in action. Either way, you can download the stable 2.3 release by running:
 
 ```bash
-curl https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Finally, we'd be remiss if we didn't point out that this approach has been deeply inspired by our friends at [Smallstep](https://smallstep.com/), [Cloudflare](https://www.cloudflare.com/), [Let's Encrypt](https://letsencrypt.org/), [Mozilla](https://www.mozilla.org/), and other amazing organizations that strive to make the Internet secure by default.

--- a/linkerd.io/content/blog/announcing-linkerd-2-4.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-4.md
@@ -74,7 +74,7 @@ features in action. Either way, you can download the stable 2.4 release by
 running:
 
 ```bash
-    curl https://run.linkerd.io/install | sh
+    curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Linkerd is a community project and is hosted by the [Cloud Native Computing

--- a/linkerd.io/content/blog/announcing-linkerd-2-4.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-4.md
@@ -74,7 +74,7 @@ features in action. Either way, you can download the stable 2.4 release by
 running:
 
 ```bash
-    curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+    curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Linkerd is a community project and is hosted by the [Cloud Native Computing

--- a/linkerd.io/content/blog/announcing-linkerd-2-5.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-5.md
@@ -73,7 +73,7 @@ these features in action. Either way, you can download the stable 2.5 release
 by running:
 
 ```bash
-curl https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Upgrading from a previous release? See our handy [Linkerd upgrade

--- a/linkerd.io/content/blog/announcing-linkerd-2-5.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-5.md
@@ -73,7 +73,7 @@ these features in action. Either way, you can download the stable 2.5 release
 by running:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Upgrading from a previous release? See our handy [Linkerd upgrade

--- a/linkerd.io/content/blog/announcing-linkerd-2-6.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-6.md
@@ -90,7 +90,7 @@ these features in action. Either way, you can download the stable 2.6 release
 by running:
 
 ```bash
-curl https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Upgrading from a previous release? See our handy [Linkerd upgrade

--- a/linkerd.io/content/blog/announcing-linkerd-2-6.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-6.md
@@ -90,7 +90,7 @@ these features in action. Either way, you can download the stable 2.6 release
 by running:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Upgrading from a previous release? See our handy [Linkerd upgrade

--- a/linkerd.io/content/blog/announcing-linkerd-2-7.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-7.md
@@ -103,7 +103,7 @@ these features in action. Either way, you can download the stable 2.7 release
 by running:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Using Helm? See our [guide to installing Linkerd with

--- a/linkerd.io/content/blog/announcing-linkerd-2-7.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-7.md
@@ -103,7 +103,7 @@ these features in action. Either way, you can download the stable 2.7 release
 by running:
 
 ```bash
-curl https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Using Helm? See our [guide to installing Linkerd with

--- a/linkerd.io/content/blog/announcing-linkerd-2-8.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-8.md
@@ -149,7 +149,7 @@ features in action. Either way, you can download the stable 2.8 release by
 running:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Using Helm? See our

--- a/linkerd.io/content/blog/announcing-linkerd-2-8.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-8.md
@@ -149,7 +149,7 @@ features in action. Either way, you can download the stable 2.8 release by
 running:
 
 ```bash
-curl https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Using Helm? See our

--- a/linkerd.io/content/blog/announcing-linkerd-2-9.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-9.md
@@ -159,7 +159,7 @@ features in action. Either way, you can download the stable 2.9 release by
 running:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Using Helm? See our

--- a/linkerd.io/content/blog/announcing-linkerd-2-9.md
+++ b/linkerd.io/content/blog/announcing-linkerd-2-9.md
@@ -159,7 +159,7 @@ features in action. Either way, you can download the stable 2.9 release by
 running:
 
 ```bash
-curl https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Using Helm? See our

--- a/linkerd.io/content/blog/debugging-node-services-in-kubernetes-with-linkerd-2-0.md
+++ b/linkerd.io/content/blog/debugging-node-services-in-kubernetes-with-linkerd-2-0.md
@@ -42,7 +42,7 @@ This application has a major bug in it, which we’ll debug by using Linkerd’s
 Before we install Linkerd, let’s install the Nodevoto demo app. In your laptop’s terminal window, run:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/emojivoto.yml | kubectl apply -f -
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/emojivoto.yml | kubectl apply -f -
 ```
 
 This command downloads the Kubernetes manifest for Nodevoto, and uses _kubectl_ to apply it to your Kubernetes cluster. Nodevoto is comprised of several services that run in the “nodevoto” namespace. You can see the services by running:
@@ -74,7 +74,7 @@ This is a very common type of failure scenario: Kubernetes thinks everything’s
 We’ll start by installing Linkerd’s command-line interface (CLI) onto your local machine. Visit the [Linkerd releases page](https://github.com/linkerd/linkerd2/releases/), or simply run:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Once installed, add the `linkerd` command to your path with:

--- a/linkerd.io/content/blog/debugging-node-services-in-kubernetes-with-linkerd-2-0.md
+++ b/linkerd.io/content/blog/debugging-node-services-in-kubernetes-with-linkerd-2-0.md
@@ -42,7 +42,7 @@ This application has a major bug in it, which we’ll debug by using Linkerd’s
 Before we install Linkerd, let’s install the Nodevoto demo app. In your laptop’s terminal window, run:
 
 ```bash
-curl https://run.linkerd.io/emojivoto.yml | kubectl apply -f -
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/emojivoto.yml | kubectl apply -f -
 ```
 
 This command downloads the Kubernetes manifest for Nodevoto, and uses _kubectl_ to apply it to your Kubernetes cluster. Nodevoto is comprised of several services that run in the “nodevoto” namespace. You can see the services by running:
@@ -74,7 +74,7 @@ This is a very common type of failure scenario: Kubernetes thinks everything’s
 We’ll start by installing Linkerd’s command-line interface (CLI) onto your local machine. Visit the [Linkerd releases page](https://github.com/linkerd/linkerd2/releases/), or simply run:
 
 ```bash
-curl -sL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Once installed, add the `linkerd` command to your path with:

--- a/linkerd.io/content/blog/debugging-ruby-services-in-kubernetes-with-linkerd.md
+++ b/linkerd.io/content/blog/debugging-ruby-services-in-kubernetes-with-linkerd.md
@@ -48,7 +48,7 @@ Before we install Linkerd, let’s add the books app onto your cluster. In your 
 
 ```bash
 kubectl create ns booksapp && \
-  curl -sL https://run.linkerd.io/booksapp.yml | \
+  curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp.yml | \
   kubectl -n booksapp apply -f -
 ```
 
@@ -94,7 +94,7 @@ In the next few steps, we’ll walk you through how to use Linkerd to diagnose t
 We’ll start by installing Linkerd’s command-line interface (CLI) onto your local machine. Visit the Linkerd releases page, or simply run:
 
 ```bash
-curl -sL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Once installed, add the linkerd command to your path with:

--- a/linkerd.io/content/blog/debugging-ruby-services-in-kubernetes-with-linkerd.md
+++ b/linkerd.io/content/blog/debugging-ruby-services-in-kubernetes-with-linkerd.md
@@ -48,7 +48,7 @@ Before we install Linkerd, let’s add the books app onto your cluster. In your 
 
 ```bash
 kubectl create ns booksapp && \
-  curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp.yml | \
+  curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/booksapp.yml | \
   kubectl -n booksapp apply -f -
 ```
 
@@ -94,7 +94,7 @@ In the next few steps, we’ll walk you through how to use Linkerd to diagnose t
 We’ll start by installing Linkerd’s command-line interface (CLI) onto your local machine. Visit the Linkerd releases page, or simply run:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Once installed, add the linkerd command to your path with:

--- a/linkerd.io/content/blog/failure-injection-using-the-service-mesh-interface-and-linkerd.md
+++ b/linkerd.io/content/blog/failure-injection-using-the-service-mesh-interface-and-linkerd.md
@@ -51,7 +51,7 @@ We'll start by installing the Linkerd CLI and deploying it on our Kubernetes
 cluster:
 
 ```bash
-> curl https://run.linkerd.io/install | sh
+> curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 > export PATH=$PATH:$HOME/.linkerd2/bin
 > linkerd install | kubectl apply -f -
 > linkerd check

--- a/linkerd.io/content/blog/failure-injection-using-the-service-mesh-interface-and-linkerd.md
+++ b/linkerd.io/content/blog/failure-injection-using-the-service-mesh-interface-and-linkerd.md
@@ -51,7 +51,7 @@ We'll start by installing the Linkerd CLI and deploying it on our Kubernetes
 cluster:
 
 ```bash
-> curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+> curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 > export PATH=$PATH:$HOME/.linkerd2/bin
 > linkerd install | kubectl apply -f -
 > linkerd check

--- a/linkerd.io/content/blog/happy-birthday-linkerd.md
+++ b/linkerd.io/content/blog/happy-birthday-linkerd.md
@@ -108,7 +108,7 @@ these features in action. Either way, you can download the stable 2.5 release
 by running:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Linkerd is a community project and is hosted by the [Cloud Native Computing

--- a/linkerd.io/content/blog/happy-birthday-linkerd.md
+++ b/linkerd.io/content/blog/happy-birthday-linkerd.md
@@ -108,7 +108,7 @@ these features in action. Either way, you can download the stable 2.5 release
 by running:
 
 ```bash
-curl https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Linkerd is a community project and is hosted by the [Cloud Native Computing

--- a/linkerd.io/content/blog/how-we-designed-retries-in-linkerd-2-2.md
+++ b/linkerd.io/content/blog/how-we-designed-retries-in-linkerd-2-2.md
@@ -89,7 +89,7 @@ We've shown how you can configure Linkerd's retry behavior by combining timeouts
 
 ```bash
 linkerd install | kubectl apply -f - && \
-  curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp.yml | linkerd inject - | kubectl apply -f - && \
+  curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/booksapp.yml | linkerd inject - | kubectl apply -f - && \
   linkerd check
 ```
 
@@ -105,7 +105,7 @@ To get a better picture of what’s going on here, let’s add a service profile
 
 <!-- markdownlint-disable MD014 -->
 ```bash
-$ curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp/authors.swagger | linkerd profile --open-api - authors | kubectl apply -f  -
+$ curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/booksapp/authors.swagger | linkerd profile --open-api - authors | kubectl apply -f  -
 $ linkerd routes deploy/books --to svc/authors
 ROUTE                       SERVICE   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
 DELETE /authors/{id}.json   authors     0.00%   0.0rps           0ms           0ms           0ms

--- a/linkerd.io/content/blog/how-we-designed-retries-in-linkerd-2-2.md
+++ b/linkerd.io/content/blog/how-we-designed-retries-in-linkerd-2-2.md
@@ -89,7 +89,7 @@ We've shown how you can configure Linkerd's retry behavior by combining timeouts
 
 ```bash
 linkerd install | kubectl apply -f - && \
-  curl https://run.linkerd.io/booksapp.yml | linkerd inject - | kubectl apply -f - && \
+  curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp.yml | linkerd inject - | kubectl apply -f - && \
   linkerd check
 ```
 
@@ -105,7 +105,7 @@ To get a better picture of what’s going on here, let’s add a service profile
 
 <!-- markdownlint-disable MD014 -->
 ```bash
-$ curl https://run.linkerd.io/booksapp/authors.swagger | linkerd profile --open-api - authors | kubectl apply -f  -
+$ curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp/authors.swagger | linkerd profile --open-api - authors | kubectl apply -f  -
 $ linkerd routes deploy/books --to svc/authors
 ROUTE                       SERVICE   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
 DELETE /authors/{id}.json   authors     0.00%   0.0rps           0ms           0ms           0ms

--- a/linkerd.io/content/blog/linkerd-and-open-governance.md
+++ b/linkerd.io/content/blog/linkerd-and-open-governance.md
@@ -67,7 +67,7 @@ amazing project together.
 Ready to try Linkerd? You can try the latest stable release by running:
 
 ```bash
-curl https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Linkerd is a community project and is hosted by the [Cloud Native Computing

--- a/linkerd.io/content/blog/linkerd-and-open-governance.md
+++ b/linkerd.io/content/blog/linkerd-and-open-governance.md
@@ -67,7 +67,7 @@ amazing project together.
 Ready to try Linkerd? You can try the latest stable release by running:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 Linkerd is a community project and is hosted by the [Cloud Native Computing

--- a/linkerd.io/content/blog/linkerd-service-account-tokens.md
+++ b/linkerd.io/content/blog/linkerd-service-account-tokens.md
@@ -21,7 +21,7 @@ order to understand that, first we need to understand how Linkerd uses service
 accounts.
 
 Linkerd provides mutual TLS (mTLS) to secure communication between workloads.
-Central to any type of communication security is the notion of *identity*—as
+Central to any type of communication security is the notion of *identity* —as
 discussed in the [Kubernetes engineer’s guide to mTLS](https://buoyant.io/mtls-guide/),
 without identity you have no authenticity, and without authenticity you do not have
 secure communication. All of Linkerd's mTLS magic is possible because the

--- a/linkerd.io/content/blog/service-profiles-for-per-route-metrics.md
+++ b/linkerd.io/content/blog/service-profiles-for-per-route-metrics.md
@@ -105,7 +105,7 @@ Here's a quick example you can try at home to see just how easy it is to get per
 ```bash
 linkerd install | kubectl apply -f -
 linkerd check
-curl https://run.linkerd.io/booksapp.yml | linkerd inject - | kubectl apply -f -
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp.yml | linkerd inject - | kubectl apply -f -
 ```
 
 At this point, the Books app is installed and receiving traffic from a built-in traffic generator. We would like to see per-route metrics for the `webapp` service—but we can't, because we haven't defined any routes for that service yet!

--- a/linkerd.io/content/blog/service-profiles-for-per-route-metrics.md
+++ b/linkerd.io/content/blog/service-profiles-for-per-route-metrics.md
@@ -105,7 +105,7 @@ Here's a quick example you can try at home to see just how easy it is to get per
 ```bash
 linkerd install | kubectl apply -f -
 linkerd check
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/booksapp.yml | linkerd inject - | kubectl apply -f -
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/booksapp.yml | linkerd inject - | kubectl apply -f -
 ```
 
 At this point, the Books app is installed and receiving traffic from a built-in traffic generator. We would like to see per-route metrics for the `webapp` service—but we can't, because we haven't defined any routes for that service yet!

--- a/linkerd.io/content/blog/the-roadmap-for-linkerd-proxy.md
+++ b/linkerd.io/content/blog/the-roadmap-for-linkerd-proxy.md
@@ -139,7 +139,7 @@ Kubernetes cluster in a matter of minutes. Download the latest stable release
 by running:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 You can be up and running with a functioning service mesh (and an awesome Rust

--- a/linkerd.io/content/blog/the-roadmap-for-linkerd-proxy.md
+++ b/linkerd.io/content/blog/the-roadmap-for-linkerd-proxy.md
@@ -139,7 +139,7 @@ Kubernetes cluster in a matter of minutes. Download the latest stable release
 by running:
 
 ```bash
-curl https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 You can be up and running with a functioning service mesh (and an awesome Rust

--- a/linkerd.io/content/edge/_index.md
+++ b/linkerd.io/content/edge/_index.md
@@ -14,7 +14,7 @@ Stable releases are periodic, and focus on stability. To install a stable
 release, you can run:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
 ## Edge (latest version: {{% latestedge %}})
@@ -25,5 +25,5 @@ more focused on adding new functionality. To install an edge release, you can
 run:
 
 ```bash
-curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install-edge | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install-edge | sh
 ```

--- a/linkerd.io/content/edge/_index.md
+++ b/linkerd.io/content/edge/_index.md
@@ -14,7 +14,7 @@ Stable releases are periodic, and focus on stability. To install a stable
 release, you can run:
 
 ```bash
-curl -sL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install | sh
 ```
 
 ## Edge (latest version: {{% latestedge %}})
@@ -25,5 +25,5 @@ more focused on adding new functionality. To install an edge release, you can
 run:
 
 ```bash
-curl -sL https://run.linkerd.io/install-edge | sh
+curl --proto '=https' --tlsv1.3 -sSfL https://run.linkerd.io/install-edge | sh
 ```

--- a/run.linkerd.io/public/install
+++ b/run.linkerd.io/public/install
@@ -25,7 +25,7 @@ happyexit() {
 
 validate_checksum() {
   filename=$1
-  SHA=$(curl --proto='=https' --tlsv1.3 -sSfL "${url}.sha256")
+  SHA=$(curl --proto='=https' --tlsv1.2 -sSfL "${url}.sha256")
   echo ""
   echo "Validating checksum..."
 
@@ -117,7 +117,7 @@ fi
   cd "$tmpdir"
 
   echo "Downloading ${srcfile}..."
-  curl --proto='=https' --tlsv1.3 -fLO "${url}"
+  curl --proto='=https' --tlsv1.2 -fLO "${url}"
   echo "Download complete!"
 
   if ! validate_checksum "${srcfile}"; then

--- a/run.linkerd.io/public/install
+++ b/run.linkerd.io/public/install
@@ -25,7 +25,7 @@ happyexit() {
 
 validate_checksum() {
   filename=$1
-  SHA=$(curl -sfL "${url}.sha256")
+  SHA=$(curl --proto='=https' --tlsv1.3 -sSfL "${url}.sha256")
   echo ""
   echo "Validating checksum..."
 
@@ -117,7 +117,7 @@ fi
   cd "$tmpdir"
 
   echo "Downloading ${srcfile}..."
-  curl -fLO "${url}"
+  curl --proto='=https' --tlsv1.3 -fLO "${url}"
   echo "Download complete!"
 
   if ! validate_checksum "${srcfile}"; then

--- a/run.linkerd.io/public/install-edge
+++ b/run.linkerd.io/public/install-edge
@@ -30,7 +30,7 @@ happyexit() {
 
 validate_checksum() {
   filename=$1
-  SHA=$(curl --proto='=https' --tlsv1.3 -sSfL "${url}.sha256")
+  SHA=$(curl --proto='=https' --tlsv1.2 -sSfL "${url}.sha256")
   echo ""
   echo "Validating checksum..."
 
@@ -134,7 +134,7 @@ fi
   cd "$tmpdir"
 
   echo "Downloading ${srcfile}..."
-  curl --proto '=https' --tlsv1.3 -fLO "${url}"
+  curl --proto '=https' --tlsv1.2 -fLO "${url}"
   echo "Download complete!"
 
   if ! validate_checksum "${srcfile}"; then

--- a/run.linkerd.io/public/install-edge
+++ b/run.linkerd.io/public/install-edge
@@ -30,7 +30,7 @@ happyexit() {
 
 validate_checksum() {
   filename=$1
-  SHA=$(curl -sfL "${url}.sha256")
+  SHA=$(curl --proto='=https' --tlsv1.3 -sSfL "${url}.sha256")
   echo ""
   echo "Validating checksum..."
 
@@ -134,7 +134,7 @@ fi
   cd "$tmpdir"
 
   echo "Downloading ${srcfile}..."
-  curl -fLO "${url}"
+  curl --proto '=https' --tlsv1.3 -fLO "${url}"
   echo "Download complete!"
 
   if ! validate_checksum "${srcfile}"; then


### PR DESCRIPTION
Our usage of `curl` could be vulnerable to protocol downgrade attacks. This
change updates most of our usage of curl--especially when fetching executable
resources--with the following command-line flags:

* `--proto '=https'` forces use of HTTPS. This ensures that dropping `https://`
  from a URL will cause the command to fail instead of reverting to use
  unsecured HTTP.
* `--tlsv1.2` disables the use of older TLS versions.
* `-f|--fail` ensures that curl does not output anything to stdout when a
  non-2xx response is received.
* `-S|--show-error` causes errors to be printed to stderr (when `-s|--silent`
  is used).

Related to linkerd/linkerd2#7593

Signed-off-by: Oliver Gould <ver@buoyant.io>