### PR TITLE
Add a devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,12 @@
 {
-    "name": "linkerd2",
-    "image": "buoyantio/website-builder:v1.3.3",
-    // "dockerFile": "./Dockerfile",
+    "name": "website",
+    //"image": "buoyantio/website-builder:v1.3.3",
+    "build": {
+        "dockerfile": "../Dockerfile"
+    },
     // "context": "..",
-    "extensions": [
-        "samverschueren.final-newline"
-    ],
     "overrideCommand": false,
-    "remoteUser": "code",
+    "remoteUser": "root",
     "mounts": [
         "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"
     ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+    "name": "linkerd2",
+    "image": "buoyantio/website-builder:v1.3.3",
+    // "dockerFile": "./Dockerfile",
+    // "context": "..",
+    "extensions": [
+        "samverschueren.final-newline"
+    ],
+    "overrideCommand": false,
+    "remoteUser": "code",
+    "mounts": [
+        "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"
+    ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,26 @@
-FROM circleci/node:12
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:12-bullseye
 
 USER root
 
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
-    lsb-core \
-    apt-transport-https \
-    shellcheck \
-  && export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" \
-  && echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" \
-    | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
-  && curl --proto '=https' --tlsv1.2 -sSfL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
-    | apt-key add - \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends google-cloud-sdk \
-  && wget https://github.com/gohugoio/hugo/releases/download/v0.61.0/hugo_extended_0.61.0_Linux-64bit.deb \
+RUN apt update && apt upgrade -y
+RUN apt install -y shellcheck
+RUN wget https://github.com/gohugoio/hugo/releases/download/v0.61.0/hugo_extended_0.61.0_Linux-64bit.deb \
   && dpkg -i hugo*.deb \
-  && rm hugo*.deb \
-  && curl --proto '=https' --tlsv1.2 -sSfL https://htmltest.wjdp.uk | bash \
-  && mv bin/htmltest /usr/local/bin \
-  && npm install -g markdownlint-cli \
-  && rm -rf /var/lib/apt/lists/*
+  && rm hugo*.deb 
+RUN curl --proto '=https' --tlsv1.2 -sSfL https://htmltest.wjdp.uk | bash \
+  && mv bin/htmltest /usr/local/bin
+RUN npm install -g markdownlint-cli@0.26.0
+RUN curl --proto '=https' --tlsv1.2 -sSfL https://sdk.cloud.google.com | bash
+ENV PATH $PATH:/root/google-cloud-sdk/bin
+
+# Install a Docker client that uses the host's Docker daemon
+ARG USE_MOBY=false
+ENV DOCKER_BUILDKIT=1
+RUN curl --proto '=https' --tlsv1.2 -sSfL https://raw.githubusercontent.com/microsoft/vscode-dev-containers/main/script-library/docker-debian.sh \
+    | bash -s --  true /var/run/docker-host.sock /var/run/docker.sock "${USER}" "${USE_MOBY}" latest
+
+RUN sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen && locale-gen
+RUN (echo "LC_ALL=en_US.UTF-8" \
+    && echo "LANGUAGE=en_US.UTF-8") >/etc/default/locale
+
+CMD ["sleep", "infinity"]


### PR DESCRIPTION
In order to have a more reproducible dev environment for the website, we update the website-builder docker image to make it suitable for use as a devcontainer.

Once merged, we will update the BUILD_IMAGE version of website-builder from 1.3.3 to 1.4.0, and publish it as 1.4.0 and have CI use this new version.  This will ensure consistency between dev and CI.