### PR TITLE
update authorization policy feature doc for 2.12

### DIFF
--- a/linkerd.io/content/2.12/features/server-policy.md
+++ b/linkerd.io/content/2.12/features/server-policy.md
@@ -25,7 +25,7 @@ successfully.
 
 Sometimes, however, we want to restrict which types of traffic are allowed.
 Linkerd's policy features allow you to *deny* access to resources unless certain
-conditions are met, including based on the TLS identity of the client.
+conditions are met, including the TLS identity of the client.
 
 Linkerd's policy is configured using two mechanisms:
 
@@ -83,7 +83,7 @@ And finally, two policy CRDs represent policy itself: the mapping of
 authentication rules to targets.
 
 - `AuthorizationPolicy`: a policy that restricts access to one or more targets
-  unless an authentication rule is met.
+  unless an authentication rule is met
 
 - `ServerAuthorization`: an earlier form of policy that restricts access to
   `Servers` only (i.e. not `HTTPRoutes`)

--- a/linkerd.io/content/2.12/features/server-policy.md
+++ b/linkerd.io/content/2.12/features/server-policy.md
@@ -76,7 +76,8 @@ policy can be applied.
 Two policy CRDs represent authentication rules that must be satisfied as part of
 a policy rule:
 
-- `MeshTLSAuthentication`: authentication based on secure workload identities
+- `MeshTLSAuthentication`: authentication based on [secure workload
+  identities](../automatic-mtls/)
 - `NetworkAuthentication`: authentication based on IP address
 
 And finally, two policy CRDs represent policy itself: the mapping of

--- a/linkerd.io/content/2.12/features/server-policy.md
+++ b/linkerd.io/content/2.12/features/server-policy.md
@@ -1,14 +1,13 @@
 +++
 title = "Authorization Policy"
-description = "Linkerd can restrict which types of traffic are allowed to ."
+description = "Linkerd can restrict which types of traffic are allowed between meshed services."
 +++
 
-Linkerd's server authorization policy allows you to control which types of
+Linkerd's authorization policy allows you to control which types of
 traffic are allowed to meshed pods. For example, you can restrict communication
-to a particular service to only come from certain other services; or you can
-enforce that mTLS must be used on a certain port; and so on.
-
-## Adding traffic policy on your services
+to a particular service (or HTTP route on a service) to only come from certain
+other services; you can enforce that mTLS must be used on a certain port; and so
+on.
 
 {{< note >}}
 Linkerd can only enforce policy on meshed pods, i.e. pods where the Linkerd
@@ -17,76 +16,94 @@ usage of these features with [HA mode](../ha/), which enforces that the proxy
 *must* be present when pods start up.
 {{< /note >}}
 
+## Policy overview
+
 By default Linkerd allows all traffic to transit the mesh, and uses a variety
 of mechanisms, including [retries](../retries-and-timeouts/) and [load
 balancing](../load-balancing/), to ensure that requests are delivered
 successfully.
 
 Sometimes, however, we want to restrict which types of traffic are allowed.
-Linkerd's policy features allow you to *deny* traffic under certain conditions.
-It is configured with two basic mechanisms:
+Linkerd's policy features allow you to *deny* access to resources unless certain
+conditions are met, including based on the TLS identity of the client.
 
-1. A set of basic _default policies_, which can be set at the cluster,
+Linkerd's policy is configured using two mechanisms:
+
+1. A set of _default policies_, which can be set at the cluster,
    namespace, workload, and pod level through Kubernetes annotations.
-2. `Server` and `ServerAuthorization` CRDs that specify fine-grained policy
-   for specific ports.
+2. A set of CRDs that specify fine-grained policy for specific ports, routes,
+   workloads, etc.
 
-These mechanisms work in conjunction. For example, a default cluster-wide
-policy of `deny` would prohibit any traffic to any meshed pod; traffic must
-then be explicitly allowed through the use of `Server` and
-`ServerAuthorization` CRDs.
+These mechanisms work in conjunction. For example, a default cluster-wide policy
+of `deny` would prohibit any traffic to any meshed pod; traffic would then need
+to be explicitly allowed through the use of CRDs.
 
-### Policy annotations
+## Default policies
 
 The `config.linkerd.io/default-inbound-policy` annotation can be set at a
 namespace, workload, and pod level, and will determine the default traffic
 policy at that point in the hierarchy. Valid default policies include:
 
-- `all-unauthenticated`: inbound proxies allow all connections
-- `all-authenticated`: inbound proxies allow only mTLS connections from other
-  meshed pods.
-- `cluster-unauthenticated`: inbound proxies allow all connections from client
-  IPs in the cluster's `clusterNetworks` (must be configured at install-time).
-- `cluster-authenticated`: inbound proxies allow only mTLS connections from other
-  meshed pods from IPs in the cluster's `clusterNetworks`.
-- `deny` inbound proxies deny all connections that are not explicitly
-  authorized.
+- `all-unauthenticated`: allow all requests. This is the default.
+- `all-authenticated`: allow requests from meshed clients only.
+- `cluster-authenticated`: allow requests form meshed clients in the same
+  cluster.
+- `deny`: deny all requests.
 
-See the [Policy reference](../../reference/authorization-policy/) for more default
-policies.
+As well as several other default policies—see the [Policy
+reference](../../reference/authorization-policy/) for more.
 
-Every cluster has a default policy (by default, `all-unauthenticated`), set at
-install / upgrade time. Annotations that are present at the workload or
-namespace level *at pod creation time* can override that value to determine the
-default policy for that pod. Note that the default policy is fixed at proxy
-initialization time, and thus, after a pod is created, changing the annotation
-will not change the default policy for that pod.
+Every cluster has a cluster-wide default policy (by default,
+`all-unauthenticated`), set at install time. Annotations that are present at the
+workload or namespace level *at pod creation time* can override that value to
+determine the default policy for that pod. (Note that the default policy is fixed
+at proxy initialization time, and thus, after a pod is created, changing the
+annotation will not change the default policy for that pod.)
 
-### Policy CRDs
+## Fine-grained policies
 
-The `Server` and `ServerAuthorization` CRDs further configure Linkerd's policy
-beyond the default policies. In contrast to annotations, these CRDs can be
-changed dynamically and policy behavior will be updated on the fly.
+For finer-grained policy that applies to specific ports, routes, or more,
+Linkerd uses a set of CRDs.  In contrast to default policy annotations, these
+policy CRDs can be changed dynamically and policy behavior will be updated on
+the fly.
 
-A `Server` selects a port and a set of pods that is subject to policy. This set
-of pods can correspond to a single workload, or to multiple workloads (e.g.
-port 4191 for every pod in a namespace). Once created, a `Server` resource
-denies all traffic to that port, and traffic to that port can only be enabled
-by creating `ServerAuthorization` resources.
+Two policy CRDs represent "targets" for policy: subsets of traffic over which
+policy can be applied.
 
-A `ServerAuthorization` defines a set of allowed traffic to a `Server`. A
-`ServerAuthorization` can allow traffic based on any number of things,
-including IP address; use of mTLS; specific mTLS identities (including
-wildcards, to allow for namespace selection); specific Service Accounts; and
-more.
+- `Server`: all traffic to a port, for a set of pods in a namespace
+- `HTTPRoute`: a subset of HTTP requests for a `Server`
 
-See the [Policy reference](../../reference/authorization-policy/) for more on
-the `Server` and `ServerAuthorization` resources.
+Two policy CRDs represent authentication rules that must be satisfied as part of
+a policy rule:
 
-{{< note >}}
-Currently, `Servers` can only reference ports that are defined as container
-ports in the pod's manifest.
-{{< /note >}}
+- `MeshTLSAuthentication`: authentication based on secure workload identities
+- `NetworkAuthentication`: authentication based on IP address
+
+And finally, two policy CRDs represent policy itself: the mapping of
+authentication rules to targets.
+
+- `AuthorizationPolicy`: a policy that restricts access to one or more targets
+  unless an authentication rule is met.
+
+- `ServerAuthorization`: an earlier form of policy that restricts access to
+  `Servers` only (i.e. not `HTTPRoutes`)
+
+The general pattern for Linkerd's dynamic, fine-grained policy is to define the
+traffic target that must be protected (via a combination of `Server` and
+`HTTPRoute` CRs); define the types of authentication that are required before
+access to that traffic is permitted (via `MeshTLSAuthentication` and
+`NetworkAuthentication`); and then define the policy that maps authentication to
+target (via an `AuthorizationPolicy`).
+
+See the [Policy reference](../../reference/authorization-policy/) for more
+details on how these resources work.
+
+## ServerAuthorization vs AuthorizationPolicy
+
+Linkerd 2.12 introduced `AuthorizationPolicy` as a more flexible alternative to
+`ServerAuthorization` that can target `HTTPRoute`s as well as `Server`s. Use of
+`AuthorizationPolicy` is preferred, and `ServerAuthorization` will be deprecated
+in future releases.
 
 ### Policy rejections
 
@@ -94,8 +111,8 @@ Any traffic that is known to be HTTP (including HTTP/2 and gRPC) that is denied
 by policy will result in the proxy returning an HTTP 403. Any non-HTTP traffic
 will be denied at the TCP level, i.e. by refusing the connection.
 
-Note that dynamically changing the policy may result in abrupt termination of
-existing TCP connections.
+Note that dynamically changing the policy to deny existing TCP connections may
+result in abrupt termination of those connections.
 
 ### Examples
 


### PR DESCRIPTION
Once the per-route policy guide is written, the Example section at the bottom should be replaced with a pointer to that.

Signed-off-by: William Morgan <william@buoyant.io>