### PR TITLE
Fix documentation on auto-rotating TLS with Helm

### DIFF
--- a/linkerd.io/content/2.12/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.12/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -213,7 +213,7 @@ kubectl get events --field-selector reason=IssuerUpdated -n linkerd
 For installing with Helm, first install the `linkerd-crds` chart:
 
 ```bash
-helm install linkerd-base -n linkerd --create-namespace linkerd/linkerd-crds
+helm install linkerd-crds -n linkerd --create-namespace linkerd/linkerd-crds
 ```
 
 Then install the `linkerd-control-plane` chart, setting the

--- a/linkerd.io/content/2.12/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.12/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -210,12 +210,10 @@ kubectl get events --field-selector reason=IssuerUpdated -n linkerd
 
 ## Installing with Helm
 
-For installing with Helm, first install the `linkerd-crds` and `linkerd-base`
-charts:
+For installing with Helm, first install the `linkerd-crds` chart:
 
 ```bash
-helm install linkerd-base -n linkerd linkerd/linkerd-crds
-helm install linkerd-base -n linkerd --create-namespace linkerd/linkerd-base
+helm install linkerd-base -n linkerd --create-namespace linkerd/linkerd-crds
 ```
 
 Then install the `linkerd-control-plane` chart, setting the


### PR DESCRIPTION
Fixed #1491, since the `linkerd-base` chart doesn't exist.