### PR TITLE
Add env variable to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,5 @@ jobs:
         gcloud auth activate-service-account --key-file=.gcp.json
 
     - name: Publish
-      env:
-        GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
       run: |-
         make publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,5 +26,7 @@ jobs:
         gcloud auth activate-service-account --key-file=.gcp.json
 
     - name: Publish
+      env:
+        GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
       run: |-
         make publish

--- a/linkerd.io/build
+++ b/linkerd.io/build
@@ -3,7 +3,6 @@
 set -e
 
 BASE_DIR=$(pwd -P)
-CURRENT_SHA=$(git rev-parse --short HEAD)
 
 rm -rf $BASE_DIR/public
 hugo


### PR DESCRIPTION
The publish step seems to fail when trying to build the website. Inside the build script, a `CURRENT_SHA` env variable is set to the latest git commit sha. When building the website, however, the contents are moved to a temp directory that does not appear to be a git repository. Because of this, attempting to do `git rev-parse` to set the value of `CURRENT_SHA` fails.

This change removes the unused `CURRENT_SHA` variable to allow the site to be built.

The `CURRENT_SHA` variable appears to be unused

Signed-off-by: Matei David <matei@buoyant.io>