### PR TITLE
Update the trust anchor rotation documentation

### DIFF
--- a/linkerd.io/content/2.11/tasks/manually-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.11/tasks/manually-rotating-control-plane-tls-credentials.md
@@ -22,8 +22,9 @@ downtime.
 
 ## Prerequisites
 
-These instructions use the [step](https://smallstep.com/cli/) and
-[jq](https://stedolan.github.io/jq/) CLI tools.
+These instructions use the following CLI tools:
+
+- [`step`](https://smallstep.com/cli/) to manipulate certificates and keys;
 
 ## Understanding the current state of your system
 
@@ -56,10 +57,10 @@ linkerd-identity-data-plane
 However, if you see a message warning you that your trust anchor ("trust root")
 or issuer certificates are expiring soon, then you must rotate them.
 
-Note that this document only applies if the trust root and issuer certificate
-are currently valid. If your trust anchor or issuer certificate have expired,
-please follow the [Replacing Expired
-Certificates Guide](../replacing_expired_certificates/) instead.
+**Note that this document only applies if the trust anchor is currently valid.**
+If your trust anchor has expired, follow the [Replacing Expired Certificates Guide](../replacing_expired_certificates/)
+instead. (If your issuer certificate has expired but your trust anchor is still
+valid, continue on with this document.)
 
 For example, if your issuer certificate has expired, you will see a message
 similar to:
@@ -100,9 +101,26 @@ can skip directly to [Rotating the identity issuer
 certificate](#rotating-the-identity-issuer-certificate) and ignore the trust
 anchor rotation steps.
 
+## Read the current trust anchor certificate from the cluster
+
+To avoid downtime, you need to bundle the existing trust anchor certificate
+with the newly-generated trust anchor certificate into a certificate bundle:
+using the bundle allows workloads ultimately signed with either trust anchor
+to work properly in the mesh. Since certificates are not sensitive information,
+we can simply pull the existing trust anchor certificate directly from the
+cluster.
+
+The following command uses `kubectl` to fetch the Linkerd config from the
+`linkerd-identity-trust-roots` ConfigMap and save it in `original-trust.crt`:
+
+```bash
+kubectl -n linkerd get cm linkerd-identity-trust-roots -o=jsonpath='{.data.ca-bundle\.crt}' > original-trust-anchors.crt
+```
+
 ## Generate a new trust anchor
 
-First, generate a new trust anchor certificate and private key:
+After saving the current trust anchor certificate, generate a new trust anchor
+certificate and private key:
 
 ```bash
 step certificate create root.linkerd.cluster.local ca-new.crt ca-new.key --profile root-ca --no-password --insecure
@@ -110,23 +128,18 @@ step certificate create root.linkerd.cluster.local ca-new.crt ca-new.key --profi
 
 Note that we use `--no-password --insecure` to avoid encrypting these files
 with a passphrase. Store the private key somewhere secure so that it can be
-used in the future to [generate new issuer
-certificates](../generate-certificates/).
+used in the future to [generate new issuer certificates](../generate-certificates/).
 
 ## Bundle your original trust anchor with the new one
 
 Next, we need to bundle the trust anchor currently used by Linkerd together with
-the new anchor. The following command uses `kubectl` to fetch the Linkerd config,
-`jq`/[`yq`](https://github.com/mikefarah/yq) to extract the current trust anchor,
-and `step` to combine it with the newly generated trust anchor:
+the new anchor. We use `step` to combine the two certificates into one bundle:
 
 ```bash
-kubectl -n linkerd get cm linkerd-config -o=jsonpath='{.data.values}' \
-  | yq e .identityTrustAnchorsPEM - > original-trust.crt
-
 step certificate bundle ca-new.crt original-trust.crt bundle.crt
-rm original-trust.crt
 ```
+
+If desired, you can `rm original-trust.crt` too.
 
 ## Deploying the new bundle to Linkerd
 
@@ -143,10 +156,14 @@ or you can also use the `helm upgrade` command:
 helm upgrade linkerd2 --set-file identityTrustAnchorsPEM=./bundle.crt
 ```
 
-This will restart the proxies in the Linkerd control plane, and they will be
-reconfigured with the new trust anchor.
+Once this is done, you'll need to explicitly restart the control plane so that
+everything in the control plane is configured to use the new trust anchor:
 
-Finally, you must restart the proxy for all injected workloads in your cluster.
+```bash
+kubectl rollout restart -n linkerd deploy
+```
+
+Wait for all the restarts to finish, then restart your meshed workloads as well.
 For example, doing that for the `emojivoto` namespace would look like:
 
 ```bash
@@ -213,9 +230,15 @@ linkerd-identity-data-plane
 √ data plane proxies certificate match CA
 ```
 
+At this point, all meshed workloads are ready to accept connections signed
+by either the old or new trust anchor, but they're all still using certificates
+signed by the old trust anchor. To change that, we'll need to rotate the
+issuer certificate.
+
 ## Rotating the identity issuer certificate
 
-To rotate the issuer certificate and key pair, first generate a new pair:
+To rotate the issuer certificate and key pair, start by generating the new
+identity issuer certificate and key:
 
 ```bash
 step certificate create identity.linkerd.cluster.local issuer-new.crt issuer-new.key \
@@ -223,13 +246,17 @@ step certificate create identity.linkerd.cluster.local issuer-new.crt issuer-new
 --ca ca-new.crt --ca-key ca-new.key
 ```
 
-Provided that the trust anchor has not expired and that, if recently rotated,
-all proxies have been updated to include a working trust anchor (as outlined in
-the previous section) it is now safe to rotate the identity issuer certificate
-by using the `upgrade` command again:
+This new issuer certificate is signed by our new trust anchor, which is why it
+was critical to install the new trust anchor (as outlined in the previous section).
+Given the working trust anchor certificate bundle – `linkerd check` should show
+all green checks and no warnings – we can safely rotate the identity issuer
+certificate and key by using the `upgrade` command again:
 
 ```bash
-linkerd upgrade --identity-issuer-certificate-file=./issuer-new.crt --identity-issuer-key-file=./issuer-new.key | kubectl apply -f -
+linkerd upgrade \
+    --identity-issuer-certificate-file=./issuer-new.crt \
+    --identity-issuer-key-file=./issuer-new.key \
+    | kubectl apply -f -
 ```
 
 or
@@ -237,16 +264,21 @@ or
 ```bash
 exp=$(cat ca-new.crt | openssl x509 -noout -dates | grep "notAfter" | sed -e 's/notAfter=\(.*\)$/"\1"/' | TZ='GMT' xargs -I{} date -d {} +"%Y-%m-%dT%H:%M:%SZ")
 
-helm upgrade linkerd2
-  --set-file identity.issuer.tls.crtPEM=./issuer-new.crt
-  --set-file identity.issuer.tls.keyPEM=./issuer-new.key
+helm upgrade linkerd2 \
+  --set-file identity.issuer.tls.crtPEM=./issuer-new.crt \
+  --set-file identity.issuer.tls.keyPEM=./issuer-new.key \
   --set identity.issuer.crtExpiry=$exp
 ```
 
-At this point Linkerd's `identity` control plane service should detect the
-change of the secret and automatically update its issuer certificates.
+At this point, you'll need to explicitly restart the control plane so that
+everything in the control plane is configured to use the new issuer certificate:
 
-To ensure this has happened, you can check for the specific Kubernetes event:
+```bash
+kubectl rollout restart -n linkerd deploy
+```
+
+Wait for all the restarts to finish, then to make certain that Linkerd saw
+the new issuer certificate, check for the `IssuerUpdated` Kubernetes event:
 
 ```bash
 kubectl get events --field-selector reason=IssuerUpdated -n linkerd
@@ -290,16 +322,9 @@ linkerd-identity-data-plane
 
 ## Removing the old trust anchor
 
-We can now remove the old trust anchor from the trust bundle we created earlier.
-
-**NOTE:** Before the action it is necessary to explicitly rollout all
-deployments in the `linkerd` namespace:
-
-```bash
-kubectl -n linkerd rollout restart deployments
-```
-
-The `upgrade` command can do that for the Linkerd components:
+Since the old trust anchor is now completely unused, we can now switch
+Linkerd from the bundle we created for the trust anchor to using only
+the new trust anchor certificate:
 
 ```bash
 linkerd upgrade  --identity-trust-anchors-file=./ca-new.crt  | kubectl apply -f -
@@ -312,15 +337,22 @@ helm upgrade linkerd2 --set-file --set-file identityTrustAnchorsPEM=./ca-new.crt
 ```
 
 Note that the ./ca-new.crt file is the same trust anchor you created at the start
-of this process. Additionally, you can use the `rollout restart` command to
-bring the configuration of your other injected resources up to date:
+of this process.
+
+Once again, we'll explicitly restart Linkerd:
+
+```bash
+kubectl rollout restart -n linkerd deploy
+```
+
+Wait for the restart to finish, then restart your meshed workloads:
 
 ```bash
 kubectl -n emojivoto rollout restart deploy
 linkerd check --proxy
 ```
 
-Finally the output of the `check` command should not produce any warnings or
+And, again, the output of the `check` command should not produce any warnings or
 errors:
 
 ```text

--- a/linkerd.io/content/2.11/tasks/manually-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.11/tasks/manually-rotating-control-plane-tls-credentials.md
@@ -247,10 +247,10 @@ step certificate create identity.linkerd.cluster.local issuer-new.crt issuer-new
 ```
 
 This new issuer certificate is signed by our new trust anchor, which is why it
-was critical to install the new trust anchor (as outlined in the previous section).
-Given the working trust anchor certificate bundle – `linkerd check` should show
-all green checks and no warnings – we can safely rotate the identity issuer
-certificate and key by using the `upgrade` command again:
+was critical to install the new trust anchor bundle (as outlined in the previous
+section). Once the new bundle is installed and running `linkerd check` shows all
+green checks and no warnings, you can safely rotate the identity issuer certificate
+and key by using the `upgrade` command again:
 
 ```bash
 linkerd upgrade \


### PR DESCRIPTION
We need to document needing to restart Linkerd to pick up changes.

Signed-off-by: Flynn <flynn@buoyant.io>