### PR TITLE
Documentation fix: Remove default timeout statement from service profile description.

### DIFF
--- a/linkerd.io/content/2.14/tasks/configuring-timeouts.md
+++ b/linkerd.io/content/2.14/tasks/configuring-timeouts.md
@@ -77,8 +77,7 @@ spec:
 Each [route](../../reference/service-profiles/#route) in a [ServiceProfile] may
 define a request timeout for requests matching that route. This timeout secifies
 the maximum amount of time to wait for a response (including retries) to
-complete after the request is sent. If unspecified, the default timeout is 10
-seconds.
+complete after the request is sent.
 
 ```yaml
 spec:


### PR DESCRIPTION
The current documentation states that, if not specified, the default timeout of a route defined via a service profile will be set to 10s.

According to the code and my tests, this default is not in place anymore (see: https://github.com/linkerd/linkerd2/blob/main/controller/api/destination/profile_translator.go#L221). Thus the statement caused some confusion and wrong expectations on our side, so I propose to remove it.