### PR TITLE
document HTTPRoute timeouts

### DIFF
--- a/linkerd.io/content/2-edge/features/httproute.md
+++ b/linkerd.io/content/2-edge/features/httproute.md
@@ -63,4 +63,4 @@ To get started with HTTPRoutes, you can:
 [Server]: ../../reference/authorization-policy/#server
 [auth-policy]: ../../tasks/configuring-per-route-policy/
 [dyn-routing]:../../tasks/configuring-dynamic-request-routing/
-[timeouts]: ../../tasks/configuring-timeouts/
+[timeouts]: ../../tasks/configuring-timeouts/#using-httproutes

--- a/linkerd.io/content/2-edge/features/httproute.md
+++ b/linkerd.io/content/2-edge/features/httproute.md
@@ -15,6 +15,8 @@ to that resource, based on parameters such as the request's path, method, and
 headers, and can configure how requests matching that rule are routed by the
 Linkerd service mesh.
 
+## Inbound and Outbound HTTPRoutes
+
 Two types of HTTPRoute are used for configuring the behavior of Linkerd's
 proxies:
 
@@ -38,17 +40,17 @@ configuration, as long as the ServiceProfile
 exists.
 {{< /warning >}}
 
+## Learn More
+
 To get started with HTTPRoutes, you can:
 
-<!-- TODO(eliza): add this link once the timeout doc discusses HTTPRoutes...
-- [Configure timeouts][timeouts] using an outbound HTTPRoute.
--->
 <!-- TODO(eliza): add this link once the fault injection doc discusses
   HTTPRoutes...
 - [Configure fault injection](../../tasks/fault-injection/) using an outbound
   HTTPRoute.
 -->
 
+- [Configure timeouts][timeouts] using an outbound HTTPRoute.
 - [Configure dynamic request routing][dyn-routing] using an outbound HTTPRoute.
 - [Configure per-route authorization policy][auth-policy] using an inbound
   HTTPRoute.
@@ -61,4 +63,4 @@ To get started with HTTPRoutes, you can:
 [Server]: ../../reference/authorization-policy/#server
 [auth-policy]: ../../tasks/configuring-per-route-policy/
 [dyn-routing]:../../tasks/configuring-dynamic-request-routing/
-[timeouts]: ../../tasks/configuring-dynamic-request-routing/
+[timeouts]: ../../tasks/configuring-timeouts/

--- a/linkerd.io/content/2-edge/reference/httproute.md
+++ b/linkerd.io/content/2-edge/reference/httproute.md
@@ -196,7 +196,7 @@ sent to. Only allowed when a route has Service [parentRefs](#parentReference).
 request.
 
 Linkerd implements HTTPRoute timeouts as described in [GEP-1742]. Timeout
-durations are configured as strings in the format parsed by
+durations are specified as strings in the format parsed by
 [Go `time.ParseDuration`] (e.g. 1h/1m/1s/1ms), and MUST be greater than 1ms.
 A timeout field with duration 0 disables that timeout.
 

--- a/linkerd.io/content/2-edge/reference/httproute.md
+++ b/linkerd.io/content/2-edge/reference/httproute.md
@@ -196,8 +196,8 @@ sent to. Only allowed when a route has Service [parentRefs](#parentReference).
 request.
 
 Linkerd implements HTTPRoute timeouts as described in [GEP-1742]. Timeout
-durations are specified as strings in the format parsed by
-[Go `time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) (e.g.
+durations are specified as strings using the [Gateway API duration format]
+specified by [GEP-2257](https://gateway-api.sigs.k8s.io/geps/gep-2257/) (e.g.
 1h/1m/1s/1ms), and MUST be greater than 1ms. A timeout field with duration 0
 disables that timeout.
 
@@ -214,6 +214,7 @@ will be started for each retry request, but each retry request will count
 against the overall `request` timeout.
 
 [GEP-1742]: https://gateway-api.sigs.k8s.io/geps/gep-1742/
+[Gateway API duration format]: https://gateway-api.sigs.k8s.io/geps/gep-2257/#gateway-api-duration-format
 
 ## HTTPRoute Examples
 

--- a/linkerd.io/content/2-edge/reference/httproute.md
+++ b/linkerd.io/content/2-edge/reference/httproute.md
@@ -199,8 +199,8 @@ request.
 Linkerd implements HTTPRoute timeouts as described in [GEP-1742]. Timeout
 durations are specified as strings using the [Gateway API duration format]
 specified by [GEP-2257](https://gateway-api.sigs.k8s.io/geps/gep-2257/) (e.g.
-1h/1m/1s/1ms), and MUST be at least 1ms or greater. A timeout field with
-duration 0 disables that timeout.
+1h/1m/1s/1ms), and MUST be at least 1ms. A timeout field with duration 0
+disables that timeout.
 
 {{< table >}}
 | field| value |

--- a/linkerd.io/content/2-edge/reference/httproute.md
+++ b/linkerd.io/content/2-edge/reference/httproute.md
@@ -197,8 +197,9 @@ request.
 
 Linkerd implements HTTPRoute timeouts as described in [GEP-1742]. Timeout
 durations are specified as strings in the format parsed by
-[Go `time.ParseDuration`] (e.g. 1h/1m/1s/1ms), and MUST be greater than 1ms.
-A timeout field with duration 0 disables that timeout.
+[Go `time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) (e.g.
+1h/1m/1s/1ms), and MUST be greater than 1ms. A timeout field with duration 0
+disables that timeout.
 
 {{< table >}}
 | field| value |
@@ -213,7 +214,6 @@ will be started for each retry request, but each retry request will count
 against the overall `request` timeout.
 
 [GEP-1742]: https://gateway-api.sigs.k8s.io/geps/gep-1742/
-[Go `time.ParseDuration`]: https://pkg.go.dev/time#ParseDuration
 
 ## HTTPRoute Examples
 

--- a/linkerd.io/content/2-edge/reference/httproute.md
+++ b/linkerd.io/content/2-edge/reference/httproute.md
@@ -198,8 +198,8 @@ request.
 Linkerd implements HTTPRoute timeouts as described in [GEP-1742]. Timeout
 durations are specified as strings using the [Gateway API duration format]
 specified by [GEP-2257](https://gateway-api.sigs.k8s.io/geps/gep-2257/) (e.g.
-1h/1m/1s/1ms), and MUST be greater than 1ms. A timeout field with duration 0
-disables that timeout.
+1h/1m/1s/1ms), and MUST be at least 1ms or greater. A timeout field with
+duration 0 disables that timeout.
 
 {{< table >}}
 | field| value |

--- a/linkerd.io/content/2-edge/tasks/configuring-timeouts.md
+++ b/linkerd.io/content/2-edge/tasks/configuring-timeouts.md
@@ -37,14 +37,13 @@ Each [rule](../../reference/httproute/#httprouterule) in an [HTTPRoute] may
 define an optional [`timeouts`](../../reference/httproute/#httproutetimeouts)
 object, which can define `request` and/or `backendRequest` fields:
 
-- `timeouts.request` bounds the *total time* spent servicing requests matching
-  this rule, starting when the proxy receives a request and when it receives a
-  response from the backend. This includes time spent in retries (if
-  applicable).
-- `timeouts.backendRequest` bounds the time that may elapse between when a single
-  request is dispatched to a
-  [backend](../../reference/httproute/#httpbackendref) and when a response is
-  received from that backend. This is a subset of the `timeouts.request`
+- `timeouts.request` specifies the *total time* to wait for a request matching
+  this rule to complete (including retries). This timeout starts when the proxy
+  receives a request, and ends when successful response is sent to the client.
+- `timeouts.backendRequest` specifies the time to wait for a single request to a
+  backend to complete. This timeout starts when a request is dispatched to a
+  [backend](../../reference/httproute/#httpbackendref), and ends when a response
+  is received from that backend. This is a subset of the `timeouts.request`
   timeout. If the request fails and is retried (if applicable), the
   `backendRequest` timeout will be restarted for each retry request.
 
@@ -71,9 +70,10 @@ spec:
 ## Using ServiceProfiles
 
 Each [route](../../reference/service-profiles/#route) in a [ServiceProfile] may
-define a request timeout for requests matching that route. This timeout bounds
-the *total time* spent servicing requests to that route, including retries (if
-applicable). If unspecified, the default timeout is 10 seconds.
+define a request timeout for requests matching that route. This timeout secifies
+the maximum amount of time to wait for a response (including retries) to
+complete after the request is sent. If unspecified, the default timeout is 10
+seconds.
 
 ```yaml
 spec:

--- a/linkerd.io/content/2-edge/tasks/configuring-timeouts.md
+++ b/linkerd.io/content/2-edge/tasks/configuring-timeouts.md
@@ -50,9 +50,8 @@ object, which can define `request` and/or `backendRequest` fields:
 Timeout durations are specified specified as strings using the [Gateway API
 duration format] specified by
 [GEP-2257](https://gateway-api.sigs.k8s.io/geps/gep-2257/)
-(e.g. 1h/1m/1s/1ms), and must be at least 1ms or greater. If either field is
-unspecified or set to 0, the timeout configured by that field will not be
-enforced.
+(e.g. 1h/1m/1s/1ms), and must be at least 1ms. If either field is unspecified or
+set to 0, the timeout configured by that field will not be enforced.
 
 For example:
 

--- a/linkerd.io/content/2-edge/tasks/configuring-timeouts.md
+++ b/linkerd.io/content/2-edge/tasks/configuring-timeouts.md
@@ -50,7 +50,7 @@ object, which can define `request` and/or `backendRequest` fields:
 Timeout durations are specified specified as strings using the [Gateway API
 duration format] specified by
 [GEP-2257](https://gateway-api.sigs.k8s.io/geps/gep-2257/)
-(e.g. 1h/1m/1s/1ms), and must be greater than 1ms. If either field is
+(e.g. 1h/1m/1s/1ms), and must be at least 1ms or greater. If either field is
 unspecified or set to 0, the timeout configured by that field will not be
 enforced.
 

--- a/linkerd.io/content/2-edge/tasks/configuring-timeouts.md
+++ b/linkerd.io/content/2-edge/tasks/configuring-timeouts.md
@@ -47,10 +47,12 @@ object, which can define `request` and/or `backendRequest` fields:
   timeout. If the request fails and is retried (if applicable), the
   `backendRequest` timeout will be restarted for each retry request.
 
-Timeout durations are specified specified as strings in the format parsed by
-[Go `time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) (e.g.
-1h/1m/1s/1ms), and must be greater than 1ms. If either field is unspecified or
-set to 0, the timeout configured by that field will not be enforced.
+Timeout durations are specified specified as strings using the [Gateway API
+duration format] specified by
+[GEP-2257](https://gateway-api.sigs.k8s.io/geps/gep-2257/)
+(e.g. 1h/1m/1s/1ms), and must be greater than 1ms. If either field is
+unspecified or set to 0, the timeout configured by that field will not be
+enforced.
 
 For example:
 
@@ -106,3 +108,4 @@ success rate.
 [504 Gateway Timeout]:
     https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [GEP-1742]: https://gateway-api.sigs.k8s.io/geps/gep-1742/
+[Gateway API duration format]: https://gateway-api.sigs.k8s.io/geps/gep-2257/#gateway-api-duration-format

--- a/linkerd.io/content/2-edge/tasks/configuring-timeouts.md
+++ b/linkerd.io/content/2-edge/tasks/configuring-timeouts.md
@@ -9,10 +9,10 @@ of time to wait for a response from a remote service to complete after the
 request is sent. If the timeout elapses without receiving a response, Linkerd
 will cancel the request and return a [504 Gateway Timeout] response.
 
-Timeouts can be specified using either Gateway API [HTTPRoute]s or legacy
-[ServiceProfile]s. Since HTTPRoute is a newer configuration mechanism intended
-to replace ServiceProfiles, prefer the use of HTTPRoute timeouts unless a
-ServiceProfile already exists for the Service.
+Timeouts can be specified either [using HTTPRoutes](#using-httproutes) or [using
+legacy ServiceProfiles](#using-serviceprofiles). Since [HTTPRoute] is a newer
+configuration mechanism intended to replace [ServiceProfile]s, prefer the use of
+HTTPRoute timeouts unless a ServiceProfile already exists for the Service.
 
 ## Using HTTPRoutes
 
@@ -21,33 +21,32 @@ HTTPRoutes](../../features/httproute/#inbound-and-outbound-httproutes)
 with Service parents.
 
 {{< warning >}}
-Support for [GEP-1742] has not yet been implemented by the upstream Gateway API
-HTTPRoute resource. The GEP has been accepted, but it has not yet been added to
-the definition of the HTTPRoute resource. This means that HTTPRoute timeout
-fields can currently be used only in HTTPRoute resources with the
-`policy.linkerd.io` API group, *not* the `gateway.networking.k8s.io` API
-group.
+Support for [GEP-1742](https://gateway-api.sigs.k8s.io/geps/gep-1742/) has not
+yet been implemented by the upstream Gateway API HTTPRoute resource. The GEP has
+been accepted, but it has not yet been added to the definition of the HTTPRoute
+resource. This means that HTTPRoute timeout fields can currently be used only in
+HTTPRoute resources with the `policy.linkerd.io` API group, *not* the
+`gateway.networking.k8s.io` API group.
 
-When the [GEP-1742] timeout fields are added to the upstream resource
-definition, Linkerd will support timeout configuration for HTTPRoutes with both
-API groups.
-
-[GEP-1742]: https://gateway-api.sigs.k8s.io/geps/gep-1742/
+When the [GEP-1742](https://gateway-api.sigs.k8s.io/geps/gep-1742/) timeout
+fields are added to the upstream resource definition, Linkerd will support
+timeout configuration for HTTPRoutes with both API groups.
 {{< /warning >}}
 
-Each [rule](../../reference/httproute/#httprouterule) may define an optional
-[`timeouts`](../../reference/httproute/#httpRouteTimeouts) object, which can
-define `request` and/or `backendRequest` fields:
+Each [rule](../../reference/httproute/#httprouterule) in an [HTTPRoute] may
+define an optional [`timeouts`](../../reference/httproute/#httproutetimeouts)
+object, which can define `request` and/or `backendRequest` fields:
 
-- `timeouts.request` applies a timeout to the total total time that may elapse
-  between when the proxy receives a request and when it receives a response from
-  the backend.
-- `timeouts.backendRequest` applies a timeout to the time that may elapse
-  between when a single request is dispatched to a
+- `timeouts.request` bounds the *total time* spent servicing requests matching
+  this rule, starting when the proxy receives a request and when it receives a
+  response from the backend. This includes time spent in retries (if
+  applicable).
+- `timeouts.backendRequest` bounds the time that may elapse between when a single
+  request is dispatched to a
   [backend](../../reference/httproute/#httpbackendref) and when a response is
   received from that backend. This is a subset of the `timeouts.request`
-  timeout. If the request fails and is retried, the `backendRequest` timeout
-  will be restarted for each retry request.
+  timeout. If the request fails and is retried (if applicable), the
+  `backendRequest` timeout will be restarted for each retry request.
 
 Timeout durations are specified specified as strings in the format parsed by
 [Go `time.ParseDuration`] (e.g. 1h/1m/1s/1ms), and must be greater than 1ms. If
@@ -91,8 +90,8 @@ a tutorial of how to configure timeouts using ServiceProfiles.
 
 ## Monitoring Timeouts
 
-Requests which reach the timeout will be canceled, return a 504 Gateway Timeout
-response, and count as a failure for the purposes of [effective success
+Requests which reach the timeout will be canceled, return a [504 Gateway
+Timeout] response, and count as a failure for the purposes of [effective success
 rate](../configuring-retries/#monitoring-retries).  Since the request was
 canceled before any actual response was received, a timeout will not count
 towards the actual request volume at all.  This means that effective request

--- a/linkerd.io/content/2-edge/tasks/configuring-timeouts.md
+++ b/linkerd.io/content/2-edge/tasks/configuring-timeouts.md
@@ -48,9 +48,9 @@ object, which can define `request` and/or `backendRequest` fields:
   `backendRequest` timeout will be restarted for each retry request.
 
 Timeout durations are specified specified as strings in the format parsed by
-[Go `time.ParseDuration`] (e.g. 1h/1m/1s/1ms), and must be greater than 1ms. If
-either field is unspecified or set to 0, the timeout configured by that field
-will not be enforced.
+[Go `time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) (e.g.
+1h/1m/1s/1ms), and must be greater than 1ms. If either field is unspecified or
+set to 0, the timeout configured by that field will not be enforced.
 
 For example:
 
@@ -101,9 +101,8 @@ possible for the request to be counted as an actual success but an effective
 failure.  This can result in effective success rate being lower than actual
 success rate.
 
-[HTTPRoute]: ../../features/httproutes/
-[ServiceProfile]: ../../features/serviceprofiles/
+[HTTPRoute]: ../../features/httproute/
+[ServiceProfile]: ../../features/service-profiles/
 [504 Gateway Timeout]:
     https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [GEP-1742]: https://gateway-api.sigs.k8s.io/geps/gep-1742/
-[Go `time.ParseDuration`]: https://pkg.go.dev/time#ParseDuration

--- a/linkerd.io/content/2-edge/tasks/configuring-timeouts.md
+++ b/linkerd.io/content/2-edge/tasks/configuring-timeouts.md
@@ -16,7 +16,7 @@ HTTPRoute timeouts unless a ServiceProfile already exists for the Service.
 
 ## Using HTTPRoutes
 
-Linkerd support timeouts as specified in [GEP-1742], for [outbound
+Linkerd supports timeouts as specified in [GEP-1742], for [outbound
 HTTPRoutes](../../features/httproute/#inbound-and-outbound-httproutes)
 with Service parents.
 

--- a/linkerd.io/content/2-edge/tasks/configuring-timeouts.md
+++ b/linkerd.io/content/2-edge/tasks/configuring-timeouts.md
@@ -108,4 +108,5 @@ success rate.
 [504 Gateway Timeout]:
     https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [GEP-1742]: https://gateway-api.sigs.k8s.io/geps/gep-1742/
-[Gateway API duration format]: https://gateway-api.sigs.k8s.io/geps/gep-2257/#gateway-api-duration-format
+[Gateway API duration format]:
+    https://gateway-api.sigs.k8s.io/geps/gep-2257/#gateway-api-duration-format


### PR DESCRIPTION
This branch adds new documentation for the HTTPRoute timeout fields
added in Linkerd 2.14. This includes adding the HTTPRoute timeout fields
to the HTTPRoute reference docs, and adding a section on using HTTPRoute
timeouts to the "Configuring Timeouts" tasks doc.