### PR TITLE
[DOCS] Path for linkerd cli

### DIFF
--- a/linkerd.io/content/2.14/getting-started/_index.md
+++ b/linkerd.io/content/2.14/getting-started/_index.md
@@ -69,7 +69,11 @@ To install the CLI manually, run:
 curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 
-Be sure to follow the instructions to add it to your path.
+Be sure to follow the instructions to add it to your path:
+
+```bash
+export PATH=$HOME/.linkerd2/bin:$PATH
+```
 
 (Alternatively, if you use [Homebrew](https://brew.sh), you can install the CLI
 with `brew install linkerd`. You can also download the CLI directly via the


### PR DESCRIPTION
More details: https://github.com/linkerd/website/pull/1703

The installation instructions provided in [Step 1](https://linkerd.io/2.14/getting-started/#step-1-install-the-cli) of the Linkerd documentation could benefit from additional clarity. Specifically, the documentation should include a step to add the Linkerd CLI to the system's PATH for easy access.

That's what I did.

