### PR TITLE
Run shellcheck on all bash scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,10 @@ endif
 .PHONY: shellcheck
 shellcheck:
 	@# lint the install scripts
-	shellcheck run.linkerd.io/public/install*
+	shellcheck run.linkerd.io/public/install* \
+		api.linkerd.io/build \
+		linkerd.io/build \
+		linkerd.io/release-next-version
 
 .PHONY: test-ci
 test-ci:

--- a/api.linkerd.io/build
+++ b/api.linkerd.io/build
@@ -3,10 +3,10 @@ set -e
 
 BASE_DIR=$(pwd -P)
 
-mkdir -p $BASE_DIR/public
+mkdir -p "$BASE_DIR"/public
 
 TMP_SLATE_DIR=$(mktemp -d /tmp/slate-linkerd.XXXXX)
-cd $TMP_SLATE_DIR
+cd "$TMP_SLATE_DIR"
 
 git clone --depth=1 git@github.com:BuoyantIO/slate-linkerd.git slate-linkerd
 cd slate-linkerd
@@ -15,8 +15,8 @@ bundle install
 bundle exec middleman build --clean
 
 # Add the slate build to the public dir!
-cp -r build/* $BASE_DIR/public
+cp -r build/* "$BASE_DIR"/public
 
 # Cleanup
-cd $BASE_DIR
-rm -rf $TMP_SLATE_DIR
+cd "$BASE_DIR"
+rm -rf "$TMP_SLATE_DIR"

--- a/linkerd.io/build
+++ b/linkerd.io/build
@@ -3,6 +3,6 @@
 set -e
 
 BASE_DIR=$(pwd -P)
+rm -rf "$BASE_DIR"/public
 
-rm -rf $BASE_DIR/public
 hugo


### PR DESCRIPTION
The `make shellcheck` task checks the install scripts but does not check other
scripts in this repo. This change updates it to check all scripts.

Signed-off-by: Oliver Gould <ver@buoyant.io>