### PR TITLE
feat: add ngrok ingress controller to ingress guide in docs

### DIFF
--- a/linkerd.io/content/2-edge/tasks/using-ingress.md
+++ b/linkerd.io/content/2-edge/tasks/using-ingress.md
@@ -79,6 +79,7 @@ Common ingress options that Linkerd has been used with include:
 - [Kong](#kong)
 - [Haproxy](#haproxy)
 - [EnRoute](#enroute)
+- [ngrok](#ngrok)
 
 For a quick start guide to using a particular ingress, please visit the section
 for that ingress below. If your ingress is not on that list, never fear—it
@@ -596,6 +597,40 @@ The flag also delegates endpoint selection for routing to linkerd.
 More details and customization can be found in,
 [End to End encryption using EnRoute with
 Linkerd](https://getenroute.io/blog/end-to-end-encryption-mtls-linkerd-enroute/)
+
+## ngrok 
+
+ngrok can be meshed normally: it does not require the [ingress mode](#ingress-mode) annotation.
+
+After signing up for a [free ngrok account](https://ngrok.com/signup), and running through the [installation steps for the ngrok Ingress controller](https://github.com/ngrok/kubernetes-ingress-controller#installation), 
+you can add ingress by configuring an ingress object for your service and applying it with `kubectl apply -f ingress.yaml`.
+
+This is an example for the emojivoto app used in the Linkerd getting started guide. You will need to replace the `host` value with your 
+[free static domain](https://dashboard.ngrok.com/cloud-edge/domains) available in your ngrok account. If you have a paid ngrok account,
+you can configure this the same way you would use the [`--domain` flag](https://ngrok.com/docs/secure-tunnels/ngrok-agent/reference/ngrok/) on the ngrok agent.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: emojivoto-ingress
+  namespace: emojivoto
+spec:
+  ingressClassName: ngrok
+  rules:
+  - host: [YOUR STATIC DOMAIN.ngrok-free.app]
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: web-svc
+            port:
+              number: 80
+```
+
+Your emojivoto app should be available to anyone in the world at your static domain.
 
 ## Ingress details
 

--- a/linkerd.io/content/2-edge/tasks/using-ingress.md
+++ b/linkerd.io/content/2-edge/tasks/using-ingress.md
@@ -598,16 +598,24 @@ More details and customization can be found in,
 [End to End encryption using EnRoute with
 Linkerd](https://getenroute.io/blog/end-to-end-encryption-mtls-linkerd-enroute/)
 
-## ngrok 
+## ngrok
 
-ngrok can be meshed normally: it does not require the [ingress mode](#ingress-mode) annotation.
+ngrok can be meshed normally: it does not require the
+[ingress mode](#ingress-mode) annotation.
 
-After signing up for a [free ngrok account](https://ngrok.com/signup), and running through the [installation steps for the ngrok Ingress controller](https://github.com/ngrok/kubernetes-ingress-controller#installation), 
-you can add ingress by configuring an ingress object for your service and applying it with `kubectl apply -f ingress.yaml`.
+After signing up for a [free ngrok account](https://ngrok.com/signup), and
+running through the [installation steps for the ngrok Ingress controller
+](https://github.com/ngrok/kubernetes-ingress-controller#installation),
+you can add ingress by configuring an ingress object for your service and
+applying it with `kubectl apply -f ingress.yaml`.
 
-This is an example for the emojivoto app used in the Linkerd getting started guide. You will need to replace the `host` value with your 
-[free static domain](https://dashboard.ngrok.com/cloud-edge/domains) available in your ngrok account. If you have a paid ngrok account,
-you can configure this the same way you would use the [`--domain` flag](https://ngrok.com/docs/secure-tunnels/ngrok-agent/reference/ngrok/) on the ngrok agent.
+This is an example for the emojivoto app used in the Linkerd getting started
+guide. You will need to replace the `host` value with your
+[free static domain](https://dashboard.ngrok.com/cloud-edge/domains) available
+in your ngrok account. If you have a paid ngrok account, you can configure this
+the same way you would use the [`--domain`
+flag](https://ngrok.com/docs/secure-tunnels/ngrok-agent/reference/ngrok/) on
+the ngrok agent.
 
 ```yaml
 apiVersion: networking.k8s.io/v1
@@ -630,7 +638,8 @@ spec:
               number: 80
 ```
 
-Your emojivoto app should be available to anyone in the world at your static domain.
+Your emojivoto app should be available to anyone in the world at your static
+domain.
 
 ## Ingress details
 


### PR DESCRIPTION
PM from ngrok here. We have recently released an open source ngrok ingress controller and would love to add it as an option in your guide. 

I was able to run through the getting started guide with linkerd using a local k3d cluster. After completing that guide, i was able to install the ngrok ingress controller into it's own namespace and apply the included ingress.yaml example with no issues. 

I'm not quite sure about the meshing mode needed here. I applied the [example command](https://linkerd.io/2.14/tasks/adding-your-service/#examples) to the ngrok-ingress namespace and didn't have any issues with the emojivoto app, and the linkerd viz dashboard seems to think everything is meshed and working 🤷🏼 

<img width="1835" alt="image" src="https://github.com/linkerd/website/assets/4805997/c84d5b50-e7dd-44f6-85db-0636048db0eb">
