### PR TITLE
Add cache override annotations

### DIFF
--- a/linkerd.io/data/cli-2-13.yaml
+++ b/linkerd.io/data/cli-2-13.yaml
@@ -75,6 +75,12 @@ AnnotationsReference:
   Name: config.linkerd.io/proxy-outbound-connect-timeout
 - Description: Inbound TCP connection timeout in the proxy
   Name: config.linkerd.io/proxy-inbound-connect-timeout
+- Description: Maximum time allowed before an unused outbound discovery result is
+    evicted from the cache
+  Name: config.linkerd.io/proxy-outbound-discovery-cache-unused-timeout
+- Description: Maximum time allowed before an unused inbound discovery result is evicted
+    from the cache
+  Name: config.linkerd.io/proxy-inbound-discovery-cache-unused-timeout
 - Description: The proxy sidecar will stay alive for at least the given period after
     receiving SIGTERM signal from Kubernetes but no longer than pod's `terminationGracePeriodSeconds`.
     Defaults to `0`

--- a/linkerd.io/data/cli-2-edge.yaml
+++ b/linkerd.io/data/cli-2-edge.yaml
@@ -75,6 +75,12 @@ AnnotationsReference:
   Name: config.linkerd.io/proxy-outbound-connect-timeout
 - Description: Inbound TCP connection timeout in the proxy
   Name: config.linkerd.io/proxy-inbound-connect-timeout
+- Description: Maximum time allowed before an unused outbound discovery result is
+    evicted from the cache
+  Name: config.linkerd.io/proxy-outbound-discovery-cache-unused-timeout
+- Description: Maximum time allowed before an unused inbound discovery result is evicted
+    from the cache
+  Name: config.linkerd.io/proxy-inbound-discovery-cache-unused-timeout
 - Description: The proxy sidecar will stay alive for at least the given period after
     receiving SIGTERM signal from Kubernetes but no longer than pod's `terminationGracePeriodSeconds`.
     Defaults to `0`


### PR DESCRIPTION
Linkerd supports install values in the most recent stable version that allow for configuring the cache eviction idle timeout values. This change adds the annotation overrides.

Depends on https://github.com/linkerd/linkerd2/pull/10871