### PR TITLE
Update canary-release.md: add prereq of SMI-extension

### DIFF
--- a/linkerd.io/content/2.11/tasks/canary-release.md
+++ b/linkerd.io/content/2.11/tasks/canary-release.md
@@ -27,6 +27,7 @@ allowing for fully-automated, metrics-aware canary deployments.
   along with its Viz extension.
   Follow the [Installing Linkerd Guide](../install/) if you haven't
   already done this.
+- The installation of [Linkerd-SMI extension](../linkerd-smi/).
 - The installation of Flagger depends on `kubectl` 1.14 or newer.
 
 ## Install Flagger


### PR DESCRIPTION
It's not obvious in the docs that we need to install the Linkerd SMI-extension before following this tutorial. This PR adds that prereq.