### PR TITLE
fix broken links in route policy docs note

### DIFF
--- a/linkerd.io/content/2.12/tasks/configuring-per-route-policy.md
+++ b/linkerd.io/content/2.12/tasks/configuring-per-route-policy.md
@@ -146,6 +146,10 @@ Service profile routes allow you to collect per-route metrics and configure
 client-side behavior such as retries and timeouts. [`HTTPRoute`] resources, on the
 other hand, can be the target of [`AuthorizationPolicies`] and allow you to specify
 per-route authorization.
+
+[`HTTPRoute`]: ../../reference/authorization-policy/#httproute
+[`AuthorizationPolicies`]:
+    ../../reference/authorization-policy/#authorizationpolicy
 {{< /note >}}
 
 First, let's create an [`HTTPRoute`] that matches `GET` requests to the `authors`


### PR DESCRIPTION
apparently that's a totally separate scope for markdown link references?
who knew!