### PR TITLE
Fix cli/annotations shortcode

### DIFF
--- a/linkerd.io/layouts/shortcodes/cli/annotations.html
+++ b/linkerd.io/layouts/shortcodes/cli/annotations.html
@@ -1,10 +1,10 @@
 {{ $docsVersion := index (split .Page.URL "/") 1 }}
 {{/* the index function doesn't accept variables */}}
-{{ $data := (index site.Data "cli").CLIReference }}
+{{ $data := (index site.Data "cli").AnnotationsReference }}
 {{ if eq $docsVersion "2.10" }}
-{{ $data = (index site.Data "cli-2-10").CLIReference }}
+{{ $data = (index site.Data "cli-2-10").AnnotationsReference }}
 {{ else if eq $docsVersion "2.11" }}
-{{ $data = (index site.Data "cli-2-11").CLIReference }}
+{{ $data = (index site.Data "cli-2-11").AnnotationsReference }}
 {{ end }}
 <div class="table-container">
   <table class="table table-striped">


### PR DESCRIPTION
Fixes #1297

The proxy reference page instead of showing the annotations list was
showing the list of commands.