### PR TITLE
Fix admission controller link in architecture.md

### DIFF
--- a/linkerd.io/content/2.11/reference/architecture.md
+++ b/linkerd.io/content/2.11/reference/architecture.md
@@ -53,7 +53,7 @@ initialization time and are used for proxy-to-proxy connections to implement
 
 ### The proxy injector
 
-The proxy injector is a Kubernetes [admission controller][admission-controller]
+The proxy injector is a Kubernetes [admission controller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/)
 that receives a webhook request every time a pod is created. This injector
 inspects resources for a Linkerd-specific annotation (`linkerd.io/inject:
 enabled`). When that annotation exists, the injector mutates the pod's


### PR DESCRIPTION
Was reading architecture and noticed a typo in the markdown link to K8s admission controller docs.