### PR TITLE
Set `-n linkerd` in helm HA install examples

### DIFF
--- a/linkerd.io/content/2-edge/tasks/install-helm.md
+++ b/linkerd.io/content/2-edge/tasks/install-helm.md
@@ -41,7 +41,7 @@ The `linkerd-crds` chart sets up the CRDs linkerd requires:
 
 ```bash
 helm install linkerd-crds linkerd/linkerd-crds \
-  -n linkerd --create-namespace 
+  -n linkerd --create-namespace
 ```
 
 {{< note >}}
@@ -90,6 +90,7 @@ Then use the `-f` flag to provide this override file. For example:
 
 ```bash
 helm install linkerd-control-plane \
+  -n linkerd \
   --set-file identityTrustAnchorsPEM=ca.crt \
   --set-file identity.issuer.tls.crtPEM=issuer.crt \
   --set-file identity.issuer.tls.keyPEM=issuer.key \

--- a/linkerd.io/content/2.12/tasks/install-helm.md
+++ b/linkerd.io/content/2.12/tasks/install-helm.md
@@ -41,7 +41,7 @@ The `linkerd-crds` chart sets up the CRDs linkerd requires:
 
 ```bash
 helm install linkerd-crds linkerd/linkerd-crds \
-  -n linkerd --create-namespace 
+  -n linkerd --create-namespace
 ```
 
 {{< note >}}
@@ -90,6 +90,7 @@ Then use the `-f` flag to provide this override file. For example:
 
 ```bash
 helm install linkerd-control-plane \
+  -n linkerd \
   --set-file identityTrustAnchorsPEM=ca.crt \
   --set-file identity.issuer.tls.crtPEM=issuer.crt \
   --set-file identity.issuer.tls.keyPEM=issuer.key \


### PR DESCRIPTION
The `helm install` commands with `values-ha.yaml` were not setting the `-n linkerd` flag, causing linkerd to be installed into the `default` namespace.

Modify the `helm install` examples to set `-n linkerd`.