### PR TITLE
Moved HTTPRoute reference doc into its own page

### DIFF
--- a/linkerd.io/content/2-edge/reference/authorization-policy.md
+++ b/linkerd.io/content/2-edge/reference/authorization-policy.md
@@ -134,13 +134,14 @@ spec:
 
 ## HTTPRoute
 
-An `HTTPRoute` represents a subset of traffic handled by a [Server].
-`HTTPRoutes` are "attached" to [Servers] and have match rules which determine
-which requests match. Matches can be based on path, headers, query params,
-and/or verb. [AuthorizationPolicies] may target `HTTPRoute` resources, thereby
-authorizing traffic to that `HTTPRoute` only rather than to the entire [Server].
-`HTTPRoutes` may also define filters which add processing steps that must be
-completed during the request or response lifecycle.
+When attached to a [Server], an `HTTPRoute` resource represents a subset of the
+traffic handled by the ports on pods referred in that Server, by declaring a set
+of rules which determine which requests match. Matches can be based on path,
+headers, query params, and/or verb. [AuthorizationPolicies] may target
+`HTTPRoute` resources, thereby authorizing traffic to that `HTTPRoute` only
+rather than to the entire [Server]. `HTTPRoutes` may also define filters which
+add processing steps that must be completed during the request or response
+lifecycle.
 
 {{< note >}}
 A given HTTP request can only match one HTTPRoute. If multiple HTTPRoutes
@@ -149,183 +150,7 @@ API rules of
 precendence](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteSpec).
 {{< /note >}}
 
-### HTTPRoute Spec
-
-An `HTTPRoute` spec may contain the following top level fields:
-
-{{< table >}}
-| field| value |
-|------|-------|
-| `parentRefs`| A set of [ParentReference](#parentreference)s which indicate which [Servers](#server) this `HTTPRoute` attach to.|
-| `hostnames`| A set of hostnames that should match against the HTTP Host header.|
-| `rules`| An array of [HTTPRouteRules](#httprouterule).|
-{{< /table >}}
-
-#### parentReference
-
-A reference to the [Servers] this `HTTPRoute` is a part of.
-
-{{< table >}}
-| field| value |
-|------|-------|
-| `group`| The group of the referent. This must be set to "group.linkerd.io".|
-| `kind`| The kind of the referent. This must be set to "Server".|
-| `namespace`| The namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route.|
-| `name`| The name of the referent.|
-{{< /table >}}
-
-#### httpRouteRule
-
-`HTTPRouteRule` defines semantics for matching an HTTP request based on conditions
-(matches) and processing it (filters).
-
-{{< table >}}
-| field| value |
-|------|-------|
-| `matches`| A list of [httpRouteMatches](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.|
-| `filters`| A list of [httpRouteFilters](#httproutefilter) which will be applied to each request which matches this rule.|
-{{< /table >}}
-
-#### httpRouteMatch
-
-`HTTPRouteMatch` defines the predicate used to match requests to a given
-action. Multiple match types are ANDed together, i.e. the match will
-evaluate to true only if all conditions are satisfied.
-
-{{< table >}}
-| field| value |
-|------|-------|
-| `path`| An [httpPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided.|
-| `headers`| A list of [httpHeaderMatches](#httpheadermatch). Multiple match values are ANDed together.|
-| `queryParams`| A list of [httpQueryParamMatches](#httpqueryparammatch). Multiple match values are ANDed together.|
-| `method`| When specified, this route will be matched only if the request has the specified method.|
-{{< /table >}}
-
-#### httpPathMatch
-
-`HTTPPathMatch` describes how to select a HTTP route by matching the HTTP
-request path.
-
-{{< table >}}
-| field| value |
-|------|-------|
-| `type`| How to match against the path Value. One of: Exact, PathPrefix, RegularExpression. If this field is not specified, a default of "PathPrefix" is provided.|
-| `value`| The HTTP path to match against.|
-{{< /table >}}
-
-#### httpHeaderMatch
-
-`HTTPHeaderMatch` describes how to select a HTTP route by matching HTTP request
-headers.
-
-{{< table >}}
-| field| value |
-|------|-------|
-| `type`| How to match against the value of the header. One of: Exact, RegularExpression. If this field is not specified, a default of "Exact" is provided.|
-| `name`| The HTTP Header to be matched against. Name matching MUST be case insensitive.|
-| `value`| Value of HTTP Header to be matched.|
-{{< /table >}}
-
-#### httpQueryParamMatch
-
-`HTTPQueryParamMatch` describes how to select a HTTP route by matching HTTP
-query parameters.
-
-{{< table >}}
-| field| value |
-|------|-------|
-| `type`| How to match against the value of the query parameter. One of: Exact, RegularExpression. If this field is not specified, a default of "Exact" is provided.|
-| `name`| The HTTP query param to be matched. This must be an exact string match.|
-| `value`| Value of HTTP query param to be matched.|
-{{< /table >}}
-
-#### httpRouteFilter
-
-`HTTPRouteFilter` defines processing steps that must be completed during the
-request or response lifecycle.
-
-{{< table >}}
-| field| value |
-|------|-------|
-| `type`| One of: RequestHeaderModifier, RequestRedirect.|
-| `requestHeaderModifier`| An [httpRequestHeaderFilter](#httprequestheaderfilter).|
-| `requestRedirect`| An [httpRequestRedirectFilter](#httprequestredirectfilter).|
-{{< /table >}}
-
-#### httpRequestHeaderFilter
-
-A filter which modifies request headers.
-
-{{< table >}}
-| field| value |
-|------|-------|
-| `set`| A list of [httpHeaders](#httpheader) to overwrites on the request.|
-| `add`|  A list of [httpHeaders](#httpheader) to add on the request, appending to any existing value.|
-| `remove`|  A list of header names to remove from the request.|
-{{< /table >}}
-
-#### httpHeader
-
-`HTTPHeader` represents an HTTP Header name and value as defined by RFC 7230.
-
-{{< table >}}
-| field| value |
-|------|-------|
-| `name`| Name of the HTTP Header to be matched. Name matching MUST be case insensitive.|
-| `value`| Value of HTTP Header to be matched.|
-{{< /table >}}
-
-#### httpRequestRedirectFilter
-
-`HTTPRequestRedirect` defines a filter that redirects a request.
-
-{{< table >}}
-| field| value |
-|------|-------|
-| `scheme`| The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.|
-| `hostname`| The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.|
-| `path`| An [httpPathModfier](#httppathmodfier) which modifies the path of the incoming request and uses the modified path in the `Location` header.|
-| `port`| The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.|
-| `statusCode`| The HTTP status code to be used in response.|
-{{< /table >}}
-
-#### httpPathModfier
-
-`HTTPPathModifier` defines configuration for path modifiers.
-
-{{< table >}}
-| field| value |
-|------|-------|
-| `type`| One of: ReplaceFullPath, ReplacePrefixMatch.|
-| `replaceFullPath`| The value with which to replace the full path of a request during a rewrite or redirect.|
-| `replacePrefixMatch`| The value with which to replace the prefix match of a request during a rewrite or redirect.|
-{{< /table >}}
-
-### HTTPRoute Examples
-
-An `HTTPRoute` which matches GETs to `/authors.json` or `/authors/*`.
-
-```yaml
-apiVersion: policy.linkerd.io/v1beta1
-kind: HTTPRoute
-metadata:
-  name: authors-get-route
-  namespace: booksapp
-spec:
-  parentRefs:
-    - name: authors-server
-      kind: Server
-      group: policy.linkerd.io
-  rules:
-    - matches:
-      - path:
-          value: "/authors.json"
-        method: GET
-      - path:
-          value: "/authors/"
-          type: "PathPrefix"
-        method: GET
-```
+Please refer to HTTPRoute's full [spec](../httproute).
 
 ## AuthorizationPolicy
 

--- a/linkerd.io/content/2-edge/reference/authorization-policy.md
+++ b/linkerd.io/content/2-edge/reference/authorization-policy.md
@@ -150,7 +150,7 @@ API rules of
 precendence](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteSpec).
 {{< /note >}}
 
-Please refer to HTTPRoute's full [spec](../httproute).
+Please refer to HTTPRoute's full [spec](../httproute/).
 
 ## AuthorizationPolicy
 

--- a/linkerd.io/content/2-edge/reference/httproute.md
+++ b/linkerd.io/content/2-edge/reference/httproute.md
@@ -3,31 +3,31 @@ title = "HTTPRoute"
 description = "Reference guide to HTTPRoute resources."
 +++
 
-`HTTPRoutes` can be attached (via `parentRefs`) to a
+HTTPRoutes can be attached (via `parentRefs`) to a
 [Server](../authorization-policy/#server) to allow defining an [authorization
 policy](../authorization-policy/#authorizationpolicy) for specific routes served
 on that Server.
 
-`HTTRoutes` can also be attached to a Service, in order to classify requests
+HTTPRoutes can also be attached to a Service, in order to classify requests
 depending on path, headers, query params, and/or verb. Requests can then be
 rerouted to different backend services. This can be used to perform header-based
 routing or traffic splitting.
 
 ## HTTPRoute Spec
 
-An `HTTPRoute` spec may contain the following top level fields:
+An HTTPRoute spec may contain the following top level fields:
 
 {{< table >}}
 | field| value |
 |------|-------|
-| `parentRefs`| A set of [ParentReference](#parentreference)s which indicate which [Servers](#server) or Services this `HTTPRoute` attaches to.|
+| `parentRefs`| A set of [ParentReference](#parentreference)s which indicate which [Servers](#server) or Services this HTTPRoute attaches to.|
 | `hostnames`| A set of hostnames that should match against the HTTP Host header.|
 | `rules`| An array of [HTTPRouteRules](#httprouterule).|
 {{< /table >}}
 
 ### parentReference
 
-A reference to the [Servers] this `HTTPRoute` is a part of.
+A reference to the parent resource this HTTPRoute is a part of.
 
 {{< table >}}
 | field| value |
@@ -41,7 +41,7 @@ A reference to the [Servers] this `HTTPRoute` is a part of.
 
 ### httpRouteRule
 
-`HTTPRouteRule` defines semantics for matching an HTTP request based on conditions
+HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 (matches) and processing it (filters).
 
 {{< table >}}
@@ -54,7 +54,7 @@ A reference to the [Servers] this `HTTPRoute` is a part of.
 
 ### httpRouteMatch
 
-`HTTPRouteMatch` defines the predicate used to match requests to a given
+HTTPRouteMatch defines the predicate used to match requests to a given
 action. Multiple match types are ANDed together, i.e. the match will
 evaluate to true only if all conditions are satisfied.
 
@@ -107,7 +107,7 @@ query parameters.
 
 ### httpRouteFilter
 
-`HTTPRouteFilter` defines processing steps that must be completed during the
+HTTPRouteFilter defines processing steps that must be completed during the
 request or response lifecycle.
 
 {{< table >}}
@@ -177,12 +177,13 @@ sent to. Only allowed when a route has Service [parentRefs](#parentReference).
 |------|-------|
 | `name`| Name of service for this backend.|
 | `port`| Destination port number for this backend.|
+| `namespace`| Namespace of service for this backend.|
 | `weight`| Proportion of requests sent to this backend.|
 {{< /table >}}
 
 ## HTTPRoute Examples
 
-An `HTTPRoute` attached to a Server resource which matches GETs to
+An HTTPRoute attached to a Server resource which matches GETs to
 `/authors.json` or `/authors/*`:
 
 ```yaml
@@ -207,7 +208,7 @@ spec:
         method: GET
 ```
 
-An `HTTPRoute` attached to a Service to perform header-based routing. If there's
+An HTTPRoute attached to a Service to perform header-based routing. If there's
 a `x-faces-user: testuser` header in the request, the request is routed to the
 `smiley2` backend Service. Otherwise, the request is routed to the `smiley`
 backend Service.

--- a/linkerd.io/content/2-edge/reference/httproute.md
+++ b/linkerd.io/content/2-edge/reference/httproute.md
@@ -27,7 +27,7 @@ on that Server.
 HTTPRoutes can also be attached to a Service, in order to route requests
 depending on path, headers, query params, and/or verb. Requests can then be
 rerouted to different backend services. This can be used to perform [dynamic
-request routing](../../tasks/configuring-dynamic-request-routing).
+request routing](../../tasks/configuring-dynamic-request-routing/).
 
 {{< table >}}
 | field| value |

--- a/linkerd.io/content/2-edge/reference/httproute.md
+++ b/linkerd.io/content/2-edge/reference/httproute.md
@@ -4,8 +4,8 @@ description = "Reference guide to HTTPRoute Resources."
 +++
 
 `HTTPRoutes` can be attached (via `parentRefs`) to a
-[Server](../authorization-policy#server) to allow defining an [authorization
-policy](../authorization-policy#authorizationpolicy) for specific routes served
+[Server](../authorization-policy/#server) to allow defining an [authorization
+policy](../authorization-policy/#authorizationpolicy) for specific routes served
 on that Server.
 
 `HTTRoutes` can also be attached to a Service, in order to classify requests
@@ -13,7 +13,7 @@ depending on path, headers, query params, and/or verb. Requests can then be
 rerouted to different backend services. This can be used to perform header-based
 routing or traffic splitting.
 
-### HTTPRoute Spec
+## HTTPRoute Spec
 
 An `HTTPRoute` spec may contain the following top level fields:
 
@@ -25,7 +25,7 @@ An `HTTPRoute` spec may contain the following top level fields:
 | `rules`| An array of [HTTPRouteRules](#httprouterule).|
 {{< /table >}}
 
-#### parentReference
+### parentReference
 
 A reference to the [Servers] this `HTTPRoute` is a part of.
 
@@ -39,7 +39,7 @@ A reference to the [Servers] this `HTTPRoute` is a part of.
 | `name`| The name of the referent.|
 {{< /table >}}
 
-#### httpRouteRule
+### httpRouteRule
 
 `HTTPRouteRule` defines semantics for matching an HTTP request based on conditions
 (matches) and processing it (filters).
@@ -52,7 +52,7 @@ A reference to the [Servers] this `HTTPRoute` is a part of.
 | `backendRefs`| An array of [HTTPBackendRefs](#httpbackendref) to declare where the traffic should be routed to (only to be used with Service parentRefs).|
 {{< /table >}}
 
-#### httpRouteMatch
+### httpRouteMatch
 
 `HTTPRouteMatch` defines the predicate used to match requests to a given
 action. Multiple match types are ANDed together, i.e. the match will
@@ -67,7 +67,7 @@ evaluate to true only if all conditions are satisfied.
 | `method`| When specified, this route will be matched only if the request has the specified method.|
 {{< /table >}}
 
-#### httpPathMatch
+### httpPathMatch
 
 `HTTPPathMatch` describes how to select a HTTP route by matching the HTTP
 request path.
@@ -79,7 +79,7 @@ request path.
 | `value`| The HTTP path to match against.|
 {{< /table >}}
 
-#### httpHeaderMatch
+### httpHeaderMatch
 
 `HTTPHeaderMatch` describes how to select a HTTP route by matching HTTP request
 headers.
@@ -92,7 +92,7 @@ headers.
 | `value`| Value of HTTP Header to be matched.|
 {{< /table >}}
 
-#### httpQueryParamMatch
+### httpQueryParamMatch
 
 `HTTPQueryParamMatch` describes how to select a HTTP route by matching HTTP
 query parameters.
@@ -105,7 +105,7 @@ query parameters.
 | `value`| Value of HTTP query param to be matched.|
 {{< /table >}}
 
-#### httpRouteFilter
+### httpRouteFilter
 
 `HTTPRouteFilter` defines processing steps that must be completed during the
 request or response lifecycle.
@@ -118,7 +118,7 @@ request or response lifecycle.
 | `requestRedirect`| An [httpRequestRedirectFilter](#httprequestredirectfilter).|
 {{< /table >}}
 
-#### httpRequestHeaderFilter
+### httpRequestHeaderFilter
 
 A filter which modifies request headers.
 
@@ -130,7 +130,7 @@ A filter which modifies request headers.
 | `remove`|  A list of header names to remove from the request.|
 {{< /table >}}
 
-#### httpHeader
+### httpHeader
 
 `HTTPHeader` represents an HTTP Header name and value as defined by RFC 7230.
 
@@ -141,7 +141,7 @@ A filter which modifies request headers.
 | `value`| Value of HTTP Header to be matched.|
 {{< /table >}}
 
-#### httpRequestRedirectFilter
+### httpRequestRedirectFilter
 
 `HTTPRequestRedirect` defines a filter that redirects a request.
 
@@ -155,7 +155,7 @@ A filter which modifies request headers.
 | `statusCode`| The HTTP status code to be used in response.|
 {{< /table >}}
 
-#### httpPathModfier
+### httpPathModfier
 
 `HTTPPathModifier` defines configuration for path modifiers.
 
@@ -167,7 +167,7 @@ A filter which modifies request headers.
 | `replacePrefixMatch`| The value with which to replace the prefix match of a request during a rewrite or redirect.|
 {{< /table >}}
 
-#### httpBackendRef
+### httpBackendRef
 
 `HTTPBackendRef` defines the list of objects where matching requests should be
 sent to. Only to be used with Service parentRefs.
@@ -180,9 +180,10 @@ sent to. Only to be used with Service parentRefs.
 | `weight`| Proportion of requests sent to this backend.|
 {{< /table >}}
 
-### HTTPRoute Examples
+## HTTPRoute Examples
 
-An `HTTPRoute` attached to a Server resource which matches GETs to `/authors.json` or `/authors/*`:
+An `HTTPRoute` attached to a Server resource which matches GETs to
+`/authors.json` or `/authors/*`:
 
 ```yaml
 apiVersion: policy.linkerd.io/v1beta2

--- a/linkerd.io/content/2-edge/reference/httproute.md
+++ b/linkerd.io/content/2-edge/reference/httproute.md
@@ -1,0 +1,236 @@
++++
+title = "HTTPRoute"
+description = "Reference guide to HTTPRoute Resources."
++++
+
+`HTTPRoutes` can be attached (via `parentRefs`) to a
+[Server](../authorization-policy#server) to allow defining an [authorization
+policy](../authorization-policy#authorizationpolicy) for specific routes served
+on that Server.
+
+`HTTRoutes` can also be attached to a Service, in order to classify requests
+depending on path, headers, query params, and/or verb. Requests can then be
+rerouted to different backend services. This can be used to perform header-based
+routing or traffic splitting.
+
+### HTTPRoute Spec
+
+An `HTTPRoute` spec may contain the following top level fields:
+
+{{< table >}}
+| field| value |
+|------|-------|
+| `parentRefs`| A set of [ParentReference](#parentreference)s which indicate which [Servers](#server) or Services this `HTTPRoute` attaches to.|
+| `hostnames`| A set of hostnames that should match against the HTTP Host header.|
+| `rules`| An array of [HTTPRouteRules](#httprouterule).|
+{{< /table >}}
+
+#### parentReference
+
+A reference to the [Servers] this `HTTPRoute` is a part of.
+
+{{< table >}}
+| field| value |
+|------|-------|
+| `group`| The group of the referent. This must either be "group.linkerd.io" (for Server) or "core" (for Service).|
+| `kind`| The kind of the referent. This must be set to either "Server" or "Service".|
+| `port`| The targeted port number, when attaching to Services.|
+| `namespace`| The namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route.|
+| `name`| The name of the referent.|
+{{< /table >}}
+
+#### httpRouteRule
+
+`HTTPRouteRule` defines semantics for matching an HTTP request based on conditions
+(matches) and processing it (filters).
+
+{{< table >}}
+| field| value |
+|------|-------|
+| `matches`| A list of [httpRouteMatches](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.|
+| `filters`| A list of [httpRouteFilters](#httproutefilter) which will be applied to each request which matches this rule.|
+| `backendRefs`| An array of [HTTPBackendRefs](#httpbackendref) to declare where the traffic should be routed to (only to be used with Service parentRefs).|
+{{< /table >}}
+
+#### httpRouteMatch
+
+`HTTPRouteMatch` defines the predicate used to match requests to a given
+action. Multiple match types are ANDed together, i.e. the match will
+evaluate to true only if all conditions are satisfied.
+
+{{< table >}}
+| field| value |
+|------|-------|
+| `path`| An [httpPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided.|
+| `headers`| A list of [httpHeaderMatches](#httpheadermatch). Multiple match values are ANDed together.|
+| `queryParams`| A list of [httpQueryParamMatches](#httpqueryparammatch). Multiple match values are ANDed together.|
+| `method`| When specified, this route will be matched only if the request has the specified method.|
+{{< /table >}}
+
+#### httpPathMatch
+
+`HTTPPathMatch` describes how to select a HTTP route by matching the HTTP
+request path.
+
+{{< table >}}
+| field| value |
+|------|-------|
+| `type`| How to match against the path Value. One of: Exact, PathPrefix, RegularExpression. If this field is not specified, a default of "PathPrefix" is provided.|
+| `value`| The HTTP path to match against.|
+{{< /table >}}
+
+#### httpHeaderMatch
+
+`HTTPHeaderMatch` describes how to select a HTTP route by matching HTTP request
+headers.
+
+{{< table >}}
+| field| value |
+|------|-------|
+| `type`| How to match against the value of the header. One of: Exact, RegularExpression. If this field is not specified, a default of "Exact" is provided.|
+| `name`| The HTTP Header to be matched against. Name matching MUST be case insensitive.|
+| `value`| Value of HTTP Header to be matched.|
+{{< /table >}}
+
+#### httpQueryParamMatch
+
+`HTTPQueryParamMatch` describes how to select a HTTP route by matching HTTP
+query parameters.
+
+{{< table >}}
+| field| value |
+|------|-------|
+| `type`| How to match against the value of the query parameter. One of: Exact, RegularExpression. If this field is not specified, a default of "Exact" is provided.|
+| `name`| The HTTP query param to be matched. This must be an exact string match.|
+| `value`| Value of HTTP query param to be matched.|
+{{< /table >}}
+
+#### httpRouteFilter
+
+`HTTPRouteFilter` defines processing steps that must be completed during the
+request or response lifecycle.
+
+{{< table >}}
+| field| value |
+|------|-------|
+| `type`| One of: RequestHeaderModifier, RequestRedirect.|
+| `requestHeaderModifier`| An [httpRequestHeaderFilter](#httprequestheaderfilter).|
+| `requestRedirect`| An [httpRequestRedirectFilter](#httprequestredirectfilter).|
+{{< /table >}}
+
+#### httpRequestHeaderFilter
+
+A filter which modifies request headers.
+
+{{< table >}}
+| field| value |
+|------|-------|
+| `set`| A list of [httpHeaders](#httpheader) to overwrites on the request.|
+| `add`|  A list of [httpHeaders](#httpheader) to add on the request, appending to any existing value.|
+| `remove`|  A list of header names to remove from the request.|
+{{< /table >}}
+
+#### httpHeader
+
+`HTTPHeader` represents an HTTP Header name and value as defined by RFC 7230.
+
+{{< table >}}
+| field| value |
+|------|-------|
+| `name`| Name of the HTTP Header to be matched. Name matching MUST be case insensitive.|
+| `value`| Value of HTTP Header to be matched.|
+{{< /table >}}
+
+#### httpRequestRedirectFilter
+
+`HTTPRequestRedirect` defines a filter that redirects a request.
+
+{{< table >}}
+| field| value |
+|------|-------|
+| `scheme`| The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.|
+| `hostname`| The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.|
+| `path`| An [httpPathModfier](#httppathmodfier) which modifies the path of the incoming request and uses the modified path in the `Location` header.|
+| `port`| The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.|
+| `statusCode`| The HTTP status code to be used in response.|
+{{< /table >}}
+
+#### httpPathModfier
+
+`HTTPPathModifier` defines configuration for path modifiers.
+
+{{< table >}}
+| field| value |
+|------|-------|
+| `type`| One of: ReplaceFullPath, ReplacePrefixMatch.|
+| `replaceFullPath`| The value with which to replace the full path of a request during a rewrite or redirect.|
+| `replacePrefixMatch`| The value with which to replace the prefix match of a request during a rewrite or redirect.|
+{{< /table >}}
+
+#### httpBackendRef
+
+`HTTPBackendRef` defines the list of objects where matching requests should be
+sent to. Only to be used with Service parentRefs.
+
+{{< table >}}
+| field| value |
+|------|-------|
+| `name`| Name of service for this backend.|
+| `port`| Destination port number for this backend.|
+| `weight`| Proportion of requests sent to this backend.|
+{{< /table >}}
+
+### HTTPRoute Examples
+
+An `HTTPRoute` attached to a Server resource which matches GETs to `/authors.json` or `/authors/*`:
+
+```yaml
+apiVersion: policy.linkerd.io/v1beta2
+kind: HTTPRoute
+metadata:
+  name: authors-get-route
+  namespace: booksapp
+spec:
+  parentRefs:
+    - name: authors-server
+      kind: Server
+      group: policy.linkerd.io
+  rules:
+    - matches:
+      - path:
+          value: "/authors.json"
+        method: GET
+      - path:
+          value: "/authors/"
+          type: "PathPrefix"
+        method: GET
+```
+
+An `HTTPRoute` attached to a Service to perform header-based routing. If there's
+a `x-faces-user: testuser` header in the request the served backend is `smiley2`,
+otherwise `smiley` is served:
+
+```yaml
+apiVersion: policy.linkerd.io/v1beta2
+kind: HTTPRoute
+metadata:
+  name: smiley-a-b
+  namespace: faces
+spec:
+  parentRefs:
+    - name: smiley
+      kind: Service
+      group: core
+      port: 80
+  rules:
+    - matches:
+      - headers:
+        - name: "x-faces-user"
+          value: "testuser"
+      backendRefs:
+        - name: smiley2
+          port: 80
+    - backendRefs:
+      - name: smiley
+        port: 80
+```

--- a/linkerd.io/content/2-edge/reference/httproute.md
+++ b/linkerd.io/content/2-edge/reference/httproute.md
@@ -3,16 +3,6 @@ title = "HTTPRoute"
 description = "Reference guide to HTTPRoute resources."
 +++
 
-HTTPRoutes can be attached (via `parentRefs`) to a
-[Server](../authorization-policy/#server) to allow defining an [authorization
-policy](../authorization-policy/#authorizationpolicy) for specific routes served
-on that Server.
-
-HTTPRoutes can also be attached to a Service, in order to classify requests
-depending on path, headers, query params, and/or verb. Requests can then be
-rerouted to different backend services. This can be used to perform header-based
-routing or traffic splitting.
-
 ## HTTPRoute Spec
 
 An HTTPRoute spec may contain the following top level fields:
@@ -29,11 +19,21 @@ An HTTPRoute spec may contain the following top level fields:
 
 A reference to the parent resource this HTTPRoute is a part of.
 
+HTTPRoutes can be attached to a [Server](../authorization-policy/#server) to
+allow defining an [authorization
+policy](../authorization-policy/#authorizationpolicy) for specific routes served
+on that Server.
+
+HTTPRoutes can also be attached to a Service, in order to classify requests
+depending on path, headers, query params, and/or verb. Requests can then be
+rerouted to different backend services. This can be used to perform dynamic
+request routing.
+
 {{< table >}}
 | field| value |
 |------|-------|
 | `group`| The group of the referent. This must either be "policy.linkerd.io" (for Server) or "core" (for Service).|
-| `kind`| The kind of the referent. This must be set to either "Server" or "Service".|
+| `kind`| The kind of the referent. This must be either "Server" or "Service".|
 | `port`| The targeted port number, when attaching to Services.|
 | `namespace`| The namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route.|
 | `name`| The name of the referent.|

--- a/linkerd.io/content/2-edge/reference/httproute.md
+++ b/linkerd.io/content/2-edge/reference/httproute.md
@@ -24,10 +24,10 @@ allow defining an [authorization
 policy](../authorization-policy/#authorizationpolicy) for specific routes served
 on that Server.
 
-HTTPRoutes can also be attached to a Service, in order to classify requests
+HTTPRoutes can also be attached to a Service, in order to route requests
 depending on path, headers, query params, and/or verb. Requests can then be
-rerouted to different backend services. This can be used to perform dynamic
-request routing.
+rerouted to different backend services. This can be used to perform [dynamic
+request routing](../../tasks/configuring-dynamic-request-routing).
 
 {{< table >}}
 | field| value |

--- a/linkerd.io/content/2-edge/reference/httproute.md
+++ b/linkerd.io/content/2-edge/reference/httproute.md
@@ -1,6 +1,6 @@
 +++
 title = "HTTPRoute"
-description = "Reference guide to HTTPRoute Resources."
+description = "Reference guide to HTTPRoute resources."
 +++
 
 `HTTPRoutes` can be attached (via `parentRefs`) to a
@@ -32,7 +32,7 @@ A reference to the [Servers] this `HTTPRoute` is a part of.
 {{< table >}}
 | field| value |
 |------|-------|
-| `group`| The group of the referent. This must either be "group.linkerd.io" (for Server) or "core" (for Service).|
+| `group`| The group of the referent. This must either be "policy.linkerd.io" (for Server) or "core" (for Service).|
 | `kind`| The kind of the referent. This must be set to either "Server" or "Service".|
 | `port`| The targeted port number, when attaching to Services.|
 | `namespace`| The namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route.|
@@ -49,7 +49,7 @@ A reference to the [Servers] this `HTTPRoute` is a part of.
 |------|-------|
 | `matches`| A list of [httpRouteMatches](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.|
 | `filters`| A list of [httpRouteFilters](#httproutefilter) which will be applied to each request which matches this rule.|
-| `backendRefs`| An array of [HTTPBackendRefs](#httpbackendref) to declare where the traffic should be routed to (only to be used with Service parentRefs).|
+| `backendRefs`| An array of [HTTPBackendRefs](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).|
 {{< /table >}}
 
 ### httpRouteMatch
@@ -170,7 +170,7 @@ A filter which modifies request headers.
 ### httpBackendRef
 
 `HTTPBackendRef` defines the list of objects where matching requests should be
-sent to. Only to be used with Service parentRefs.
+sent to. Only allowed when a route has Service [parentRefs](#parentReference).
 
 {{< table >}}
 | field| value |
@@ -208,8 +208,9 @@ spec:
 ```
 
 An `HTTPRoute` attached to a Service to perform header-based routing. If there's
-a `x-faces-user: testuser` header in the request the served backend is `smiley2`,
-otherwise `smiley` is served:
+a `x-faces-user: testuser` header in the request, the request is routed to the
+`smiley2` backend Service. Otherwise, the request is routed to the `smiley`
+backend Service.
 
 ```yaml
 apiVersion: policy.linkerd.io/v1beta2


### PR DESCRIPTION
Moved out of Authorization Policy given it's also used for Header-Based routing which is unrelated to Auth.

Also added missing fields in the ref.

Upcoming: Header-Based routing tutorial