### PR TITLE
2.15 and forward getting-started docs should point people to edge CLI

### DIFF
--- a/linkerd.io/content/2.15/getting-started/_index.md
+++ b/linkerd.io/content/2.15/getting-started/_index.md
@@ -66,7 +66,7 @@ your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
-curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install-edge | sh
 ```
 
 Be sure to follow the instructions to add it to your path:


### PR DESCRIPTION
Move to use `-edge` as the current script gives this warning.

```
*******************************************
* This script is deprecated and no longer *
* installs stable releases.               *
*                                         *
* The latest edge release has been        *
* installed. In the future, please use    *
*   run.linkerd.io/install-edge           *
* for this behavior.                      *
*                                         *
* For stable releases, please see         *
*  https://linkerd.io/releases/           *
*******************************************
```