### PR TITLE
Add markdownlint to on-create script

### DIFF
--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -13,6 +13,9 @@ rm hugo*.deb
 scurl https://htmltest.wjdp.uk | bash
 sudo mv bin/htmltest /usr/local/bin
 
+# markdownlint
+sudo npm install -g markdownlint-cli@0.26.0
+
 # gcloud
 echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
     | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list


### PR DESCRIPTION
markdownlint is needed in order to run `make lint` 

Signed-off-by: Alex Leong <alex@buoyant.io>