### PR TITLE
Update getting started guide for Buoyant Cloud extension

### DIFF
--- a/linkerd.io/content/2.11/tasks/extensions.md
+++ b/linkerd.io/content/2.11/tasks/extensions.md
@@ -43,12 +43,25 @@ automatically call the `linkerd-foo` binary, if it is found on your path.)
 
 [Buoyant Cloud](https://buoyant.io/cloud) is a hosted Linkerd management service
 with a comprehensive multi-cluster dashboard. The Buoyant Cloud extension will
-connect your cluster to Buoyant Cloud. To install this extension, run:
+connect your cluster to Buoyant Cloud. In order to use the extension, you
+must first install the CLI:
 
 ```bash
-## optional
+## adds an optional extension to the linkerd CLI
 curl --proto '=https' --tlsv1.2 -sSfL https://buoyant.cloud/install | sh
-linkerd buoyant install | kubectl apply -f - # free, hosted metrics dashboard
+```
+
+Once you've installed the CLI, you can register with Buoyant Cloud and obtain
+your API credentials by visiting the
+[Settings](https://buoyant.cloud/settings?cli=1) page. That page will give you a
+command to run that installs the Buoyant Cloud extension on your cluster. If you
+already know your API credentials, you can run:
+
+```bash
+BUOYANT_CLOUD_CLIENT_ID=<your client id> \
+BUOYANT_CLOUD_CLIENT_SECRET=<your client secret> \
+linkerd buoyant install --cluster-name=my-new-cluster | \
+kubectl apply -f - # installs a free, hosted metrics dashboard
 ```
 
 To access Buoyant Cloud at any point, you can run:


### PR DESCRIPTION
Add more info about installing the Buoyant Cloud extension, now that auto-cluster registration is supported.

This replaces #1324.