### PR TITLE
troubleshooting section: link to rotation instructions for expired tap cert

### DIFF
--- a/linkerd.io/content/2-edge/tasks/troubleshooting.md
+++ b/linkerd.io/content/2-edge/tasks/troubleshooting.md
@@ -1631,6 +1631,18 @@ entries.
 Here you need to make sure the certificate was issued specifically for
 `tap.linkerd-viz.svc`.
 
+```bash
+× tap API server has valid cert
+    anchors not within their validity period:
+        * tap.linkerd-viz.svc not valid anymore. Expired on <DATE>
+    see https://linkerd.io/checks/#l5d-tap-cert-valid for hints
+```
+
+Here you need to rotate the expired certificate, see
+[Rotating webhooks certificates](../rotating_webhooks_certificates/) for a single rotation or
+[Automatically Rotating your webhook TLS Credentials](../automatically-rotating-webhook-tls-credentials/)
+for automatic rotation which won't incur downtime.
+
 ### √ tap API server cert is valid for at least 60 days {#l5d-tap-cert-not-expiring-soon}
 
 Example failure:

--- a/linkerd.io/content/2.10/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.10/tasks/troubleshooting.md
@@ -1677,6 +1677,18 @@ entries.
 Here you need to make sure the certificate was issued specifically for
 `tap.linkerd-viz.svc`.
 
+```bash
+× tap API server has valid cert
+    anchors not within their validity period:
+        * tap.linkerd-viz.svc not valid anymore. Expired on <DATE>
+    see https://linkerd.io/checks/#l5d-tap-cert-valid for hints
+```
+
+Here you need to rotate the expired certificate, see
+[Rotating webhooks certificates](../rotating_webhooks_certificates/) for a single rotation or
+[Automatically Rotating your webhook TLS Credentials](../automatically-rotating-webhook-tls-credentials/)
+for automatic rotation which won't incur downtime.
+
 ### √ tap API server cert is valid for at least 60 days {#l5d-tap-cert-not-expiring-soon}
 
 Example failure:

--- a/linkerd.io/content/2.11/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.11/tasks/troubleshooting.md
@@ -1823,6 +1823,18 @@ entries.
 Here you need to make sure the certificate was issued specifically for
 `tap.linkerd-viz.svc`.
 
+```bash
+× tap API server has valid cert
+    anchors not within their validity period:
+        * tap.linkerd-viz.svc not valid anymore. Expired on <DATE>
+    see https://linkerd.io/checks/#l5d-tap-cert-valid for hints
+```
+
+Here you need to rotate the expired certificate, see
+[Rotating webhooks certificates](../rotating_webhooks_certificates/) for a single rotation or
+[Automatically Rotating your webhook TLS Credentials](../automatically-rotating-webhook-tls-credentials/)
+for automatic rotation which won't incur downtime.
+
 ### √ tap API server cert is valid for at least 60 days {#l5d-tap-cert-not-expiring-soon}
 
 Example failure:

--- a/linkerd.io/content/2.12/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.12/tasks/troubleshooting.md
@@ -1631,6 +1631,18 @@ entries.
 Here you need to make sure the certificate was issued specifically for
 `tap.linkerd-viz.svc`.
 
+```bash
+× tap API server has valid cert
+    anchors not within their validity period:
+        * tap.linkerd-viz.svc not valid anymore. Expired on <DATE>
+    see https://linkerd.io/checks/#l5d-tap-cert-valid for hints
+```
+
+Here you need to rotate the expired certificate, see
+[Rotating webhooks certificates](../rotating_webhooks_certificates/) for a single rotation or
+[Automatically Rotating your webhook TLS Credentials](../automatically-rotating-webhook-tls-credentials/)
+for automatic rotation which won't incur downtime.
+
 ### √ tap API server cert is valid for at least 60 days {#l5d-tap-cert-not-expiring-soon}
 
 Example failure:

--- a/linkerd.io/content/2.13/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.13/tasks/troubleshooting.md
@@ -1631,6 +1631,18 @@ entries.
 Here you need to make sure the certificate was issued specifically for
 `tap.linkerd-viz.svc`.
 
+```bash
+× tap API server has valid cert
+    anchors not within their validity period:
+        * tap.linkerd-viz.svc not valid anymore. Expired on <DATE>
+    see https://linkerd.io/checks/#l5d-tap-cert-valid for hints
+```
+
+Here you need to rotate the expired certificate, see
+[Rotating webhooks certificates](../rotating_webhooks_certificates/) for a single rotation or
+[Automatically Rotating your webhook TLS Credentials](../automatically-rotating-webhook-tls-credentials/)
+for automatic rotation which won't incur downtime.
+
 ### √ tap API server cert is valid for at least 60 days {#l5d-tap-cert-not-expiring-soon}
 
 Example failure:

--- a/linkerd.io/content/2.9/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.9/tasks/troubleshooting.md
@@ -787,6 +787,18 @@ entries.
 Here you need to make sure the certificate was issued specifically for
 `linkerd-tap.linkerd.svc`.
 
+```bash
+× tap API server has valid cert
+    anchors not within their validity period:
+        * tap.linkerd-viz.svc not valid anymore. Expired on <DATE>
+    see https://linkerd.io/checks/#l5d-tap-cert-valid for hints
+```
+
+Here you need to rotate the expired certificate, see
+[Rotating webhooks certificates](../rotating_webhooks_certificates/) for a single rotation or
+[Automatically Rotating your webhook TLS Credentials](../automatically-rotating-webhook-tls-credentials/)
+for automatic rotation which won't incur downtime.
+
 ### √ webhook cert is valid for at least 60 days {#l5d-webhook-cert-not-expiring-soon}
 
 Example failure:


### PR DESCRIPTION
couldn't find anywhere these pages were centrally generated from, so figured content was copy-pasted between them? let me know if that is wrong. happy to update.