### PR TITLE
Link from Traffic Split to SMI task page

### DIFF
--- a/linkerd.io/content/2.11/features/traffic-split.md
+++ b/linkerd.io/content/2.11/features/traffic-split.md
@@ -23,7 +23,8 @@ Linkerd exposes this functionality via the
 [Service Mesh Interface](https://smi-spec.io/) (SMI)
 [TrafficSplit API](https://github.com/servicemeshinterface/smi-spec/tree/master/apis/traffic-split).
 To use this feature, you create a Kubernetes resource as described in the
-TrafficSplit spec, and Linkerd takes care of the rest.
+TrafficSplit spec, and Linkerd takes care of the rest. You can see step by step
+documentation on our [Getting started with Linkerd SMI extension](../../tasks/linkerd-smi/) page.
 
 By combining traffic splitting with Linkerd's metrics, it is possible to
 accomplish even more powerful deployment techniques that automatically take into

--- a/linkerd.io/content/2.11/features/traffic-split.md
+++ b/linkerd.io/content/2.11/features/traffic-split.md
@@ -24,7 +24,8 @@ Linkerd exposes this functionality via the
 [TrafficSplit API](https://github.com/servicemeshinterface/smi-spec/tree/master/apis/traffic-split).
 To use this feature, you create a Kubernetes resource as described in the
 TrafficSplit spec, and Linkerd takes care of the rest. You can see step by step
-documentation on our [Getting started with Linkerd SMI extension](../../tasks/linkerd-smi/) page.
+documentation on our
+[Getting started with Linkerd SMI extension](../../tasks/linkerd-smi/) page.
 
 By combining traffic splitting with Linkerd's metrics, it is possible to
 accomplish even more powerful deployment techniques that automatically take into


### PR DESCRIPTION
The [documentation for Traffic Split](https://linkerd.io/2.11/features/traffic-split/) does not link to the step-by-step instructions on the [Linkerd SMI](https://linkerd.io/2.11/tasks/linkerd-smi/#) page. This PR adds the missing link.

Signed-off-by: Jeremy Chase <jeremy.chase@gmail.com>