### PR TITLE
move data plane proxy metrics check to `linkerd-viz` section

### DIFF
--- a/linkerd.io/content/2.12/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.12/tasks/troubleshooting.md
@@ -1091,31 +1091,6 @@ For more information on `linkerd inject`, see
 [Step 5: Install the demo app](../../getting-started/#step-5-install-the-demo-app)
 in our [Getting Started](../../getting-started/) guide.
 
-### √ data plane proxy metrics are present in Prometheus {#l5d-data-plane-prom}
-
-Example failure:
-
-```bash
-× data plane proxy metrics are present in Prometheus
-    Data plane metrics not found for linkerd/linkerd-controller-b8c4c48c8-pflc9.
-```
-
-Ensure Prometheus can connect to each `linkerd-proxy` via the Prometheus
-dashboard:
-
-```bash
-kubectl -n linkerd port-forward svc/linkerd-prometheus 9090
-```
-
-...and then browse to
-[http://localhost:9090/targets](http://localhost:9090/targets), validate the
-`linkerd-proxy` section.
-
-You should see all your pods here. If they are not:
-
-- Prometheus might be experiencing connectivity issues with the k8s api server.
-  Check out the logs and delete the pod to flush any possible transient errors.
-
 ### √ data plane is up-to-date {#l5d-data-plane-version}
 
 Example failure:
@@ -1979,6 +1954,31 @@ Check the logs on the viz extensions's metrics API:
 ```bash
 kubectl -n linkerd-viz logs deploy/metrics-api metrics-api
 ```
+
+### √ data plane proxy metrics are present in Prometheus {#l5d-data-plane-prom}
+
+Example failure:
+
+```bash
+× data plane proxy metrics are present in Prometheus
+    Data plane metrics not found for linkerd/linkerd-controller-b8c4c48c8-pflc9.
+```
+
+Ensure Prometheus can connect to each `linkerd-proxy` via the Prometheus
+dashboard:
+
+```bash
+kubectl -n linkerd port-forward svc/linkerd-prometheus 9090
+```
+
+...and then browse to
+[http://localhost:9090/targets](http://localhost:9090/targets), validate the
+`linkerd-proxy` section.
+
+You should see all your pods here. If they are not:
+
+- Prometheus might be experiencing connectivity issues with the k8s api server.
+  Check out the logs and delete the pod to flush any possible transient errors.
 
 ## The "linkerd-jaeger" checks {#l5d-jaeger}
 


### PR DESCRIPTION
This check is run as part of `linkerd viz check --proxy`, _not_ 
`linkerd check --proxy`, but it's currently in the section "The
'linkerd-data-plane' checks". I've moved it to the section "The
'linkerd-viz' checks, which I think is where it should be.