### PR TITLE
Apparently a double slash in an image URL passes website lint but doesn't render correctly?? Also fix the alt text. Sigh.

### DIFF
--- a/linkerd.io/content/blog/2023/0621-edge-roundup.md
+++ b/linkerd.io/content/blog/2023/0621-edge-roundup.md
@@ -12,8 +12,8 @@ featured: false
 ---
 
 {{< fig
-  alt="Dynamic Request Routing"
-  src="/uploads/2023/06//roundup-clocks-rect.png" >}}
+  alt="21 June Linkerd Edge Roundup"
+  src="/uploads/2023/06/roundup-clocks-rect.png" >}}
 
 Linkerd’s edge releases are a big part of our development process that we’re
 going to start talking more about – and so far in June, we’ve done a couple of


### PR DESCRIPTION
It makes me tremendously sad that this doesn't look right on the website, but it passed lint _and_ rendered correctly in my local preview. 😢 

Signed-off-by: Flynn <flynn@buoyant.io>
