### PR TITLE
Remove no-longer valid note about `automountServiceAccountToken`

### DIFF
--- a/linkerd.io/content/2.12/tasks/validating-your-traffic.md
+++ b/linkerd.io/content/2.12/tasks/validating-your-traffic.md
@@ -14,14 +14,6 @@ Linkerd's automatic mTLS is done in a way that's completely transparent to
 the application. Of course, sometimes it's helpful to be able to validate
 whether mTLS is in effect!
 
-{{< note >}}
-Linkerd uses Kubernetes *ServiceAccounts* to define service identity. This
-requires that the `automountServiceAccountToken` feature (on by default) has
-not been disabled on the pods. See the [Kubernetes service account
-documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
-for more.
-{{< /note >}}
-
 ## Validating mTLS with `linkerd viz edges`
 
 To validate that mTLS is working, you can view a summary of the TCP


### PR DESCRIPTION
Fixes linkerd/linkerd2#9970

Removed note stating that `automountServiceAccountToken` needs to be enabled in a pod in order to be injectable. That is no longer the case after `edge-21.11.1` after which we're adding Service Account Token Volume projections.