### PR TITLE
Remove ingress from tracing docs

### DIFF
--- a/linkerd.io/content/2.12/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.12/tasks/distributed-tracing.md
@@ -229,10 +229,10 @@ participate in traces.
 ### Ingress
 
 The ingress is an especially important component for distributed tracing because
-it creates the root span of each trace and is responsible for deciding if that
-trace should be sampled or not.  Having the ingress make all sampling decisions
-ensures that either an entire trace is sampled or none of it is, and avoids
-creating "partial traces".
+it typically creates the root span of each trace and is responsible for deciding
+if that trace should be sampled or not.  Having the ingress make all sampling
+decisions ensures that either an entire trace is sampled or none of it is, and
+avoids creating "partial traces".
 
 Distributed tracing systems all rely on services to propagate metadata about the
 current trace from requests that they receive to requests that they send. This
@@ -244,22 +244,8 @@ format](https://github.com/openzipkin/b3-propagation) today. Being one of the
 earliest widely used formats, it has the widest support, especially among
 ingresses like Nginx.
 
-This reference architecture includes a simple Nginx config that samples 50% of
-traces and emits trace data to the collector (using the Zipkin protocol).  Any
-ingress controller can be used here in place of Nginx as long as it:
-
-- Supports probabilistic sampling
-- Encodes trace context in the b3 format
-- Emits spans in a protocol supported by the OpenCensus collector
-
-If using helm to install ingress-nginx, you can configure tracing by using:
-
-```yaml
-controller:
-  config:
-    enable-opentracing: "true"
-    zipkin-collector-host: collector.linkerd-jaeger
-```
+This reference architecture uses a traffic generator called `vote-bot` instead
+of an ingress to create the root span of each trace.
 
 ### Client Library
 


### PR DESCRIPTION
Fixes https://github.com/linkerd/linkerd2/issues/9753

Our emojivoto based reference architecture does not use an ingress, but instead uses vote-bot to initiate traces.  However, the docs still make reference to using nginx as an ingress for this.

Update the docs to indicate that an ingress typically initiates traces but that our reference architecture uses vote-bot instead.

Signed-off-by: Alex Leong <alex@buoyant.io>