### PR TITLE
Add troubleshooting section to pod-to-pod-multicluster for required metadata in secret

### DIFF
--- a/linkerd.io/content/2.14/tasks/pod-to-pod-multicluster.md
+++ b/linkerd.io/content/2.14/tasks/pod-to-pod-multicluster.md
@@ -315,7 +315,7 @@ Multicluster setup requires 2 secrets on the `source` cluster to function correc
 1. `cluster-credentials-<remote-cluster-name>` residing in `linkerd-multicluster` namespace (default, it may be different if you have changed it, during installation of `linkerd-multicluster` extension).
 2. `cluster-credentials-<remote-cluster-name>` residing in the LinkerD control-plane namespace -- usually `linkerd`.
 
-The second secret (in `linkerd` namespace) has a specific metadata requirements - `linkerd-destination` required the secret to contain following labels and annotations (assuming we are linking `east` cluster to `west` cluster):
+The second secret (in `linkerd` namespace) has a specific metadata requirements. Labels and annotations shown below are neccessary for the control plane, to be able to retrieve the remote cluster credentials. Assuming we are linking `east` cluster to `west` cluster, the secret would have to contain below metadata:
 
 ```
 metadata:


### PR DESCRIPTION
Adding `Troubleshooting` section to the pod-to-pod-multicluster task, as the required metadata for secrets in control plane namespace is not documented.

References:
* https://github.com/linkerd/linkerd2/issues/11542
* https://github.com/linkerd/linkerd2/blob/ce950d17c60eab8c7c2a3e67c130241f96056ac2/controller/api/destination/watcher/cluster_store.go#L63C1-L67

Signed-off-by: @Majkel1999 mkaleta1999@gmail.com