### PR TITLE
Alejandro's ingress-mode warning

### DIFF
--- a/linkerd.io/content/2.12/tasks/using-ingress.md
+++ b/linkerd.io/content/2.12/tasks/using-ingress.md
@@ -17,8 +17,15 @@ metrics and mTLS the moment the traffic is inside the cluster. (See
 [Adding your service](../adding-your-service/) for instructions on how to mesh
 your ingress.)
 
-Note that some ingress options need to be meshed in "ingress" mode. See details
-below.
+Note that, as explained below, some ingress options need to be meshed in
+"ingress" mode, which means injecting with the `linkerd.io/inject: ingress`
+annotation rather than the default `enabled`. It's possible to use this
+annotation at the namespace level, but it's recommended to do it at the
+individual workload level instead. The reason is that many ingress
+implementations also place other types of workloads under the same namespace for
+tasks other than routing and therefore you'd rather inject them using the
+default `enabled` mode (or some you wouldn't want to inject at all, such as
+Jobs).
 
 Common ingress options that Linkerd has been used with include:
 


### PR DESCRIPTION
This is a cherry-pick of @alpeb's ingress-mode warning, onto the new `shared/docs/2.12`, since @alpeb is out at the moment. (Retargeting his #1398 to `shared/docs/2.12` did not have good results. 😂)

@alpeb's comments below:
> Note that, as explained below, some ingress options need to be meshed in
"ingress" mode, which means injecting with the `linkerd.io/inject: ingress`
annotation rather than the default `enabled`. It's possible to use this
annotation at the namespace level, but it's recommended to do it at the
individual workload level instead. The reason is that many ingress
implementations also place other types of workloads under the same namespace for
tasks other than routing and therefore you'd rather inject them using the
default `enabled` mode (or some you wouldn't want to inject at all, such as
Jobs)

This only applies to `2.12` because in `2.11` we were not properly inheriting
the `linkerd.io/inject: ingress` annotation (it was seen as just
`enabled` at the workload level).

(cherry picked from commit e9c289018c3548b6ac2164887fdf12c23d407be4)
