### PR TITLE
fix typo which in auto rotate control plane tls

### DIFF
--- a/linkerd.io/content/2-edge/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2-edge/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -7,7 +7,7 @@ aliases = [ "use_external_certs" ]
 Linkerd's [automatic mTLS](../../features/automatic-mtls/) feature generates TLS
 certificates for proxies and automatically rotates them without user
 intervention. These certificates are derived from a *trust anchor*, which is
-shared across clusters, and an *issuer certificate*, whcih is specific to the
+shared across clusters, and an *issuer certificate*, which is specific to the
 cluster.
 
 While Linkerd automatically rotates the per-proxy TLS certificates, it does not

--- a/linkerd.io/content/2.13/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.13/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -7,7 +7,7 @@ aliases = [ "use_external_certs" ]
 Linkerd's [automatic mTLS](../../features/automatic-mtls/) feature generates TLS
 certificates for proxies and automatically rotates them without user
 intervention. These certificates are derived from a *trust anchor*, which is
-shared across clusters, and an *issuer certificate*, whcih is specific to the
+shared across clusters, and an *issuer certificate*, which is specific to the
 cluster.
 
 While Linkerd automatically rotates the per-proxy TLS certificates, it does not


### PR DESCRIPTION
Was fixed in 2.12 here https://github.com/linkerd/website/pull/1581 but not in 2.13 / edge.