### PR TITLE
Correct misspelling in FAQ

### DIFF
--- a/linkerd.io/content/faq/_index.md
+++ b/linkerd.io/content/faq/_index.md
@@ -62,7 +62,7 @@ faqs:
   - question: Who created Linkerd?
     answer:
       Linkerd was originally created by [Buoyant](https://buoyant.io/linkerd).
-      Buoyant continues to be a sponsor of the project and to provid
+      Buoyant continues to be a sponsor of the project and to provide
       commercial support.
   - question: Who is Linkerd for?
     answer:


### PR DESCRIPTION
Correcting spelling. I checked `linkerd.io/content/faq/_index.md` for additional misspellings and didn't notice any other issues in this file.

Signed-off-by: Jeremy Chase <jeremy.chase@gmail.com>