### PR TITLE
Fix markdown linting

### DIFF
--- a/linkerd.io/content/2.12/tasks/customize-install.md
+++ b/linkerd.io/content/2.12/tasks/customize-install.md
@@ -96,4 +96,3 @@ and piping it to `kubectl apply`. For example you can run:
 ```bash
 kubectl kustomize . | kubectl apply -f -
 ```
-

--- a/linkerd.io/content/2.12/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.12/tasks/troubleshooting.md
@@ -1954,13 +1954,13 @@ Example failure:
 ```
 
 This warning indicates that the listed pods have the
-[`deny` default inbound policy](features/server-policy#policy-annotations),
+[`deny` default inbound policy](../../features/server-policy#policy-annotations),
 which may prevent the `linkerd-viz` Prometheus instance from scraping the data
 plane proxies in those pods. If Prometheus cannot scrape a data plane pod,
 `linkerd viz` commands targeting that pod will return no data.
 
 This may be resolved by running the `linkerd viz allow-scrapes` command, which
-generates [policy resources](features/server-policy) authorizing Prometheus to
+generates [policy resources](../../features/server-policy) authorizing Prometheus to
 scrape the data plane proxies in a namespace:
 
 ```bash

--- a/linkerd.io/content/2.12/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.12/tasks/troubleshooting.md
@@ -1937,7 +1937,7 @@ Check the logs on the viz extensions's metrics API:
 kubectl -n linkerd-viz logs deploy/metrics-api metrics-api
 ```
 
-### √ prometheus is authorized to scrape data plane pods {#l5d-viz-data-plane-prom-authz} 
+### √ prometheus is authorized to scrape data plane pods {#l5d-viz-data-plane-prom-authz}
 
 Example failure:
 
@@ -1945,10 +1945,10 @@ Example failure:
 
 ‼ prometheus is authorized to scrape data plane pods
     prometheus may not be authorized to scrape the following pods:
-	* emojivoto/voting-5f46cbcdc6-p5dhn
-	* emojivoto/emoji-54f8786975-6qc8s
-	* emojivoto/vote-bot-85dfbf8996-86c44
-	* emojivoto/web-79db6f4548-4mzkg
+        * emojivoto/voting-5f46cbcdc6-p5dhn
+        * emojivoto/emoji-54f8786975-6qc8s
+        * emojivoto/vote-bot-85dfbf8996-86c44
+        * emojivoto/web-79db6f4548-4mzkg
     consider running `linkerd viz allow-scrapes` to authorize prometheus scrapes
     see https://linkerd.io/2/checks/#l5d-viz-data-plane-prom-authz for hints
 ```

--- a/linkerd.io/content/2.12/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.12/tasks/troubleshooting.md
@@ -1960,8 +1960,8 @@ plane proxies in those pods. If Prometheus cannot scrape a data plane pod,
 `linkerd viz` commands targeting that pod will return no data.
 
 This may be resolved by running the `linkerd viz allow-scrapes` command, which
-generates [policy resources](../../features/server-policy) authorizing Prometheus to
-scrape the data plane proxies in a namespace:
+generates [policy resources](../../features/server-policy) authorizing
+Prometheus to scrape the data plane proxies in a namespace:
 
 ```bash
 linkerd viz allow-scrapes --namespace emojivoto | kubectl apply -f -

--- a/linkerd.io/content/2.12/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.12/tasks/troubleshooting.md
@@ -1954,13 +1954,13 @@ Example failure:
 ```
 
 This warning indicates that the listed pods have the
-[`deny` default inbound policy](../../features/server-policy#policy-annotations),
+[`deny` default inbound policy](../../features/server-policy/#policy-annotations),
 which may prevent the `linkerd-viz` Prometheus instance from scraping the data
 plane proxies in those pods. If Prometheus cannot scrape a data plane pod,
 `linkerd viz` commands targeting that pod will return no data.
 
 This may be resolved by running the `linkerd viz allow-scrapes` command, which
-generates [policy resources](../../features/server-policy) authorizing
+generates [policy resources](../../features/server-policy/) authorizing
 Prometheus to scrape the data plane proxies in a namespace:
 
 ```bash

--- a/linkerd.io/content/2.12/tasks/upgrade.md
+++ b/linkerd.io/content/2.12/tasks/upgrade.md
@@ -384,14 +384,14 @@ upgrading.
 The Linkerd proxy container is now the *first* container in the pod. This may
 affect tooling that assumed the application was the first container in the pod.
 
-#### Control plane changes
+### Control plane changes
 
 The `controller` pod has been removed from the control plane. All configuration
 options that previously applied to it are no longer valid (e.g
 `publicAPIResources` and all of its nested fields). Additionally, the
 destination pod has a new `policy` container that runs the policy controller.
 
-#### Data plane changes
+### Data plane changes
 
 In order to fix a class of startup race conditions, the container ordering
 within meshed pods has changed so that the Linkerd proxy container is now the
@@ -404,7 +404,7 @@ container startup ordering is thus longer necessary. (However, using
 `linkerd-await -S` to ensure proxy shutdown in Jobs and Cronjobs is still
 valid.)
 
-#### Routing breaking changes
+### Routing breaking changes
 
 There are two breaking changes to be aware of when it comes to how traffic is
 routed.
@@ -421,7 +421,7 @@ localhost, such as `127.0.0.1:8080`. Services that want to receive traffic from
 other pods should now be bound to a public interface (e.g `0.0.0.0:8080`). This
 change prevents ports from being accidentally exposed outside of the pod.
 
-#### Multicluster
+### Multicluster
 
 The gateway component has been changed to use a `pause` container instead of
 `nginx`. This change should reduce the footprint of the extension; the proxy
@@ -437,7 +437,7 @@ under the `gateway` field. If you have installed the extension with other
 options than the provided defaults, you will need to update your `values.yaml`
 file to reflect this change in field grouping.
 
-#### Other changes
+### Other changes
 
 Besides the breaking changes described above, there are other minor changes to
 be aware of when upgrading from `stable-2.10.x`:
@@ -453,7 +453,7 @@ be aware of when upgrading from `stable-2.10.x`:
  to the default opaque ports list. The default ignore inbound ports list has
  also been changed to include ports `4567` and `4568`.
 
-### Upgrade notice: stable-2.10.0
+## Upgrade notice: stable-2.10.0
 
 If you are currently running Linkerd 2.9.0, 2.9.1, 2.9.2, or 2.9.3 (but *not*
 2.9.4), and you *upgraded* to that release using the `--prune` flag (as opposed
@@ -470,7 +470,7 @@ Second, we've introduced [extensions](../extensions/) and moved the
 default visualization components into a Linkerd-Viz extension. Read on for what
 this means for you.
 
-#### Visualization components moved to Linkerd-Viz extension
+### Visualization components moved to Linkerd-Viz extension
 
 With the introduction of [extensions](../extensions/), all of the
 Linkerd control plane components related to visibility (including Prometheus,
@@ -535,13 +535,13 @@ you had customized there will need to be migrated; in particular
 `identityTrustAnchorsPEM` in order to conserve the value you set during
 install."
 
-### Upgrade notice: stable-2.9.4
+## Upgrade notice: stable-2.9.4
 
 See upgrade notes for 2.9.3 below.
 
-### Upgrade notice: stable-2.9.3
+## Upgrade notice: stable-2.9.3
 
-#### Linkerd Repair
+### Linkerd Repair
 
 Due to a known issue in versions stable-2.9.0, stable-2.9.1, and stable-2.9.2,
 users who upgraded to one of those versions with the --prune flag (as described
@@ -558,14 +558,14 @@ linkerd repair | kubectl apply -f -
 This will restore the `secret/linkerd-config-overrides` resource and allow you
 to proceed with upgrading your control plane.
 
-### Upgrade notice: stable-2.9.0
+## Upgrade notice: stable-2.9.0
 
-#### Images are now hosted on ghcr.io
+### Images are now hosted on ghcr.io
 
 As of this version images are now hosted under `ghcr.io` instead of `gcr.io`. If
 you're pulling images into a private repo please make the necessary changes.
 
-#### Upgrading multicluster environments
+### Upgrading multicluster environments
 
 Linkerd 2.9 changes the way that some of the multicluster components work and
 are installed compared to Linkerd 2.8.x. Users installing the multicluster
@@ -577,7 +577,7 @@ Users who installed the multicluster component in Linkerd 2.8.x and wish to
 upgrade to Linkerd 2.9 should follow the [upgrade multicluster
 instructions](../upgrade-multicluster/).
 
-#### Ingress behavior changes
+### Ingress behavior changes
 
 In previous versions when you injected your ingress controller (Nginx, Traefik,
 Ambassador, etc), then the ingress' balancing/routing choices would be
@@ -592,7 +592,7 @@ If you want to revert to the previous behavior, inject the proxy into the
 ingress controller using the annotation `linkerd.io/inject: ingress`, as
 explained in [using ingress](../using-ingress/)
 
-#### Breaking changes in Helm charts
+### Breaking changes in Helm charts
 
 Some entries like `controllerLogLevel` and all the Prometheus config have
 changed their position in the settings hierarchy. To get a precise view of what
@@ -602,7 +602,7 @@ and
 [stable-2.9.0](https://github.com/linkerd/linkerd2/blob/stable-2.9.0/charts/linkerd2/values.yaml)
 `values.yaml` files.
 
-#### Post-upgrade cleanup
+### Post-upgrade cleanup
 
 In order to better support cert-manager, the secrets
 `linkerd-proxy-injector-tls`, `linkerd-sp-validator-tls` and `linkerd-tap-tls`


### PR DESCRIPTION
Clean up some whitespace and be consistent about H2 & H3 in the upgrade notices.

- Fix whitespace lint issues
- Be consistent about H2/H3 in the upgrade notes.
