### PR TITLE
Fix port to proxy's inbound port

### DIFF
--- a/linkerd.io/content/2.9/tasks/installing-multicluster.md
+++ b/linkerd.io/content/2.9/tasks/installing-multicluster.md
@@ -113,7 +113,7 @@ First, you'll want to inject the `ambassador` deployment with Linkerd:
 kubectl -n ambassador get deploy ambassador -o yaml | \
     linkerd inject \
     --skip-inbound-ports 80,443 \
-    --require-identity-on-inbound-ports 4183 - | \
+    --require-identity-on-inbound-ports 4143 - | \
     kubectl apply -f -
 ```
 


### PR DESCRIPTION
Closes linkerd/linkerd2#7612.

The gateway port is `4143`, not `4183`.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>