### PR TITLE
Whoops, it's 18 May.

### DIFF
--- a/linkerd.io/static/uploads/sma-2023/2023-05.ics
+++ b/linkerd.io/static/uploads/sma-2023/2023-05.ics
@@ -23,8 +23,8 @@ END:VTIMEZONE
 BEGIN:VEVENT
 DTSTAMP:20221214T175415Z
 UID:559525E5-2E82-430F-8AC3-9E0D8250DC6E@ical.buoyant.io
-DTSTART;TZID=America/New_York:20230516T120000
-DTEND;TZID=America/New_York:20230516T130000
+DTSTART;TZID=America/New_York:20230518T120000
+DTEND;TZID=America/New_York:20230518T133000
 SUMMARY:Circuit Breakers & Dynamic Request Routing Deep Dive
 DESCRIPTION:In our sneak peek of Linkerd 2.13\, we introduced dynamic request routing and circuit breaking. With the launch of stable-2.13.0\, this Service Mesh Academy can take a deep dive into these powerful features.
 LOCATION:https://buoyant.io/service-mesh-academy/live-workshop


### PR DESCRIPTION
This should've been 18 May 12-1330. Fixed now.

Signed-off-by: Flynn <flynn@buoyant.io>
