### PR TITLE
Adds notes about l5d-dst-override requirement

### DIFF
--- a/linkerd.io/content/2.13/tasks/upgrade.md
+++ b/linkerd.io/content/2.13/tasks/upgrade.md
@@ -234,7 +234,10 @@ version.
 Please be sure to read the [Linkerd 2.13.0 release
 notes](https://github.com/linkerd/linkerd2/releases/tag/stable-2.13.0).
 
-There are no other extra steps for upgrading to 2.13.0.
+One important change could affect the upgrade process for 2.13.0:
+
+- The behaviour of ingress mode has changed to fail requests without
+ `l5d-dst-override` headers.
 
 ### Upgrade notice: stable-2.12.0
 

--- a/linkerd.io/content/2.13/tasks/using-ingress.md
+++ b/linkerd.io/content/2.13/tasks/using-ingress.md
@@ -613,6 +613,11 @@ Thus, combining an ingress with Linkerd takes one of two forms:
 The most common approach in form #2 is to use the explicit `l5d-dst-override` header.
 
 {{< note >}}
+As of 2.13 linkerd in *ingress* mode requires the `l5d-dst-override` header.
+Requests on a pod meshed in ingress mode without the header will fail.
+{{< /note >}}
+
+{{< note >}}
 Some ingress controllers support sticky sessions. For session stickiness, the
 ingress controller has to do its own endpoint selection. This means that
 Linkerd will not be able to connect to the IP/port of the Kubernetes Service,


### PR DESCRIPTION
2.13 changed behavior for ingress mode proxies,
failling requests without l5d-dst-override.

This add notes about this behaviour change to the docs

Fixes linkerd/linkerd2#10908