### PR TITLE
Update linkerd-smi.md: fix URL for trafficsplit sample app

### DIFF
--- a/linkerd.io/content/2.11/tasks/canary-release.md
+++ b/linkerd.io/content/2.11/tasks/canary-release.md
@@ -27,6 +27,7 @@ allowing for fully-automated, metrics-aware canary deployments.
   along with its Viz extension.
   Follow the [Installing Linkerd Guide](../install/) if you haven't
   already done this.
+- The installation of [Linkerd-SMI extension](../linkerd-smi/).
 - The installation of Flagger depends on `kubectl` 1.14 or newer.
 
 ## Install Flagger

--- a/linkerd.io/content/2.11/tasks/linkerd-smi.md
+++ b/linkerd.io/content/2.11/tasks/linkerd-smi.md
@@ -78,7 +78,7 @@ First, let's install the sample application.
 kubectl create namespace trafficsplit-sample
 
 # install the sample application
-linkerd inject https://raw.githubusercontent.com/linkerd/linkerd2/main/test/integration/trafficsplit/testdata/application.yaml | kubectl -n trafficsplit-sample apply -f -
+linkerd inject https://raw.githubusercontent.com/linkerd/linkerd2/main/test/integration/viz/trafficsplit/testdata/application.yaml | kubectl -n trafficsplit-sample apply -f -
 ```
 
 This installs a simple client, and two server deployments.


### PR DESCRIPTION
The URL for the `trafficsplit` sample app is wrong. This PR fixes it.