### PR TITLE
update ServiceProfile compat warning

### DIFF
--- a/linkerd.io/content/2-edge/reference/httproute.md
+++ b/linkerd.io/content/2-edge/reference/httproute.md
@@ -30,11 +30,12 @@ rerouted to different backend services. This can be used to perform [dynamic
 request routing](../../tasks/configuring-dynamic-request-routing/).
 
 {{< warning >}}
-Outbound HTTPRoutes are **incompatible with ServiceProfiles**. If the
-[ParentReference](#parentreference) of an HTTPRoute is a Service, and a
-[ServiceProfile](../../features/service-profiles/) is also defined for that
-Service, proxies will use the ServiceProfile configuration, rather than the
-HTTPRoute configuration, as long as the ServiceProfile exists.
+**Outbound HTTPRoutes and [ServiceProfile]s provide overlapping configuration.**
+For backwards-compatibility reasons, a ServiceProfile will take precedence over
+HTTPRoutes which configure the same Service. If a ServiceProfile is defined for
+the parent Service of an HTTPRoute, proxies will use the ServiceProfile
+configuration, rather than the HTTPRoute configuration, as long as the
+ServiceProfile exists.
 {{< /warning >}}
 
 {{< table >}}
@@ -245,3 +246,5 @@ spec:
       - name: smiley
         port: 80
 ```
+
+[ServiceProfile]: ../../features/service-profiles/

--- a/linkerd.io/content/2-edge/tasks/configuring-dynamic-request-routing.md
+++ b/linkerd.io/content/2-edge/tasks/configuring-dynamic-request-routing.md
@@ -110,10 +110,12 @@ namespace (`test`), and also specify the Service port number (not the Service's
 target port).
 
 {{< warning >}}
-Outbound `HTTPRoute`s are **incompatible with `ServiceProfiles`**. If a
-[ServiceProfile](../../features/service-profiles/) is defined for the parent
-Service of an [`HTTPRoute`], proxies will use the `ServiceProfile` configuration,
-rather than the [`HTTPRoute`] configuration, as long as the `ServiceProfile`
+**Outbound [`HTTPRoute`]s and [`ServiceProfile`]s provide overlapping
+configuration.** For backwards-compatibility reasons, a [`ServiceProfile`] will
+take precedence over [`HTTPRoute`s] which configure the same Service. If a
+[`ServiceProfile`] is defined for the parent Service of an [`HTTPRoute`],
+proxies will use the [`ServiceProfile`] configuration, rather than the
+[`HTTPRoute`] configuration, as long as the [`ServiceProfile`]
 exists.
 {{< /warning >}}
 
@@ -171,3 +173,4 @@ more workloads you have injected the better, to benefit from things like easy
 mTLS setup and all the other advantages that linkerd brings to the table!
 
 [`HTTPRoute`]: ../../features/httproute/
+[`ServiceProfile`]: ../../features/ServiceProfile/


### PR DESCRIPTION
This commit updates the HTTPRoute/ServiceProfile incompatibility warning in the documentation to use the new wording suggested by @wmorgan in https://github.com/linkerd/website/pull/1657#discussion_r1298905092.