### PR TITLE
remove references to production toolkit

### DIFF
--- a/linkerd.io/content/2-edge/getting-started/_index.md
+++ b/linkerd.io/content/2-edge/getting-started/_index.md
@@ -25,10 +25,8 @@ Finally, you'll "mesh" a application by adding Linkerd's *data plane* to it.
 
 {{< note >}}
 This page contains quick start instructions intended for non-production
-installations. For production-oriented configurations, we suggest alternative
-approaches, such as the [Linkerd Production
-Toolkit](https://buoyant.io/linkerd/getting-started/) by Buoyant, which includes
-continuous monitoring, vulnerability alerts, and upgrade assistance for Linkerd.
+installations. For production-oriented configurations, we suggest reviewing
+resources in [Going to Production](/going-to-production/).
 {{< /note >}}
 
 ## Step 0: Setup

--- a/linkerd.io/content/2.10/getting-started/_index.md
+++ b/linkerd.io/content/2.10/getting-started/_index.md
@@ -25,10 +25,8 @@ more of your own services by adding Linkerd's *data plane* to them.
 
 {{< note >}}
 This page contains quick start instructions intended for non-production
-installations. For production-oriented configurations, we suggest alternative
-approaches, such as the [Linkerd Production
-Toolkit](https://buoyant.io/linkerd/getting-started/) by Buoyant, which includes
-continuous monitoring, vulnerability alerts, and upgrade assistance for Linkerd.
+installations. For production-oriented configurations, we suggest reviewing
+resources in [Going to Production](/going-to-production/).
 {{< /note >}}
 
 ## Step 0: Setup

--- a/linkerd.io/content/2.11/getting-started/_index.md
+++ b/linkerd.io/content/2.11/getting-started/_index.md
@@ -25,10 +25,8 @@ Finally, you'll "mesh" a application by adding Linkerd's *data plane* to it.
 
 {{< note >}}
 This page contains quick start instructions intended for non-production
-installations. For production-oriented configurations, we suggest alternative
-approaches, such as the [Linkerd Production
-Toolkit](https://buoyant.io/linkerd/getting-started/) by Buoyant, which includes
-continuous monitoring, vulnerability alerts, and upgrade assistance for Linkerd.
+installations. For production-oriented configurations, we suggest reviewing
+resources in [Going to Production](/going-to-production/).
 {{< /note >}}
 
 ## Step 0: Setup

--- a/linkerd.io/content/2.12/getting-started/_index.md
+++ b/linkerd.io/content/2.12/getting-started/_index.md
@@ -25,10 +25,8 @@ Finally, you'll "mesh" a application by adding Linkerd's *data plane* to it.
 
 {{< note >}}
 This page contains quick start instructions intended for non-production
-installations. For production-oriented configurations, we suggest alternative
-approaches, such as the [Linkerd Production
-Toolkit](https://buoyant.io/linkerd/getting-started/) by Buoyant, which includes
-continuous monitoring, vulnerability alerts, and upgrade assistance for Linkerd.
+installations. For production-oriented configurations, we suggest reviewing
+resources in [Going to Production](/going-to-production/).
 {{< /note >}}
 
 ## Step 0: Setup

--- a/linkerd.io/content/2.13/getting-started/_index.md
+++ b/linkerd.io/content/2.13/getting-started/_index.md
@@ -25,10 +25,8 @@ Finally, you'll "mesh" a application by adding Linkerd's *data plane* to it.
 
 {{< note >}}
 This page contains quick start instructions intended for non-production
-installations. For production-oriented configurations, we suggest alternative
-approaches, such as the [Linkerd Production
-Toolkit](https://buoyant.io/linkerd/getting-started/) by Buoyant, which includes
-continuous monitoring, vulnerability alerts, and upgrade assistance for Linkerd.
+installations. For production-oriented configurations, we suggest reviewing
+resources in [Going to Production](/going-to-production/).
 {{< /note >}}
 
 ## Step 0: Setup

--- a/linkerd.io/content/2.14/getting-started/_index.md
+++ b/linkerd.io/content/2.14/getting-started/_index.md
@@ -25,10 +25,8 @@ Finally, you'll "mesh" a application by adding Linkerd's *data plane* to it.
 
 {{< note >}}
 This page contains quick start instructions intended for non-production
-installations. For production-oriented configurations, we suggest alternative
-approaches, such as the [Linkerd Production
-Toolkit](https://buoyant.io/linkerd/getting-started/) by Buoyant, which includes
-continuous monitoring, vulnerability alerts, and upgrade assistance for Linkerd.
+installations. For production-oriented configurations, we suggest reviewing
+resources in [Going to Production](/going-to-production/).
 {{< /note >}}
 
 ## Step 0: Setup

--- a/linkerd.io/content/2.9/getting-started/_index.md
+++ b/linkerd.io/content/2.9/getting-started/_index.md
@@ -25,10 +25,8 @@ more services by adding the *data plane* proxies. (See the
 
 {{< note >}}
 This page contains quick start instructions intended for non-production
-installations. For production-oriented configurations, we suggest alternative
-approaches, such as the [Linkerd Production
-Toolkit](https://buoyant.io/linkerd/getting-started/) by Buoyant, which includes
-continuous monitoring, vulnerability alerts, and upgrade assistance for Linkerd.
+installations. For production-oriented configurations, we suggest reviewing
+resources in [Going to Production](/going-to-production/).
 {{< /note >}}
 
 ## Step 0: Setup


### PR DESCRIPTION
Let's keep it simple and point them to content we already have on the site.