### PR TITLE
add ResponseHeaderModifier to HTTPRoute docs

### DIFF
--- a/linkerd.io/content/2-edge/reference/httproute.md
+++ b/linkerd.io/content/2-edge/reference/httproute.md
@@ -123,21 +123,22 @@ request or response lifecycle.
 {{< table >}}
 | field| value |
 |------|-------|
-| `type`| One of: RequestHeaderModifier, RequestRedirect.|
-| `requestHeaderModifier`| An [httpRequestHeaderFilter](#httprequestheaderfilter).|
+| `type`| One of: RequestHeaderModifier, ResponseHeaderModifier, or RequestRedirect.|
+| `requestHeaderModifier`| An [httpHeaderFilter](#httheaderfilter) which modifies request headers.|
+| `responseHeaderModifier` | An [httpHeaderFilter](#httpheaderfilter) which modifies response headers.|
 | `requestRedirect`| An [httpRequestRedirectFilter](#httprequestredirectfilter).|
 {{< /table >}}
 
-### httpRequestHeaderFilter
+### httpHeaderFilter
 
-A filter which modifies request headers.
+A filter which modifies HTTP request or response headers.
 
 {{< table >}}
 | field| value |
 |------|-------|
-| `set`| A list of [httpHeaders](#httpheader) to overwrites on the request.|
-| `add`|  A list of [httpHeaders](#httpheader) to add on the request, appending to any existing value.|
-| `remove`|  A list of header names to remove from the request.|
+| `set`| A list of [httpHeaders](#httpheader) to overwrite on the request or response.|
+| `add`| A list of [httpHeaders](#httpheader) to add on to the request or response, appending to any existing value.|
+| `remove`| A list of header names to remove from the request or response.|
 {{< /table >}}
 
 ### httpHeader

--- a/linkerd.io/content/2-edge/reference/httproute.md
+++ b/linkerd.io/content/2-edge/reference/httproute.md
@@ -124,7 +124,7 @@ request or response lifecycle.
 | field| value |
 |------|-------|
 | `type`| One of: RequestHeaderModifier, ResponseHeaderModifier, or RequestRedirect.|
-| `requestHeaderModifier`| An [httpHeaderFilter](#httheaderfilter) which modifies request headers.|
+| `requestHeaderModifier`| An [httpHeaderFilter](#httpheaderfilter) which modifies request headers.|
 | `responseHeaderModifier` | An [httpHeaderFilter](#httpheaderfilter) which modifies response headers.|
 | `requestRedirect`| An [httpRequestRedirectFilter](#httprequestredirectfilter).|
 {{< /table >}}


### PR DESCRIPTION
Support for the ResponseHeaderModifier HTTPRoute filter was added in
2.14. This branch updates the HTTPRoute docs to reflect that this filter
is availble.