### PR TITLE
Removed nominated heroes, linked to blog for voted heroes

### DIFF
--- a/linkerd.io/content/blog/linkerd-hero-march.md
+++ b/linkerd.io/content/blog/linkerd-hero-march.md
@@ -11,7 +11,8 @@ tags:
 keywords: [hero]
 ---
 
-We are excited to announce that this month's Linkerd Hero is Naveen Nalam.
+We are excited to announce that this month's Linkerd Hero is
+[Naveen Nalam](https://www.linkedin.com/in/nnalam/).
 Congrats, Naveen!
 
 ## What are Linkerd Heroes?

--- a/linkerd.io/content/community/heroes/_index.md
+++ b/linkerd.io/content/community/heroes/_index.md
@@ -25,147 +25,148 @@ voted:
     hero_type: contributor
     image: "/uploads/2023/09/cameron-portrait.jpeg"
     alt: Portrait of Cameron Boulton
-    github_url: "https://www.linkedin.com/in/cameronboulton/"
+    url: "/2023/09/30/announcing-the-september-2023-linkerd-hero/"
   - name: Mikael Fridh
     date: July 2023
     blurb: Technical contributions
     hero_type: contributor
     image: "/uploads/2023/07/mikael-fridh-portrait.jpeg"
     alt: Portrait of Mikael Fridh
-    github_url: "https://www.linkedin.com/in/mikaelfridh/"
+    url: "/2023/07/25/announcing-the-july-2023-linkerd-hero/"
   - name: Yu Cao
     date: February 2023
     blurb: Technical contributions
     hero_type: contributor
     image: "/uploads/2023/02/yu-cao-portrait.png"
     alt: Portrait of Yu Cao
-    github_url: "https://github.com/yc185050"
+    url: "/2023/02/10/announcing-the-february-2023-linkerd-hero/"
   - name: Steve Reardon
     date: November 2022
     blurb: Helping community members
     hero_type: community
     image: "/uploads/steve-reardon.jpeg"
     alt: Portrait of Steve Reardon
-    github_url: "https://github.com/Monkman08/"
+    url: "/2022/11/22/announcing-novembers-linkerd-hero/"
   - name: Dan Williams
     date: September 2022
     blurb: Helping community members
     hero_type: community
     image: "/uploads/dan-williams-portrait.png"
     alt: Portrait of Dan Williams
-    github_url: "https://www.linkedin.com/in/dan-williams-5501a8105/"
+    url: "/2022/09/23/announcing-septembers-linkerd-hero/"
   - name: Dani Baeyens
     date: August 2022
     blurb: Technical contributions
     hero_type: contributor
     image: "/uploads/dani-baeyens-portrait.png"
     alt: Portrait of Dani Baeyens
-    github_url: "https://www.linkedin.com/in/danibaeyens/"
+    url: "/2022/08/24/announcing-augusts-linkerd-hero/"
   - name: Dominik Táskai
     date: July 2022
     blurb: Helping community members
     hero_type: community
     image: "/uploads/dominik-taskai-portrait.png"
     alt: Portrait of Dominik Táskai
-    github_url: "https://www.linkedin.com/in/dtaskai/"
+    url: "/2022/07/27/announcing-julys-linkerd-hero/"
   - name: Chris Voss
     date: June 2022
     blurb: Spreading the Linkerd message
     hero_type: ambassador
     image: "/uploads/chris-voss.jpeg"
     alt: Portrait of Chris Voss
-    github_url: "https://www.linkedin.com/in/christopher-voss-99161111/"
+    url: "/2022/06/08/announcing-junes-linkerd-hero/"
   - name: Naveen Nalam
     date: March 2022
     blurb: Technical contributions
     hero_type: contributor
     image: "/uploads/naveen-nalam.png"
     alt: Portrait of Naveen Nalam
-    github_url: "https://www.linkedin.com/in/nnalam/"
+    url: "/2022/04/05/announcing-marchs-linkerd-hero/"
   - name: Krzysztof Dryś
     date: January 2022
     blurb: Technical contributions
     hero_type: contributor
     image: "/uploads/krzysztof_drys.jpeg"
     alt: Portrait of Krzysztof Dryś
-    github_url: "https://github.com/krzysztofdrys"
+    url: "/2022/01/27/announcing-januarys-linkerd-hero/"
   - name: Aleksandr Tarasov
     date: December 2021
     blurb: Spreading the Linkerd message
     hero_type: ambassador
     image: "/uploads/aleksandr_tarasov.jpeg"
     alt: Portrait of Aleksandr Tarasov
-    github_url: "https://github.com/aatarasoff"
+    url: "/2021/12/09/announcing-decembers-linkerd-hero/"
   - name: Alberto Sadde
     date: October 2021
     blurb: Helping community members
     hero_type: community
     image: "/uploads/alberto-sadde.png"
     alt: Portrait of Alberto Sadde
-    github_url: https://github.com/aesadde
+    url: "/2021/10/28/announcing-octobers-linkerd-hero/"
   - name: Dom DePasquale
     date: August 2021
     blurb: Spreading the Linkerd message
     hero_type: ambassador
     image: "/uploads/dom-depasqual.png"
     alt: Portrait of Dom DePasquale
-    github_url: https://github.com/dad264
+    url: "/2021/08/26/announcing-augusts-linkerd-hero/"
   - name: Sanskar Jaiswal
     date: July 2021
     blurb: Technical contributions
     hero_type: contributor
     image: "/uploads/jaiswal.png"
     alt: Portrait of Jasiwal
-    github_url: https://github.com/aryan9600
+    url: "/2021/07/29/announcing-julys-linkerd-hero/"
   - name: Steve Gray
     date: June 2021
     blurb: Spreading the Linkerd message
     hero_type: ambassador
     image: "/uploads/steve-gray.png"
     alt: Portrait of Steve Gray
-    github_url: https://github.com/steve-gray
+    url: "/2021/06/24/announcing-junes-linkerd-heroes/"
   - name: Steve Reardon
     date: June 2021
     blurb: Spreading the Linkerd message
     hero_type: ambassador
     image: "/uploads/steve-reardon.jpeg"
     alt: Portrait of Steve Reardon
-    github_url: https://github.com/Monkman08
+    url: "/2021/06/24/announcing-junes-linkerd-heroes/"
   - name: Rio Kierkels
     date: April 2021
     blurb: Helping community members
     hero_type: community
     image: "/uploads/rio-kierkels.png"
     alt: Portrait of Rio Kierkels
-    github_url: https://www.linkedin.com/in/rio-kierkels-70a67b26/
+    url: https://www.linkedin.com/in/rio-kierkels-70a67b26/
   - name: Mayank Shah
     date: March 2021
     blurb: Technical contributions
     hero_type: contributor
     image: "/uploads/mayank-shah.png"
     alt: Portrait of Mayank Shah
-    github_url: https://github.com/mayankshah1607
+    url: https://github.com/mayankshah1607
   - name: Sergio Mendéz
     date: February 2021
     blurb: Spreading the Linkerd message
     hero_type: ambassador
     image: "/uploads/sergio.jpg"
     alt: Portrait of Sergio Mendéz
-    github_url: https://www.linkedin.com/in/sergioarmgpl/
+    url: https://www.linkedin.com/in/sergioarmgpl/
   - name: Richard Pijnenburg
     date: January 2021
     blurb: Helping community members
     hero_type: community
     image: "/uploads/richard-pijnenberg-2.jpg"
     alt: Portrait of Richard Pijnenberg
-    github_url: https://www.linkedin.com/in/richard-pijnenburg/
+    url: https://www.linkedin.com/in/richard-pijnenburg/
   - name: Lutz Behnke
     date: December 2020
     blurb: Technical contributions
     hero_type: contributor
     image: "/uploads/vita_image_lutz_behnke.jpg"
     alt: Portrait of Lutz Behnke
-    github_url: https://www.linkedin.com/in/lutz-behnke-096a19/
+    url: https://www.linkedin.com/in/lutz-behnke-096a19/
+# Nominated heros are no longer displayed on the Heroes pages
 nominated:
   badge: "/uploads/credly-badges_nominated.svg"
   heroes:
@@ -175,75 +176,75 @@ nominated:
     hero_type: ambassador
     image: "/uploads/saim safdar 1.png"
     alt: Portrait of Saim Safdar
-    github_url: https://github.com/Saim-Safdar
+    url: https://github.com/Saim-Safdar
   - name: Ali Ariff
     date: April 2021
     blurb: Technical contributions
     hero_type: contributor
     image: "/uploads/ali 1.png"
     alt: Portrait of Ali Ariff
-    github_url: https://github.com/aliariff
+    url: https://github.com/aliariff
   - name: Fredrik Klingenberg
     date: March 2021
     blurb: Spreading the Linkerd message
     hero_type: ambassador
     image: "/uploads/fredrick-klingenberg.jpg"
     alt: Portrait of Fredrick Klingenberg
-    github_url: https://www.linkedin.com/in/fredrikklingenberg/
+    url: https://www.linkedin.com/in/fredrikklingenberg/
   - name: Henry Hagnäs
     date: March 2021
     blurb: Spreading the Linkerd message
     hero_type: ambassador
     image: "/uploads/henry-elk-profile.jpg"
     alt: Portrait of Henry Hagnas
-    github_url: https://www.linkedin.com/in/hagnas/
+    url: https://www.linkedin.com/in/hagnas/
   - name: Christian Hüning
     date: March 2021
     blurb: Helping community members
     hero_type: community
     image: "/uploads/christian-huning.png"
     alt: Portrait of Christian Huning
-    github_url: https://www.linkedin.com/in/christian-h%C3%BCning-964191a3/
+    url: https://www.linkedin.com/in/christian-h%C3%BCning-964191a3/
   - name: NJM
     date: February 2021
     blurb: Helping community members
     hero_type: community
     image: "/uploads/njm.png"
     alt: Portrait of NJM
-    github_url: https://linkerd.io/community/heroes/
+    url: https://linkerd.io/community/heroes/
   - name: Piyush Singariya
     date: February 2021
     blurb: Technical contributions
     hero_type: contributions
     image: "/uploads/piyush-singariya.png"
     alt: Portrait of Piyush Singariya
-    github_url: https://www.linkedin.com/in/piyushsingariya/
+    url: https://www.linkedin.com/in/piyushsingariya/
   - name: Matt Young
     date: January 2021
     blurb: Spreading the Linkerd message
     hero_type: ambassador
     image: "/uploads/matt-young.png"
     alt: Portrait of Matt Young
-    github_url: https://www.linkedin.com/in/halcyondude/
+    url: https://www.linkedin.com/in/halcyondude/
   - name: Jimil Desai
     date: January 2021
     blurb: Technical contributions
     hero_type: contributor
     image: "/uploads/jamil-desai-2.jpeg"
     alt: Portrait of Jimil Desai
-    github_url: https://www.linkedin.com/in/jimil-desai-30179416b/
+    url: https://www.linkedin.com/in/jimil-desai-30179416b/
   - name: Maxime Bélanger
     date: December 2020
     blurb: Helping community members
     hero_type: community
     image: "/uploads/maxime-belanger.png"
     alt: Portrait of Maxime Bélanger
-    github_url: https://www.linkedin.com/in/maximeb/
+    url: https://www.linkedin.com/in/maximeb/
   - name: David Sudia
     date: December 2020
     blurb: Spreading the Linkerd message
     hero_type: ambassador
     image: "/uploads/david-sudia.png"
     alt: Portrait of David Sudia
-    github_url: https://www.linkedin.com/in/davidsudia/
+    url: https://www.linkedin.com/in/davidsudia/
 ---

--- a/linkerd.io/content/community/heroes/_index.md
+++ b/linkerd.io/content/community/heroes/_index.md
@@ -16,9 +16,7 @@ top_hero:
   image: "/images/heroes-graphic.svg"
   image_on_the_right: false
   alt: Portrait of Rio Kierkels
-voted:
-  badge: "/uploads/credly-badges_voted.svg"
-  heroes:
+heroes:
   - name: Cameron Boulton
     date: September 2023
     blurb: Technical contributions
@@ -138,38 +136,6 @@ voted:
     image: "/uploads/rio-kierkels.png"
     alt: Portrait of Rio Kierkels
     url: https://www.linkedin.com/in/rio-kierkels-70a67b26/
-  - name: Mayank Shah
-    date: March 2021
-    blurb: Technical contributions
-    hero_type: contributor
-    image: "/uploads/mayank-shah.png"
-    alt: Portrait of Mayank Shah
-    url: https://github.com/mayankshah1607
-  - name: Sergio Mendéz
-    date: February 2021
-    blurb: Spreading the Linkerd message
-    hero_type: ambassador
-    image: "/uploads/sergio.jpg"
-    alt: Portrait of Sergio Mendéz
-    url: https://www.linkedin.com/in/sergioarmgpl/
-  - name: Richard Pijnenburg
-    date: January 2021
-    blurb: Helping community members
-    hero_type: community
-    image: "/uploads/richard-pijnenberg-2.jpg"
-    alt: Portrait of Richard Pijnenberg
-    url: https://www.linkedin.com/in/richard-pijnenburg/
-  - name: Lutz Behnke
-    date: December 2020
-    blurb: Technical contributions
-    hero_type: contributor
-    image: "/uploads/vita_image_lutz_behnke.jpg"
-    alt: Portrait of Lutz Behnke
-    url: https://www.linkedin.com/in/lutz-behnke-096a19/
-# Nominated heros are no longer displayed on the Heroes pages
-nominated:
-  badge: "/uploads/credly-badges_nominated.svg"
-  heroes:
   - name: Saim Safdar
     date: April 2021
     blurb: Spreading the Linkerd message
@@ -177,6 +143,7 @@ nominated:
     image: "/uploads/saim safdar 1.png"
     alt: Portrait of Saim Safdar
     url: https://github.com/Saim-Safdar
+    nominated: true
   - name: Ali Ariff
     date: April 2021
     blurb: Technical contributions
@@ -184,6 +151,14 @@ nominated:
     image: "/uploads/ali 1.png"
     alt: Portrait of Ali Ariff
     url: https://github.com/aliariff
+    nominated: true
+  - name: Mayank Shah
+    date: March 2021
+    blurb: Technical contributions
+    hero_type: contributor
+    image: "/uploads/mayank-shah.png"
+    alt: Portrait of Mayank Shah
+    url: https://github.com/mayankshah1607
   - name: Fredrik Klingenberg
     date: March 2021
     blurb: Spreading the Linkerd message
@@ -191,6 +166,7 @@ nominated:
     image: "/uploads/fredrick-klingenberg.jpg"
     alt: Portrait of Fredrick Klingenberg
     url: https://www.linkedin.com/in/fredrikklingenberg/
+    nominated: true
   - name: Henry Hagnäs
     date: March 2021
     blurb: Spreading the Linkerd message
@@ -198,6 +174,7 @@ nominated:
     image: "/uploads/henry-elk-profile.jpg"
     alt: Portrait of Henry Hagnas
     url: https://www.linkedin.com/in/hagnas/
+    nominated: true
   - name: Christian Hüning
     date: March 2021
     blurb: Helping community members
@@ -205,6 +182,14 @@ nominated:
     image: "/uploads/christian-huning.png"
     alt: Portrait of Christian Huning
     url: https://www.linkedin.com/in/christian-h%C3%BCning-964191a3/
+    nominated: true
+  - name: Sergio Mendéz
+    date: February 2021
+    blurb: Spreading the Linkerd message
+    hero_type: ambassador
+    image: "/uploads/sergio.jpg"
+    alt: Portrait of Sergio Mendéz
+    url: https://www.linkedin.com/in/sergioarmgpl/
   - name: NJM
     date: February 2021
     blurb: Helping community members
@@ -212,6 +197,7 @@ nominated:
     image: "/uploads/njm.png"
     alt: Portrait of NJM
     url: https://linkerd.io/community/heroes/
+    nominated: true
   - name: Piyush Singariya
     date: February 2021
     blurb: Technical contributions
@@ -219,6 +205,14 @@ nominated:
     image: "/uploads/piyush-singariya.png"
     alt: Portrait of Piyush Singariya
     url: https://www.linkedin.com/in/piyushsingariya/
+    nominated: true
+  - name: Richard Pijnenburg
+    date: January 2021
+    blurb: Helping community members
+    hero_type: community
+    image: "/uploads/richard-pijnenberg-2.jpg"
+    alt: Portrait of Richard Pijnenberg
+    url: https://www.linkedin.com/in/richard-pijnenburg/
   - name: Matt Young
     date: January 2021
     blurb: Spreading the Linkerd message
@@ -226,6 +220,7 @@ nominated:
     image: "/uploads/matt-young.png"
     alt: Portrait of Matt Young
     url: https://www.linkedin.com/in/halcyondude/
+    nominated: true
   - name: Jimil Desai
     date: January 2021
     blurb: Technical contributions
@@ -233,6 +228,14 @@ nominated:
     image: "/uploads/jamil-desai-2.jpeg"
     alt: Portrait of Jimil Desai
     url: https://www.linkedin.com/in/jimil-desai-30179416b/
+    nominated: true
+  - name: Lutz Behnke
+    date: December 2020
+    blurb: Technical contributions
+    hero_type: contributor
+    image: "/uploads/vita_image_lutz_behnke.jpg"
+    alt: Portrait of Lutz Behnke
+    url: https://www.linkedin.com/in/lutz-behnke-096a19/
   - name: Maxime Bélanger
     date: December 2020
     blurb: Helping community members
@@ -240,6 +243,7 @@ nominated:
     image: "/uploads/maxime-belanger.png"
     alt: Portrait of Maxime Bélanger
     url: https://www.linkedin.com/in/maximeb/
+    nominated: true
   - name: David Sudia
     date: December 2020
     blurb: Spreading the Linkerd message
@@ -247,4 +251,5 @@ nominated:
     image: "/uploads/david-sudia.png"
     alt: Portrait of David Sudia
     url: https://www.linkedin.com/in/davidsudia/
+    nominated: true
 ---

--- a/linkerd.io/layouts/community/heroes.html
+++ b/linkerd.io/layouts/community/heroes.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 {{ partial "heroes/top-hero.html" .Params.top_hero }}
 {{ partial "heroes/heroes-section.html" .Params.voted }}
-{{ partial "heroes/heroes-section.html" .Params.nominated }}
+{{/* partial "heroes/heroes-section.html" .Params.nominated */}}
 
 {{ end }}

--- a/linkerd.io/layouts/community/heroes.html
+++ b/linkerd.io/layouts/community/heroes.html
@@ -1,6 +1,4 @@
 {{ define "main" }}
 {{ partial "heroes/top-hero.html" .Params.top_hero }}
-{{ partial "heroes/heroes-section.html" .Params.voted }}
-{{/* partial "heroes/heroes-section.html" .Params.nominated */}}
-
+{{ partial "heroes/heroes-section.html" .Params.heroes }}
 {{ end }}

--- a/linkerd.io/layouts/partials/heroes/heroes-section.html
+++ b/linkerd.io/layouts/partials/heroes/heroes-section.html
@@ -4,7 +4,7 @@
       <div class="columns column is-multiline">
         {{ range .heroes }}
         <div class="column is-6">
-          <a href="{{ .github_url }}" target="_blank">
+          <a href="{{.url}}"{{ if hasPrefix .url "http" }} target="_blank"{{ end }}>
           <div class="heroes-card box is-flex is-justify-content-flex-start is-align-items-center px-2 py-3">
             <figure class="image is-96x96 mr-4 is-flex-shrink-0">
               <img class="is-rounded" src="{{.image}}" alt="{{.alt}}" />

--- a/linkerd.io/layouts/partials/heroes/heroes-section.html
+++ b/linkerd.io/layouts/partials/heroes/heroes-section.html
@@ -2,7 +2,7 @@
   <div class="container columns is-multiline">
     <div class="column is-12 is-10-desktop is-offset-1-desktop">
       <div class="columns column is-multiline">
-        {{ range .heroes }}
+        {{ range . }}
         <div class="column is-6">
           <a href="{{.url}}"{{ if hasPrefix .url "http" }} target="_blank"{{ end }}>
           <div class="heroes-card box is-flex is-justify-content-flex-start is-align-items-center px-2 py-3">


### PR DESCRIPTION
We are currently missing a content header on the Heroes page. We have 2 sections: voted and nominated, and they run together without anything separating them. Since we haven't added nominated heroes since 2021, we should remove them.

For voted heroes, instead of linking to their Github or Linkedin page, we should link to the blog, if it available.

---

With this PR, I have removed the nominated heros, and updated the links to point to the blog post for voted heroes. If a blog post wasn't made for a hero, then the existing Github or Linkedin url is used.

I also checked to see if every hero blog post had a link to the hero's Github or Linkedin page, and added it if needed. The one exception is the blog post for Dom DePasquale. The Github page we have for him returns a 404, and I can't find his Github or Linkedin page.