### PR TITLE
Adds helm chart to app version matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ node_modules
 .DS_Store
 tmp
 .idea
-bin
+bin/htmltest

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ serve-api.linkerd.io: build-api.linkerd.io
 		&& python3 -m http.server 9999
 
 .PHONY: build-linkerd.io
-build-linkerd.io: get-versions tmp/linkerd.io
+build-linkerd.io: build-release-matrix get-versions tmp/linkerd.io
 	@# Build linkerd.io
 ifndef HAS_HUGO
 	@printf "Install hugo first. For OSX: brew install hugo\n"; exit 1

--- a/Makefile
+++ b/Makefile
@@ -143,8 +143,8 @@ replace-env-%: has-env-% tmp-sites
 .PHONY: build-release-matrix
 build-release-matrix:
 	@# Build release matrix
-	./bin/generate_release_matrix.py --format=json > linkerd.io/data/releases/release_matrix.json
-	./bin/generate_release_matrix.py --format=yaml > linkerd.io/content/releases/release_matrix.yaml
+	./bin/generate_release_matrix.py --release_type=stable --format=json > linkerd.io/data/releases/release_matrix.json
+	./bin/generate_release_matrix.py --release_type=stable --format=yaml > linkerd.io/content/releases/release_matrix.yaml
 	cp linkerd.io/data/releases/release_matrix.json linkerd.io/content/releases/release_matrix.json
 
 

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,14 @@ replace-env-%: has-env-% tmp-sites
 		sed 's/$*/$($*)/g' < $$fname > /tmp/__sed && mv /tmp/__sed $$fname; \
 	done
 
+.PHONY: build-release-matrix
+build-release-matrix:
+	@# Build release matrix
+	./bin/generate_release_matrix.py --format=json > linkerd.io/data/releases/release_matrix.json
+	./bin/generate_release_matrix.py --format=yaml > linkerd.io/content/releases/release_matrix.yaml
+	cp linkerd.io/data/releases/release_matrix.json linkerd.io/content/releases/release_matrix.json
+
+
 .PHONY: has-env-%
 has-env-%:
 	@if [ ! $${$*:-} ]; then printf "You must define: $*\n" && exit 1; fi
@@ -147,3 +155,5 @@ has-env-%:
 .PHONY: clean
 clean:
 	rm -rf tmp
+
+

--- a/bin/generate_release_matrix.py
+++ b/bin/generate_release_matrix.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+# Author: Corey Osman <corey@logicminds.biz>
+# Purpose: Geneate a list in specified format of all the linkerd charts by app version
+# Usage: ./generate_release_matrix.py [--format=json|table|yaml] [--update_repo]
+# Notes: Help determine which charts go with which app versions
+# Notes: This is primary aimed at the stable release only, although a slight modification 
+#        could yeild support for edge and Enterprise releases too.  Right now edge versions
+#        follow date schemes and the manual mappings do not work
+
+
+import subprocess
+import json
+import yaml
+import argparse
+
+
+charts = [
+   # "linkerd2",  # This makes the search return results for everything
+    "linkerd2-cni",
+    "linkerd-viz",
+    "linkerd-control-plane",
+    "linkerd-jaeger",
+    "linkerd-multicluster",
+    "linkerd-failover",
+]
+
+# these versions are old and do not have the proper mappings anyways
+ignored_y_versions = [6, 7, 8, 9]
+
+# Manually map in the old chart, otherwise we get duplicates mixed in
+linkerd2_map = {
+    '2.11': {
+        "linkerd2": {
+            "chart_name": "linkerd2",
+            "chart_version": "2.11.5",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2/2.11.5"
+        }
+    },
+    '2.10': {
+        "linkerd2": {
+            "chart_name": "linkerd2",
+            "chart_version": "2.10.2",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2/2.10.2"
+        }
+    }
+}
+# Manually map in the crds because there is no app version associated with them
+crds_map = {
+    "2.12": {
+        "linkerd-crds": {
+            "chart_name": "linkerd-crds",
+            "chart_version": "1.6.1",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-crds/1.6.1"
+        }
+    },
+    "2.13": {
+        "linkerd-crds": {
+            "chart_name": "linkerd-crds",
+            "chart_version": "1.6.1",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-crds/1.6.1"
+        }
+    },
+    "2.14": {
+        "linkerd-crds": {
+            "chart_name": "linkerd-crds",
+            "chart_version": "1.8.0",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-crds/1.8.0"
+        }
+    },
+}
+
+
+def find_newest_versions(versions):
+    """
+    Finds the newest version with the highest X value for a given Y version
+
+    Parameters:
+        versions (list): A list of version objects
+        Example: [('linkerd2/linkerd2', '2.11.5', 'stable-2.11.5'), ('linkerd2/linkerd2', '2.11.4', 'stable-2.11.4')
+
+    Returns:
+        list: A list of version objects
+        Example: [('linkerd2/linkerd2', '2.11.5', 'stable-2.11.5'),
+          ('linkerd2/linkerd2', '2.10.2', 'stable-2.10.2'),
+          ('linkerd2/linkerd2', '30.12.1', 'stable-2.14.3'),
+          ('linkerd2/linkerd2', '30.8.5', 'stable-2.13.7'),
+          ('linkerd2/linkerd2', '30.3.8', 'stable-2.12.6'),
+          ('linkerd2/linkerd2', '2.11.5', 'stable-2.11.5'),
+          ('linkerd2/linkerd2', '2.10.2', 'stable-2.10.2')]
+
+    """
+    winners = {}
+    for entry in versions:
+        _, _, version, _ = entry
+        try:
+            x, y, z = map(int, version.split("-")[1].split("."))
+            if not y in ignored_y_versions:
+                current_winner = winners.get(
+                    f"{x}.{y}.Z", {"x": x, "y": y, "z": z, version: version}
+                )
+                if current_winner["y"] == y and z >= current_winner["z"]:
+                    # new winner
+                    winners[f"{x}.{y}.Z"] = {"x": x, "y": y, "z": z, "version": version}
+
+        except IndexError:
+            next
+        except UnboundLocalError:
+            next
+
+    latest_versions = [v["version"] for v in winners.values()]
+    common_versions = []
+
+    for version in versions:
+        if version[2] in latest_versions:
+            common_versions.append(version)
+
+    return common_versions
+
+
+def combine_charts_by_app_version(versions):
+    """
+    Gathers all charts tuples under a single app version
+
+    Parameters:
+        versions (list): Raw list of versions tuples
+        [('linkerd2/linkerd-control-plane', '1.12.7', 'stable-2.13.7'),
+          ('linkerd2/linkerd-control-plane', '1.16.4', 'stable-2.14.3'),
+            ('linkerd2/linkerd-control-plane', '1.9.8', 'stable-2.12.6')]
+
+    Returns:
+        dict: versions object after combing under an app version.
+        {'stable-2.13.7': 
+          {'linkerd2-crds': 
+            {'chart_name': 'linkerd2/linkerd2-crds', 'chart_version': '1.6.1'}, 
+            'linkerd-jaeger': {
+                'chart_name': 'linkerd2/linkerd-jaeger', 'chart_version': '30.8.7'}
+            }
+        }
+
+    """
+    combined_charts = {}
+    for chart, version, app_version, link in versions:
+        name = chart # chart.split("/")[1]
+       
+        if not app_version:
+            app_version = version
+        if not combined_charts.get(app_version):
+            combined_charts[app_version] = {}
+
+        combined_charts[app_version][name] = {
+            "chart_name": chart,
+            "chart_version": version,
+            "chart_url": link
+        }
+        # merge in the crds chart info if it exist for the version
+        x, y, z = map(int, app_version.split("-")[1].split("."))
+        try:
+            if y > 11 and x == 2:
+                combined_charts[app_version] = {**combined_charts[app_version], **crds_map[f"{x}.{y}"]}
+            elif x == 2:
+                combined_charts[app_version] = {**combined_charts[app_version], **linkerd2_map[f"{x}.{y}"]}
+        except KeyError as e:
+            print(e)
+    
+    # sorted(combined_charts.items(), key=lambda x: x[0] != "stable-2.11.5")
+    return combined_charts
+
+def find_repo_name(release_type):
+    if release_type == "stable":
+        repo_name = "linkerd2"
+    elif release_type == "edge":
+        repo_name = "linkerd2-edge"
+    else:
+        repo_name = "linkerd2"
+    
+    return repo_name
+
+def add_repo(release_type, helm_url, repo_name):
+    command = ["helm", "repo", "add", repo_name, f"{helm_url}/{release_type}"]
+
+    try:
+        process = subprocess.Popen(
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        )
+        stdout, stderr = process.communicate()
+
+    except OSError as e:
+        print(f"Error: {e}")
+    
+    return repo_name
+
+
+def update_repo(release_type, helm_url, repo_name):
+    add_repo(release_type, helm_url, repo_name)
+
+    command = ["helm", "repo", "update", repo_name]
+
+    try:
+        process = subprocess.Popen(
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        )
+        stdout, stderr = process.communicate()
+
+    except OSError as e:
+        print(f"Error: {e}")
+
+    return repo_name
+
+def list_chart_versions(charts, repo_name, latest_only=True):
+    """
+    Fetches all the linkerd charts 
+
+    Parameters:
+    charts (list): A list of chart names to fetch
+
+    Returns:
+        dict: A list of chart version tuples
+        Example: {('linkerd2/linkerd2', '2.11.5', 'stable-2.11.5')}
+      
+    """
+    all_versions = set()
+   
+
+    for chart in charts:
+        # helm repo update linkerd2
+        search_term = f"{repo_name}/{chart}"
+        command = ["helm", "search", "repo", search_term, "--versions", "--output", "json"]
+        try:
+            process = subprocess.Popen(
+                command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+            )
+            stdout, stderr = process.communicate()
+            
+            if process.returncode == 0:
+                chart_data = json.loads(stdout)
+                versions = [
+                    (chart, item["version"], item["app_version"], f"https://artifacthub.io/packages/helm/{repo_name}/{chart}/{item['version']}") for item in chart_data
+                ]
+                if latest_only:
+                    latest_versions = find_newest_versions(versions)
+                else:
+                    latest_versions = versions
+
+                all_versions.update(latest_versions)
+            else:
+                print(f"Error: Failed to list chart versions for {chart}")
+                print(stderr)
+        except OSError as e:
+            print(f"Error: {e}")
+    
+    return sorted(all_versions)
+
+
+def print_output(data, format):
+    if format == "json":
+        print(json.dumps(data, indent=4))
+    elif format == "yaml":
+        print(yaml.dump(data, indent=4))
+    else:
+        try:
+            from tabulate import tabulate
+        except ImportError as e:
+            print("Please install tabulate: pip3 install tabulate")
+            exit(1)
+        headers = ["App Version", "Chart Name", "Chart Version"]
+        table = []
+        for app_version, charts in sorted(
+            data.items(), reverse=True
+        ):
+            for chart_name, chart_data in charts.items():
+                table.append(
+                    [app_version, chart_data["chart_name"], chart_data["chart_version"]]
+                )
+            print(tabulate(table, headers=headers, tablefmt="github"))
+            print("\n")
+            table = []
+
+
+parser = argparse.ArgumentParser(description="List linkerd chart versions in various formats")
+parser.add_argument(
+    "--format", default="table", choices=["table", "json", "yaml"], help="Desired Output format, defaults to table"
+)
+parser.add_argument('--release_type', choices=["stable", "edge"], default="stable", help="Use the specific release type, defaults to stable")
+parser.add_argument('--helm_url', choices=["https://helm.linkerd.io"], default="https://helm.linkerd.io", help="The helm url to use" )
+args = parser.parse_args()
+
+repo_name = find_repo_name(args.release_type)
+update_repo(args.release_type, args.helm_url, repo_name)
+
+all_versions = list_chart_versions(charts, repo_name)
+combined_charts_by_app_version = combine_charts_by_app_version(all_versions)
+print_output(combined_charts_by_app_version, args.format)

--- a/linkerd.io/content/releases/_index.md
+++ b/linkerd.io/content/releases/_index.md
@@ -36,16 +36,17 @@ bugfixes or enhancements.
 Commercial providers of Linkerd (e.g. [Buoyant](https://buoyant.io)) may
 provide stronger support guarantees.
 
-### Helm Version Matrix
-The following version matrices include only the latest versions of the stable releases along with corresponding app and helm versions for linkerd and extensions.  Use these to guide you to the right helm chart version or to automate workflows you might have.
+## Helm Version Matrix
+
+The following version matrices include only the latest versions of the stable
+releases along with corresponding app and helm versions for linkerd and
+extensions.  Use these to guide you to the right helm chart version or to
+automate workflows you might have.
 
 * [YAML matrix](./release_matrix.yaml)
 * [JSON matrix](./release_matrix.json)
 
 {{< release-data-table />}}
-
-
-
 
 ## Edge (latest version: {{% latestedge %}})
 

--- a/linkerd.io/content/releases/_index.md
+++ b/linkerd.io/content/releases/_index.md
@@ -36,6 +36,17 @@ bugfixes or enhancements.
 Commercial providers of Linkerd (e.g. [Buoyant](https://buoyant.io)) may
 provide stronger support guarantees.
 
+### Helm Version Matrix
+The following version matrices include only the latest versions of the stable releases along with corresponding app and helm versions for linkerd and extensions.  Use these to guide you to the right helm chart version or to automate workflows you might have.
+
+* [YAML matrix](./release_matrix.yaml)
+* [JSON matrix](./release_matrix.json)
+
+{{< release-data-table />}}
+
+
+
+
 ## Edge (latest version: {{% latestedge %}})
 
 Edge releases are frequent (usually, weekly) and can be used to work with the

--- a/linkerd.io/content/releases/release_matrix.json
+++ b/linkerd.io/content/releases/release_matrix.json
@@ -31,11 +31,11 @@
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/30.8.5"
         }
     },
-    "stable-2.14.5": {
+    "stable-2.14.7": {
         "linkerd-control-plane": {
             "chart_name": "linkerd-control-plane",
-            "chart_version": "1.16.6",
-            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.16.6"
+            "chart_version": "1.16.8",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.16.8"
         },
         "linkerd-crds": {
             "chart_name": "linkerd-crds",
@@ -44,18 +44,18 @@
         },
         "linkerd-jaeger": {
             "chart_name": "linkerd-jaeger",
-            "chart_version": "30.12.6",
-            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.12.6"
+            "chart_version": "30.12.8",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.12.8"
         },
         "linkerd-multicluster": {
             "chart_name": "linkerd-multicluster",
-            "chart_version": "30.11.6",
-            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.11.6"
+            "chart_version": "30.11.8",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.11.8"
         },
         "linkerd-viz": {
             "chart_name": "linkerd-viz",
-            "chart_version": "30.12.6",
-            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.12.6"
+            "chart_version": "30.12.8",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.12.8"
         },
         "linkerd2-cni": {
             "chart_name": "linkerd2-cni",

--- a/linkerd.io/content/releases/release_matrix.json
+++ b/linkerd.io/content/releases/release_matrix.json
@@ -1,150 +1,150 @@
 {
     "stable-2.13.7": {
         "linkerd-control-plane": {
-            "chart_name": "linkerd2/linkerd-control-plane",
+            "chart_name": "linkerd-control-plane",
             "chart_version": "1.12.7",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.12.7"
         },
-        "linkerd2-crds": {
-            "chart_name": "linkerd2/linkerd2-crds",
+        "linkerd-crds": {
+            "chart_name": "linkerd-crds",
             "chart_version": "1.6.1",
-            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-crds/1.6.1"
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-crds/1.6.1"
         },
         "linkerd-jaeger": {
-            "chart_name": "linkerd2/linkerd-jaeger",
+            "chart_name": "linkerd-jaeger",
             "chart_version": "30.8.7",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.8.7"
         },
         "linkerd-multicluster": {
-            "chart_name": "linkerd2/linkerd-multicluster",
+            "chart_name": "linkerd-multicluster",
             "chart_version": "30.7.7",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.7.7"
         },
         "linkerd-viz": {
-            "chart_name": "linkerd2/linkerd-viz",
+            "chart_name": "linkerd-viz",
             "chart_version": "30.8.7",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.8.7"
         },
         "linkerd2-cni": {
-            "chart_name": "linkerd2/linkerd2-cni",
+            "chart_name": "linkerd2-cni",
             "chart_version": "30.8.5",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/30.8.5"
         }
     },
     "stable-2.14.5": {
         "linkerd-control-plane": {
-            "chart_name": "linkerd2/linkerd-control-plane",
+            "chart_name": "linkerd-control-plane",
             "chart_version": "1.16.6",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.16.6"
         },
-        "linkerd2-crds": {
-            "chart_name": "linkerd2/linkerd2-crds",
+        "linkerd-crds": {
+            "chart_name": "linkerd-crds",
             "chart_version": "1.8.0",
-            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-crds/1.8.0"
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-crds/1.8.0"
         },
         "linkerd-jaeger": {
-            "chart_name": "linkerd2/linkerd-jaeger",
+            "chart_name": "linkerd-jaeger",
             "chart_version": "30.12.6",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.12.6"
         },
         "linkerd-multicluster": {
-            "chart_name": "linkerd2/linkerd-multicluster",
+            "chart_name": "linkerd-multicluster",
             "chart_version": "30.11.6",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.11.6"
         },
         "linkerd-viz": {
-            "chart_name": "linkerd2/linkerd-viz",
+            "chart_name": "linkerd-viz",
             "chart_version": "30.12.6",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.12.6"
         },
         "linkerd2-cni": {
-            "chart_name": "linkerd2/linkerd2-cni",
+            "chart_name": "linkerd2-cni",
             "chart_version": "30.12.1",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/30.12.1"
         }
     },
     "stable-2.12.6": {
         "linkerd-control-plane": {
-            "chart_name": "linkerd2/linkerd-control-plane",
+            "chart_name": "linkerd-control-plane",
             "chart_version": "1.9.8",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.9.8"
         },
-        "linkerd2-crds": {
-            "chart_name": "linkerd2/linkerd2-crds",
+        "linkerd-crds": {
+            "chart_name": "linkerd-crds",
             "chart_version": "1.6.1",
-            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-crds/1.6.1"
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-crds/1.6.1"
         },
         "linkerd-jaeger": {
-            "chart_name": "linkerd2/linkerd-jaeger",
+            "chart_name": "linkerd-jaeger",
             "chart_version": "30.4.8",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.4.8"
         },
         "linkerd-multicluster": {
-            "chart_name": "linkerd2/linkerd-multicluster",
+            "chart_name": "linkerd-multicluster",
             "chart_version": "30.2.8",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.2.8"
         },
         "linkerd-viz": {
-            "chart_name": "linkerd2/linkerd-viz",
+            "chart_name": "linkerd-viz",
             "chart_version": "30.3.8",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.3.8"
         },
         "linkerd2-cni": {
-            "chart_name": "linkerd2/linkerd2-cni",
+            "chart_name": "linkerd2-cni",
             "chart_version": "30.3.8",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/30.3.8"
         }
     },
     "stable-2.10.2": {
         "linkerd-jaeger": {
-            "chart_name": "linkerd2/linkerd-jaeger",
+            "chart_name": "linkerd-jaeger",
             "chart_version": "2.10.2",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/2.10.2"
         },
         "linkerd2": {
-            "chart_name": "linkerd2/linkerd2",
+            "chart_name": "linkerd2",
             "chart_version": "2.10.2",
-            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2/2.10"
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2/2.10.2"
         },
         "linkerd-multicluster": {
-            "chart_name": "linkerd2/linkerd-multicluster",
+            "chart_name": "linkerd-multicluster",
             "chart_version": "2.10.2",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/2.10.2"
         },
         "linkerd-viz": {
-            "chart_name": "linkerd2/linkerd-viz",
+            "chart_name": "linkerd-viz",
             "chart_version": "2.10.2",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/2.10.2"
         },
         "linkerd2-cni": {
-            "chart_name": "linkerd2/linkerd2-cni",
+            "chart_name": "linkerd2-cni",
             "chart_version": "2.10.2",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/2.10.2"
         }
     },
     "stable-2.11.5": {
         "linkerd-jaeger": {
-            "chart_name": "linkerd2/linkerd-jaeger",
+            "chart_name": "linkerd-jaeger",
             "chart_version": "2.11.5",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/2.11.5"
         },
         "linkerd2": {
-            "chart_name": "linkerd2/linkerd2",
+            "chart_name": "linkerd2",
             "chart_version": "2.11.5",
-            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2/2.11"
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2/2.11.5"
         },
         "linkerd-multicluster": {
-            "chart_name": "linkerd2/linkerd-multicluster",
+            "chart_name": "linkerd-multicluster",
             "chart_version": "2.11.5",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/2.11.5"
         },
         "linkerd-viz": {
-            "chart_name": "linkerd2/linkerd-viz",
+            "chart_name": "linkerd-viz",
             "chart_version": "2.11.5",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/2.11.5"
         },
         "linkerd2-cni": {
-            "chart_name": "linkerd2/linkerd2-cni",
+            "chart_name": "linkerd2-cni",
             "chart_version": "2.11.5",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/2.11.5"
         }

--- a/linkerd.io/content/releases/release_matrix.json
+++ b/linkerd.io/content/releases/release_matrix.json
@@ -1,0 +1,152 @@
+{
+    "stable-2.13.7": {
+        "linkerd-control-plane": {
+            "chart_name": "linkerd2/linkerd-control-plane",
+            "chart_version": "1.12.7",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.12.7"
+        },
+        "linkerd2-crds": {
+            "chart_name": "linkerd2/linkerd2-crds",
+            "chart_version": "1.6.1",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-crds/1.6.1"
+        },
+        "linkerd-jaeger": {
+            "chart_name": "linkerd2/linkerd-jaeger",
+            "chart_version": "30.8.7",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.8.7"
+        },
+        "linkerd-multicluster": {
+            "chart_name": "linkerd2/linkerd-multicluster",
+            "chart_version": "30.7.7",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.7.7"
+        },
+        "linkerd-viz": {
+            "chart_name": "linkerd2/linkerd-viz",
+            "chart_version": "30.8.7",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.8.7"
+        },
+        "linkerd2-cni": {
+            "chart_name": "linkerd2/linkerd2-cni",
+            "chart_version": "30.8.5",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/30.8.5"
+        }
+    },
+    "stable-2.14.5": {
+        "linkerd-control-plane": {
+            "chart_name": "linkerd2/linkerd-control-plane",
+            "chart_version": "1.16.6",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.16.6"
+        },
+        "linkerd2-crds": {
+            "chart_name": "linkerd2/linkerd2-crds",
+            "chart_version": "1.8.0",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-crds/1.8.0"
+        },
+        "linkerd-jaeger": {
+            "chart_name": "linkerd2/linkerd-jaeger",
+            "chart_version": "30.12.6",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.12.6"
+        },
+        "linkerd-multicluster": {
+            "chart_name": "linkerd2/linkerd-multicluster",
+            "chart_version": "30.11.6",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.11.6"
+        },
+        "linkerd-viz": {
+            "chart_name": "linkerd2/linkerd-viz",
+            "chart_version": "30.12.6",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.12.6"
+        },
+        "linkerd2-cni": {
+            "chart_name": "linkerd2/linkerd2-cni",
+            "chart_version": "30.12.1",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/30.12.1"
+        }
+    },
+    "stable-2.12.6": {
+        "linkerd-control-plane": {
+            "chart_name": "linkerd2/linkerd-control-plane",
+            "chart_version": "1.9.8",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.9.8"
+        },
+        "linkerd2-crds": {
+            "chart_name": "linkerd2/linkerd2-crds",
+            "chart_version": "1.6.1",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-crds/1.6.1"
+        },
+        "linkerd-jaeger": {
+            "chart_name": "linkerd2/linkerd-jaeger",
+            "chart_version": "30.4.8",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.4.8"
+        },
+        "linkerd-multicluster": {
+            "chart_name": "linkerd2/linkerd-multicluster",
+            "chart_version": "30.2.8",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.2.8"
+        },
+        "linkerd-viz": {
+            "chart_name": "linkerd2/linkerd-viz",
+            "chart_version": "30.3.8",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.3.8"
+        },
+        "linkerd2-cni": {
+            "chart_name": "linkerd2/linkerd2-cni",
+            "chart_version": "30.3.8",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/30.3.8"
+        }
+    },
+    "stable-2.10.2": {
+        "linkerd-jaeger": {
+            "chart_name": "linkerd2/linkerd-jaeger",
+            "chart_version": "2.10.2",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/2.10.2"
+        },
+        "linkerd2": {
+            "chart_name": "linkerd2/linkerd2",
+            "chart_version": "2.10.2",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2/2.10"
+        },
+        "linkerd-multicluster": {
+            "chart_name": "linkerd2/linkerd-multicluster",
+            "chart_version": "2.10.2",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/2.10.2"
+        },
+        "linkerd-viz": {
+            "chart_name": "linkerd2/linkerd-viz",
+            "chart_version": "2.10.2",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/2.10.2"
+        },
+        "linkerd2-cni": {
+            "chart_name": "linkerd2/linkerd2-cni",
+            "chart_version": "2.10.2",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/2.10.2"
+        }
+    },
+    "stable-2.11.5": {
+        "linkerd-jaeger": {
+            "chart_name": "linkerd2/linkerd-jaeger",
+            "chart_version": "2.11.5",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/2.11.5"
+        },
+        "linkerd2": {
+            "chart_name": "linkerd2/linkerd2",
+            "chart_version": "2.11.5",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2/2.11"
+        },
+        "linkerd-multicluster": {
+            "chart_name": "linkerd2/linkerd-multicluster",
+            "chart_version": "2.11.5",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/2.11.5"
+        },
+        "linkerd-viz": {
+            "chart_name": "linkerd2/linkerd-viz",
+            "chart_version": "2.11.5",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/2.11.5"
+        },
+        "linkerd2-cni": {
+            "chart_name": "linkerd2/linkerd2-cni",
+            "chart_version": "2.11.5",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/2.11.5"
+        }
+    }
+}

--- a/linkerd.io/content/releases/release_matrix.yaml
+++ b/linkerd.io/content/releases/release_matrix.yaml
@@ -1,118 +1,118 @@
 stable-2.10.2:
     linkerd-jaeger:
-        chart_name: linkerd2/linkerd-jaeger
+        chart_name: linkerd-jaeger
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/2.10.2
         chart_version: 2.10.2
     linkerd-multicluster:
-        chart_name: linkerd2/linkerd-multicluster
+        chart_name: linkerd-multicluster
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/2.10.2
         chart_version: 2.10.2
     linkerd-viz:
-        chart_name: linkerd2/linkerd-viz
+        chart_name: linkerd-viz
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/2.10.2
         chart_version: 2.10.2
     linkerd2:
-        chart_name: linkerd2/linkerd2
-        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2/2.10
+        chart_name: linkerd2
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2/2.10.2
         chart_version: 2.10.2
     linkerd2-cni:
-        chart_name: linkerd2/linkerd2-cni
+        chart_name: linkerd2-cni
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/2.10.2
         chart_version: 2.10.2
 stable-2.11.5:
     linkerd-jaeger:
-        chart_name: linkerd2/linkerd-jaeger
+        chart_name: linkerd-jaeger
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/2.11.5
         chart_version: 2.11.5
     linkerd-multicluster:
-        chart_name: linkerd2/linkerd-multicluster
+        chart_name: linkerd-multicluster
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/2.11.5
         chart_version: 2.11.5
     linkerd-viz:
-        chart_name: linkerd2/linkerd-viz
+        chart_name: linkerd-viz
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/2.11.5
         chart_version: 2.11.5
     linkerd2:
-        chart_name: linkerd2/linkerd2
-        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2/2.11
+        chart_name: linkerd2
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2/2.11.5
         chart_version: 2.11.5
     linkerd2-cni:
-        chart_name: linkerd2/linkerd2-cni
+        chart_name: linkerd2-cni
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/2.11.5
         chart_version: 2.11.5
 stable-2.12.6:
     linkerd-control-plane:
-        chart_name: linkerd2/linkerd-control-plane
+        chart_name: linkerd-control-plane
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.9.8
         chart_version: 1.9.8
+    linkerd-crds:
+        chart_name: linkerd-crds
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-crds/1.6.1
+        chart_version: 1.6.1
     linkerd-jaeger:
-        chart_name: linkerd2/linkerd-jaeger
+        chart_name: linkerd-jaeger
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.4.8
         chart_version: 30.4.8
     linkerd-multicluster:
-        chart_name: linkerd2/linkerd-multicluster
+        chart_name: linkerd-multicluster
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.2.8
         chart_version: 30.2.8
     linkerd-viz:
-        chart_name: linkerd2/linkerd-viz
+        chart_name: linkerd-viz
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.3.8
         chart_version: 30.3.8
     linkerd2-cni:
-        chart_name: linkerd2/linkerd2-cni
+        chart_name: linkerd2-cni
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/30.3.8
         chart_version: 30.3.8
-    linkerd2-crds:
-        chart_name: linkerd2/linkerd2-crds
-        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2-crds/1.6.1
-        chart_version: 1.6.1
 stable-2.13.7:
     linkerd-control-plane:
-        chart_name: linkerd2/linkerd-control-plane
+        chart_name: linkerd-control-plane
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.12.7
         chart_version: 1.12.7
+    linkerd-crds:
+        chart_name: linkerd-crds
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-crds/1.6.1
+        chart_version: 1.6.1
     linkerd-jaeger:
-        chart_name: linkerd2/linkerd-jaeger
+        chart_name: linkerd-jaeger
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.8.7
         chart_version: 30.8.7
     linkerd-multicluster:
-        chart_name: linkerd2/linkerd-multicluster
+        chart_name: linkerd-multicluster
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.7.7
         chart_version: 30.7.7
     linkerd-viz:
-        chart_name: linkerd2/linkerd-viz
+        chart_name: linkerd-viz
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.8.7
         chart_version: 30.8.7
     linkerd2-cni:
-        chart_name: linkerd2/linkerd2-cni
+        chart_name: linkerd2-cni
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/30.8.5
         chart_version: 30.8.5
-    linkerd2-crds:
-        chart_name: linkerd2/linkerd2-crds
-        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2-crds/1.6.1
-        chart_version: 1.6.1
 stable-2.14.5:
     linkerd-control-plane:
-        chart_name: linkerd2/linkerd-control-plane
+        chart_name: linkerd-control-plane
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.16.6
         chart_version: 1.16.6
+    linkerd-crds:
+        chart_name: linkerd-crds
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-crds/1.8.0
+        chart_version: 1.8.0
     linkerd-jaeger:
-        chart_name: linkerd2/linkerd-jaeger
+        chart_name: linkerd-jaeger
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.12.6
         chart_version: 30.12.6
     linkerd-multicluster:
-        chart_name: linkerd2/linkerd-multicluster
+        chart_name: linkerd-multicluster
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.11.6
         chart_version: 30.11.6
     linkerd-viz:
-        chart_name: linkerd2/linkerd-viz
+        chart_name: linkerd-viz
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.12.6
         chart_version: 30.12.6
     linkerd2-cni:
-        chart_name: linkerd2/linkerd2-cni
+        chart_name: linkerd2-cni
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/30.12.1
         chart_version: 30.12.1
-    linkerd2-crds:
-        chart_name: linkerd2/linkerd2-crds
-        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2-crds/1.8.0
-        chart_version: 1.8.0
 

--- a/linkerd.io/content/releases/release_matrix.yaml
+++ b/linkerd.io/content/releases/release_matrix.yaml
@@ -90,27 +90,27 @@ stable-2.13.7:
         chart_name: linkerd2-cni
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/30.8.5
         chart_version: 30.8.5
-stable-2.14.5:
+stable-2.14.7:
     linkerd-control-plane:
         chart_name: linkerd-control-plane
-        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.16.6
-        chart_version: 1.16.6
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.16.8
+        chart_version: 1.16.8
     linkerd-crds:
         chart_name: linkerd-crds
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-crds/1.8.0
         chart_version: 1.8.0
     linkerd-jaeger:
         chart_name: linkerd-jaeger
-        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.12.6
-        chart_version: 30.12.6
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.12.8
+        chart_version: 30.12.8
     linkerd-multicluster:
         chart_name: linkerd-multicluster
-        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.11.6
-        chart_version: 30.11.6
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.11.8
+        chart_version: 30.11.8
     linkerd-viz:
         chart_name: linkerd-viz
-        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.12.6
-        chart_version: 30.12.6
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.12.8
+        chart_version: 30.12.8
     linkerd2-cni:
         chart_name: linkerd2-cni
         chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/30.12.1

--- a/linkerd.io/content/releases/release_matrix.yaml
+++ b/linkerd.io/content/releases/release_matrix.yaml
@@ -1,0 +1,118 @@
+stable-2.10.2:
+    linkerd-jaeger:
+        chart_name: linkerd2/linkerd-jaeger
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/2.10.2
+        chart_version: 2.10.2
+    linkerd-multicluster:
+        chart_name: linkerd2/linkerd-multicluster
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/2.10.2
+        chart_version: 2.10.2
+    linkerd-viz:
+        chart_name: linkerd2/linkerd-viz
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/2.10.2
+        chart_version: 2.10.2
+    linkerd2:
+        chart_name: linkerd2/linkerd2
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2/2.10
+        chart_version: 2.10.2
+    linkerd2-cni:
+        chart_name: linkerd2/linkerd2-cni
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/2.10.2
+        chart_version: 2.10.2
+stable-2.11.5:
+    linkerd-jaeger:
+        chart_name: linkerd2/linkerd-jaeger
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/2.11.5
+        chart_version: 2.11.5
+    linkerd-multicluster:
+        chart_name: linkerd2/linkerd-multicluster
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/2.11.5
+        chart_version: 2.11.5
+    linkerd-viz:
+        chart_name: linkerd2/linkerd-viz
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/2.11.5
+        chart_version: 2.11.5
+    linkerd2:
+        chart_name: linkerd2/linkerd2
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2/2.11
+        chart_version: 2.11.5
+    linkerd2-cni:
+        chart_name: linkerd2/linkerd2-cni
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/2.11.5
+        chart_version: 2.11.5
+stable-2.12.6:
+    linkerd-control-plane:
+        chart_name: linkerd2/linkerd-control-plane
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.9.8
+        chart_version: 1.9.8
+    linkerd-jaeger:
+        chart_name: linkerd2/linkerd-jaeger
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.4.8
+        chart_version: 30.4.8
+    linkerd-multicluster:
+        chart_name: linkerd2/linkerd-multicluster
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.2.8
+        chart_version: 30.2.8
+    linkerd-viz:
+        chart_name: linkerd2/linkerd-viz
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.3.8
+        chart_version: 30.3.8
+    linkerd2-cni:
+        chart_name: linkerd2/linkerd2-cni
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/30.3.8
+        chart_version: 30.3.8
+    linkerd2-crds:
+        chart_name: linkerd2/linkerd2-crds
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2-crds/1.6.1
+        chart_version: 1.6.1
+stable-2.13.7:
+    linkerd-control-plane:
+        chart_name: linkerd2/linkerd-control-plane
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.12.7
+        chart_version: 1.12.7
+    linkerd-jaeger:
+        chart_name: linkerd2/linkerd-jaeger
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.8.7
+        chart_version: 30.8.7
+    linkerd-multicluster:
+        chart_name: linkerd2/linkerd-multicluster
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.7.7
+        chart_version: 30.7.7
+    linkerd-viz:
+        chart_name: linkerd2/linkerd-viz
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.8.7
+        chart_version: 30.8.7
+    linkerd2-cni:
+        chart_name: linkerd2/linkerd2-cni
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/30.8.5
+        chart_version: 30.8.5
+    linkerd2-crds:
+        chart_name: linkerd2/linkerd2-crds
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2-crds/1.6.1
+        chart_version: 1.6.1
+stable-2.14.5:
+    linkerd-control-plane:
+        chart_name: linkerd2/linkerd-control-plane
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.16.6
+        chart_version: 1.16.6
+    linkerd-jaeger:
+        chart_name: linkerd2/linkerd-jaeger
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.12.6
+        chart_version: 30.12.6
+    linkerd-multicluster:
+        chart_name: linkerd2/linkerd-multicluster
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.11.6
+        chart_version: 30.11.6
+    linkerd-viz:
+        chart_name: linkerd2/linkerd-viz
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.12.6
+        chart_version: 30.12.6
+    linkerd2-cni:
+        chart_name: linkerd2/linkerd2-cni
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/30.12.1
+        chart_version: 30.12.1
+    linkerd2-crds:
+        chart_name: linkerd2/linkerd2-crds
+        chart_url: https://artifacthub.io/packages/helm/linkerd2/linkerd2-crds/1.8.0
+        chart_version: 1.8.0
+

--- a/linkerd.io/data/releases/release_matrix.json
+++ b/linkerd.io/data/releases/release_matrix.json
@@ -31,11 +31,11 @@
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/30.8.5"
         }
     },
-    "stable-2.14.5": {
+    "stable-2.14.7": {
         "linkerd-control-plane": {
             "chart_name": "linkerd-control-plane",
-            "chart_version": "1.16.6",
-            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.16.6"
+            "chart_version": "1.16.8",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.16.8"
         },
         "linkerd-crds": {
             "chart_name": "linkerd-crds",
@@ -44,18 +44,18 @@
         },
         "linkerd-jaeger": {
             "chart_name": "linkerd-jaeger",
-            "chart_version": "30.12.6",
-            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.12.6"
+            "chart_version": "30.12.8",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.12.8"
         },
         "linkerd-multicluster": {
             "chart_name": "linkerd-multicluster",
-            "chart_version": "30.11.6",
-            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.11.6"
+            "chart_version": "30.11.8",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.11.8"
         },
         "linkerd-viz": {
             "chart_name": "linkerd-viz",
-            "chart_version": "30.12.6",
-            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.12.6"
+            "chart_version": "30.12.8",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.12.8"
         },
         "linkerd2-cni": {
             "chart_name": "linkerd2-cni",

--- a/linkerd.io/data/releases/release_matrix.json
+++ b/linkerd.io/data/releases/release_matrix.json
@@ -1,150 +1,150 @@
 {
     "stable-2.13.7": {
         "linkerd-control-plane": {
-            "chart_name": "linkerd2/linkerd-control-plane",
+            "chart_name": "linkerd-control-plane",
             "chart_version": "1.12.7",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.12.7"
         },
-        "linkerd2-crds": {
-            "chart_name": "linkerd2/linkerd2-crds",
+        "linkerd-crds": {
+            "chart_name": "linkerd-crds",
             "chart_version": "1.6.1",
-            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-crds/1.6.1"
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-crds/1.6.1"
         },
         "linkerd-jaeger": {
-            "chart_name": "linkerd2/linkerd-jaeger",
+            "chart_name": "linkerd-jaeger",
             "chart_version": "30.8.7",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.8.7"
         },
         "linkerd-multicluster": {
-            "chart_name": "linkerd2/linkerd-multicluster",
+            "chart_name": "linkerd-multicluster",
             "chart_version": "30.7.7",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.7.7"
         },
         "linkerd-viz": {
-            "chart_name": "linkerd2/linkerd-viz",
+            "chart_name": "linkerd-viz",
             "chart_version": "30.8.7",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.8.7"
         },
         "linkerd2-cni": {
-            "chart_name": "linkerd2/linkerd2-cni",
+            "chart_name": "linkerd2-cni",
             "chart_version": "30.8.5",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/30.8.5"
         }
     },
     "stable-2.14.5": {
         "linkerd-control-plane": {
-            "chart_name": "linkerd2/linkerd-control-plane",
+            "chart_name": "linkerd-control-plane",
             "chart_version": "1.16.6",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.16.6"
         },
-        "linkerd2-crds": {
-            "chart_name": "linkerd2/linkerd2-crds",
+        "linkerd-crds": {
+            "chart_name": "linkerd-crds",
             "chart_version": "1.8.0",
-            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-crds/1.8.0"
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-crds/1.8.0"
         },
         "linkerd-jaeger": {
-            "chart_name": "linkerd2/linkerd-jaeger",
+            "chart_name": "linkerd-jaeger",
             "chart_version": "30.12.6",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.12.6"
         },
         "linkerd-multicluster": {
-            "chart_name": "linkerd2/linkerd-multicluster",
+            "chart_name": "linkerd-multicluster",
             "chart_version": "30.11.6",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.11.6"
         },
         "linkerd-viz": {
-            "chart_name": "linkerd2/linkerd-viz",
+            "chart_name": "linkerd-viz",
             "chart_version": "30.12.6",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.12.6"
         },
         "linkerd2-cni": {
-            "chart_name": "linkerd2/linkerd2-cni",
+            "chart_name": "linkerd2-cni",
             "chart_version": "30.12.1",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/30.12.1"
         }
     },
     "stable-2.12.6": {
         "linkerd-control-plane": {
-            "chart_name": "linkerd2/linkerd-control-plane",
+            "chart_name": "linkerd-control-plane",
             "chart_version": "1.9.8",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.9.8"
         },
-        "linkerd2-crds": {
-            "chart_name": "linkerd2/linkerd2-crds",
+        "linkerd-crds": {
+            "chart_name": "linkerd-crds",
             "chart_version": "1.6.1",
-            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-crds/1.6.1"
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-crds/1.6.1"
         },
         "linkerd-jaeger": {
-            "chart_name": "linkerd2/linkerd-jaeger",
+            "chart_name": "linkerd-jaeger",
             "chart_version": "30.4.8",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.4.8"
         },
         "linkerd-multicluster": {
-            "chart_name": "linkerd2/linkerd-multicluster",
+            "chart_name": "linkerd-multicluster",
             "chart_version": "30.2.8",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.2.8"
         },
         "linkerd-viz": {
-            "chart_name": "linkerd2/linkerd-viz",
+            "chart_name": "linkerd-viz",
             "chart_version": "30.3.8",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.3.8"
         },
         "linkerd2-cni": {
-            "chart_name": "linkerd2/linkerd2-cni",
+            "chart_name": "linkerd2-cni",
             "chart_version": "30.3.8",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/30.3.8"
         }
     },
     "stable-2.10.2": {
         "linkerd-jaeger": {
-            "chart_name": "linkerd2/linkerd-jaeger",
+            "chart_name": "linkerd-jaeger",
             "chart_version": "2.10.2",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/2.10.2"
         },
         "linkerd2": {
-            "chart_name": "linkerd2/linkerd2",
+            "chart_name": "linkerd2",
             "chart_version": "2.10.2",
-            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2/2.10"
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2/2.10.2"
         },
         "linkerd-multicluster": {
-            "chart_name": "linkerd2/linkerd-multicluster",
+            "chart_name": "linkerd-multicluster",
             "chart_version": "2.10.2",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/2.10.2"
         },
         "linkerd-viz": {
-            "chart_name": "linkerd2/linkerd-viz",
+            "chart_name": "linkerd-viz",
             "chart_version": "2.10.2",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/2.10.2"
         },
         "linkerd2-cni": {
-            "chart_name": "linkerd2/linkerd2-cni",
+            "chart_name": "linkerd2-cni",
             "chart_version": "2.10.2",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/2.10.2"
         }
     },
     "stable-2.11.5": {
         "linkerd-jaeger": {
-            "chart_name": "linkerd2/linkerd-jaeger",
+            "chart_name": "linkerd-jaeger",
             "chart_version": "2.11.5",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/2.11.5"
         },
         "linkerd2": {
-            "chart_name": "linkerd2/linkerd2",
+            "chart_name": "linkerd2",
             "chart_version": "2.11.5",
-            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2/2.11"
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2/2.11.5"
         },
         "linkerd-multicluster": {
-            "chart_name": "linkerd2/linkerd-multicluster",
+            "chart_name": "linkerd-multicluster",
             "chart_version": "2.11.5",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/2.11.5"
         },
         "linkerd-viz": {
-            "chart_name": "linkerd2/linkerd-viz",
+            "chart_name": "linkerd-viz",
             "chart_version": "2.11.5",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/2.11.5"
         },
         "linkerd2-cni": {
-            "chart_name": "linkerd2/linkerd2-cni",
+            "chart_name": "linkerd2-cni",
             "chart_version": "2.11.5",
             "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/2.11.5"
         }

--- a/linkerd.io/data/releases/release_matrix.json
+++ b/linkerd.io/data/releases/release_matrix.json
@@ -1,0 +1,152 @@
+{
+    "stable-2.13.7": {
+        "linkerd-control-plane": {
+            "chart_name": "linkerd2/linkerd-control-plane",
+            "chart_version": "1.12.7",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.12.7"
+        },
+        "linkerd2-crds": {
+            "chart_name": "linkerd2/linkerd2-crds",
+            "chart_version": "1.6.1",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-crds/1.6.1"
+        },
+        "linkerd-jaeger": {
+            "chart_name": "linkerd2/linkerd-jaeger",
+            "chart_version": "30.8.7",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.8.7"
+        },
+        "linkerd-multicluster": {
+            "chart_name": "linkerd2/linkerd-multicluster",
+            "chart_version": "30.7.7",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.7.7"
+        },
+        "linkerd-viz": {
+            "chart_name": "linkerd2/linkerd-viz",
+            "chart_version": "30.8.7",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.8.7"
+        },
+        "linkerd2-cni": {
+            "chart_name": "linkerd2/linkerd2-cni",
+            "chart_version": "30.8.5",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/30.8.5"
+        }
+    },
+    "stable-2.14.5": {
+        "linkerd-control-plane": {
+            "chart_name": "linkerd2/linkerd-control-plane",
+            "chart_version": "1.16.6",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.16.6"
+        },
+        "linkerd2-crds": {
+            "chart_name": "linkerd2/linkerd2-crds",
+            "chart_version": "1.8.0",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-crds/1.8.0"
+        },
+        "linkerd-jaeger": {
+            "chart_name": "linkerd2/linkerd-jaeger",
+            "chart_version": "30.12.6",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.12.6"
+        },
+        "linkerd-multicluster": {
+            "chart_name": "linkerd2/linkerd-multicluster",
+            "chart_version": "30.11.6",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.11.6"
+        },
+        "linkerd-viz": {
+            "chart_name": "linkerd2/linkerd-viz",
+            "chart_version": "30.12.6",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.12.6"
+        },
+        "linkerd2-cni": {
+            "chart_name": "linkerd2/linkerd2-cni",
+            "chart_version": "30.12.1",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/30.12.1"
+        }
+    },
+    "stable-2.12.6": {
+        "linkerd-control-plane": {
+            "chart_name": "linkerd2/linkerd-control-plane",
+            "chart_version": "1.9.8",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-control-plane/1.9.8"
+        },
+        "linkerd2-crds": {
+            "chart_name": "linkerd2/linkerd2-crds",
+            "chart_version": "1.6.1",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-crds/1.6.1"
+        },
+        "linkerd-jaeger": {
+            "chart_name": "linkerd2/linkerd-jaeger",
+            "chart_version": "30.4.8",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/30.4.8"
+        },
+        "linkerd-multicluster": {
+            "chart_name": "linkerd2/linkerd-multicluster",
+            "chart_version": "30.2.8",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/30.2.8"
+        },
+        "linkerd-viz": {
+            "chart_name": "linkerd2/linkerd-viz",
+            "chart_version": "30.3.8",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/30.3.8"
+        },
+        "linkerd2-cni": {
+            "chart_name": "linkerd2/linkerd2-cni",
+            "chart_version": "30.3.8",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/30.3.8"
+        }
+    },
+    "stable-2.10.2": {
+        "linkerd-jaeger": {
+            "chart_name": "linkerd2/linkerd-jaeger",
+            "chart_version": "2.10.2",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/2.10.2"
+        },
+        "linkerd2": {
+            "chart_name": "linkerd2/linkerd2",
+            "chart_version": "2.10.2",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2/2.10"
+        },
+        "linkerd-multicluster": {
+            "chart_name": "linkerd2/linkerd-multicluster",
+            "chart_version": "2.10.2",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/2.10.2"
+        },
+        "linkerd-viz": {
+            "chart_name": "linkerd2/linkerd-viz",
+            "chart_version": "2.10.2",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/2.10.2"
+        },
+        "linkerd2-cni": {
+            "chart_name": "linkerd2/linkerd2-cni",
+            "chart_version": "2.10.2",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/2.10.2"
+        }
+    },
+    "stable-2.11.5": {
+        "linkerd-jaeger": {
+            "chart_name": "linkerd2/linkerd-jaeger",
+            "chart_version": "2.11.5",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-jaeger/2.11.5"
+        },
+        "linkerd2": {
+            "chart_name": "linkerd2/linkerd2",
+            "chart_version": "2.11.5",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2/2.11"
+        },
+        "linkerd-multicluster": {
+            "chart_name": "linkerd2/linkerd-multicluster",
+            "chart_version": "2.11.5",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-multicluster/2.11.5"
+        },
+        "linkerd-viz": {
+            "chart_name": "linkerd2/linkerd-viz",
+            "chart_version": "2.11.5",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd-viz/2.11.5"
+        },
+        "linkerd2-cni": {
+            "chart_name": "linkerd2/linkerd2-cni",
+            "chart_version": "2.11.5",
+            "chart_url": "https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni/2.11.5"
+        }
+    }
+}

--- a/linkerd.io/layouts/shortcodes/release-data-table.html
+++ b/linkerd.io/layouts/shortcodes/release-data-table.html
@@ -1,0 +1,58 @@
+{{ $table := $.Site.Data.releases.release_matrix   }}
+{{ $data := .Inner }}
+{{ $table_headers := slice "Chart Name" "Chart Version" "App Version" }}
+<style type="text/css" media="screen">
+
+  table{
+  border-collapse:collapse;
+  border:1px solid #000000;
+  }
+  th, td {
+  padding: 5px;
+  }
+  table td{
+  border:1px solid #000000;
+
+  }
+  table th{
+  border:1px solid #000000;
+  }
+  </style>
+<table>
+  <caption>Helm to App version matrix</caption>
+  <thead>
+    <tr>
+       <th class="text-center">Release Name</th>
+    </tr>
+  </thead>
+  <tbody>
+    {{ range $release_version, $charts := $table }}  
+    <tr>
+        <td class="text-center">
+            {{ $release_version }}
+        </td>
+        <td>
+          <table>
+            <thead>
+              <tr>
+                {{ range $table_headers }} <th class="text-center" >{{ . | humanize }}</th> {{ end }}
+              </tr>
+            </thead>
+            <tbody>
+              {{ range $chart_name, $chart_data := $charts }}
+               
+                <tr>
+                  <td> <a target="_blank" href="{{ $chart_data.chart_url }}">{{ $chart_name }}</a></td>
+                  <td> {{ $chart_data.chart_version }} </td>
+                  <td> {{ $release_version }} </td>
+
+                </tr>
+              {{ end }}
+            </tbody>
+          </table>
+            
+        </td>
+      </tr>
+    {{ end }}
+  </tbody>
+</table>        


### PR DESCRIPTION
Previously, there was not an easy way to correlate the app version to a helm chart version.  Many people ask this question in public slack channel or must get data themselves.  This adds a script to produce the desired matrix data as a table, json, or yaml output to help folks who are upgrading.  Without this matrix the versions are very confusing.  A python script is provided to generate the necessary data. 

This also adds a new make target to produce the content `build-release-matrix`.  I prepended the target call to the `build-linkerd.io` target so that upon creation the data would be generated.


<img width="826" alt="Screenshot 2023-11-27 at 9 34 34 PM" src="https://github.com/linkerd/website/assets/563900/83d86a83-e9b6-4164-8b71-a1d8b9b86bae">
