### PR TITLE
docs: only response total metrics have classifications

### DIFF
--- a/linkerd.io/content/2.12/reference/proxy-metrics.md
+++ b/linkerd.io/content/2.12/reference/proxy-metrics.md
@@ -72,13 +72,30 @@ Each of these metrics has the following labels:
 
 The following labels are only applicable on `response_*` metrics.
 
+* `status_code`: The HTTP status code of the response.
+
+#### Response Total Labels
+
+In addition to the labels applied to all `response_*` metrics, the
+`response_total`, `route_response_total`, and `control_response_total` metrics
+also have the following labels:
+
 * `classification`: `success` if the response was successful, or `failure` if
                     a server error occurred. This classification is based on
                     the gRPC status code if one is present, and on the HTTP
-                    status code otherwise. Only applicable to response metrics.
+                    status code otherwise.
 * `grpc_status_code`: The value of the `grpc-status` trailer.  Only applicable
                       for gRPC responses.
-* `status_code`: The HTTP status code of the response.
+
+{{< note >}}
+Because response classification may be determined based on the `grpc-status`
+trailer (if one is present), a response may not be classified until its body
+stream completes. Response latency, however, is determined based on
+[time-to-first-byte][ttfb], so the `response_latency_ms` metric is recorded as
+soon as data is received, rather than when the response body ends. Therefore,
+the values of the `classification` and `grpc_status_code` labels are not yet
+known when the `response_latency_ms` metric is recorded.
+{{< /note >}}
 
 #### Outbound labels
 


### PR DESCRIPTION
Currently, the documentation for proxy metrics states that the `status_code`, `grpc_status_code`, and `classification` labels are present on "all `response_*` metrics". This is incorrect. The `response_latency_ms` metric does not include `classification` and `grpc_status_code` labels, since it is recorded when the first byte of a response body is received, and the response is not classified (and the gRPC status is not known) until the response body _ends_. The incorrect docs have caused confusion for users (see linkerd/linkerd2#9737).

This branch updates the proxy metrics documentation to distinguish between the labels that are present on all `response_*` metrics, and the labels that are present only on `response_total` metrics. In addition, I added a note explaining _why_ some labels are only present on the `response_total` metrics and not on `response_latency_ms`.

Fixes linkerd/linkerd2#9737