### PR TITLE
Add NetworkPolicy notes to protocol detection

### DIFF
--- a/linkerd.io/content/2.10/features/protocol-detection.md
+++ b/linkerd.io/content/2.10/features/protocol-detection.md
@@ -128,3 +128,16 @@ diagnosing issues, but otherwise should rarely be necessary.
 
 As with opaque ports, multiple skipports can be provided as a comma-delimited
 string.
+
+## Using `NetworkPolicy` resources with opaque ports
+
+When a service has a port marked as opaque, any `NetworkPolicy` resources that
+apply to the respective port and restrict ingress access will have to be
+changed to target the proxy's inbound port instead (by default, `4143`). If the
+service has a mix of opaque and non-opaque ports, then the `NetworkPolicy`
+should target both the non-opaque ports, and the proxy's inbound port.
+
+A connection that targets an opaque endpoint (i.e a pod with a port marked as
+opaque) will have its original target port replaced with the proxy's inbound
+port. Once the inbound proxy receives the traffic, it will transparently
+forward it to the main application container over a TCP connection.

--- a/linkerd.io/content/2.11/features/protocol-detection.md
+++ b/linkerd.io/content/2.11/features/protocol-detection.md
@@ -144,4 +144,3 @@ A connection that targets an opaque endpoint (i.e a pod with a port marked as
 opaque) will have its original target port replaced with the proxy's inbound
 port. Once the inbound proxy receives the traffic, it will transparently
 forward it to the main application container over a TCP connection.
-

--- a/linkerd.io/content/2.11/features/protocol-detection.md
+++ b/linkerd.io/content/2.11/features/protocol-detection.md
@@ -131,3 +131,17 @@ There was a bug in Linkerd 2.11.0 and 2.11.1 that prevented the opaque ports
 behavior of `enable-external-profiles` from working. This was fixed in Linkerd
 2.11.2.
 {{< /note >}}
+
+## Using `NetworkPolicy` resources with opaque ports
+
+When a service has a port marked as opaque, any `NetworkPolicy` resources that
+apply to the respective port and restrict ingress access will have to be
+changed to target the proxy's inbound port instead (by default, `4143`). If the
+service has a mix of opaque and non-opaque ports, then the `NetworkPolicy`
+should target both the non-opaque ports, and the proxy's inbound port.
+
+A connection that targets an opaque endpoint (i.e a pod with a port marked as
+opaque) will have its original target port replaced with the proxy's inbound
+port. Once the inbound proxy receives the traffic, it will transparently
+forward it to the main application container over a TCP connection.
+


### PR DESCRIPTION
NetworkPolicies that restrict ingress access should target the proxy's
inbound port (4143) when the application's exposed port is marked as
opaque. The outbound proxy will re-write the target port based on the
opaque protocol hint set by the destination controller.

Signed-off-by: Matei David <matei@buoyant.io>