### PR TITLE
a few cleanups for edge vs stable releases

### DIFF
--- a/linkerd.io/content/2.15/getting-started/_index.md
+++ b/linkerd.io/content/2.15/getting-started/_index.md
@@ -52,9 +52,10 @@ Now that we have our cluster, we'll install the Linkerd CLI and use it validate
 that your cluster is capable of hosting Linkerd.
 
 {{< note >}}
-If you're using a GKE "private cluster" or Calico CNI, there are some [extra steps
-required](../reference/cluster-configuration/#private-clusters) before you can
-proceed to the next step.
+If you're using a GKE "private cluster", or if you're using Cilium as a CNI,
+there may be some [cluster-specific
+configuration](../reference/cluster-configuration/) before you can proceed to
+the next step.
 {{< /note >}}
 
 ## Step 1: Install the CLI
@@ -75,9 +76,9 @@ Be sure to follow the instructions to add it to your path:
 export PATH=$HOME/.linkerd2/bin:$PATH
 ```
 
-(Alternatively, if you use [Homebrew](https://brew.sh), you can install the CLI
-with `brew install linkerd`. You can also download the CLI directly via the
-[Linkerd releases page](https://github.com/linkerd/linkerd2/releases/).)
+This will install the CLI for the latest _edge release_ of Linkerd. (For more
+information about what edge releases are, see our [Releases and
+Versions](../../releases/) page.)
 
 Once installed, verify the CLI is running correctly with:
 

--- a/linkerd.io/content/releases/_index.md
+++ b/linkerd.io/content/releases/_index.md
@@ -39,14 +39,6 @@ The full list of edge releases can be found on
 
 ## Stable
 
-Stable releases are designed to introduce minimal change to an existing system
-and come with documented stability guarantees. In stable releases, we take the
-specific bug fix changes (or, occasionally, feature additions) and "back port"
-these changes against the code in the previous stable version. This minimizes
-the overall delta between releases. We also do any additional work required to
-ensure that upgrades and rollbacks between stable releases are seamless and
-contain no breaking changes.
-
 As of Linkerd 2.15.0, the open source project no longer publishes stable
 releases. Instead, the vendor community around Linkerd is responsible for
 supported, stable releases.


### PR DESCRIPTION
- Removed redundant note about GitHub releases page
- Cluster-specific configuration page mentions Cilium, not Calico, so I updated that. (This page could use some love.)
- Simplified releases page