### PR TITLE
cleanup versions across docs

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,8 +1,2 @@
 The maintainers of the Linkerd website are the Linkerd maintainers listed in
-https://github.com/linkerd/linkerd2/blob/main/MAINTAINERS.md, plus:
-
-- Paul Michael Armstrong (@PaulMichaelArmstrong)
-- Charles Pretzer (@cpretzer)
-- William Morgan (@wmorgan)
-
-If you'd like to become a maintainer, just come talk to us!
+https://github.com/linkerd/linkerd2/blob/main/MAINTAINERS.md.

--- a/linkerd.io/content/2-edge/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2-edge/tasks/distributed-tracing.md
@@ -209,7 +209,7 @@ The YAML file is merged with the [Helm values.yaml][helm-values] which shows
 other possible values that can be configured.
 
 <!-- markdownlint-disable MD034 -->
-[helm-values]: https://github.com/linkerd/linkerd2/blob/stable-{{% latest-linkerd2-stable-version %}}.0/jaeger/charts/linkerd-jaeger/values.yaml
+[helm-values]: https://github.com/linkerd/linkerd2/blob/main/jaeger/charts/linkerd-jaeger/values.yaml
 
 It is also possible to manually edit the OpenCensus configuration to have it
 export to any backend which it supports. See the

--- a/linkerd.io/content/2.11/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.11/tasks/distributed-tracing.md
@@ -207,7 +207,7 @@ The YAML file is merged with the [Helm values.yaml][helm-values] which shows
 other possible values that can be configured.
 
 <!-- markdownlint-disable MD034 -->
-[helm-values]: https://github.com/linkerd/linkerd2/blob/stable-{{% latest-linkerd2-stable-version %}}.0/jaeger/charts/linkerd-jaeger/values.yaml
+[helm-values]: https://github.com/linkerd/linkerd2/blob/main/jaeger/charts/linkerd-jaeger/values.yaml
 
 It is also possible to manually edit the OpenCensus configuration to have it
 export to any backend which it supports. See the

--- a/linkerd.io/content/2.12/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.12/tasks/distributed-tracing.md
@@ -207,7 +207,7 @@ The YAML file is merged with the [Helm values.yaml][helm-values] which shows
 other possible values that can be configured.
 
 <!-- markdownlint-disable MD034 -->
-[helm-values]: https://github.com/linkerd/linkerd2/blob/stable-{{% latest-linkerd2-stable-version %}}.0/jaeger/charts/linkerd-jaeger/values.yaml
+[helm-values]: https://github.com/linkerd/linkerd2/blob/main/jaeger/charts/linkerd-jaeger/values.yaml
 
 It is also possible to manually edit the OpenCensus configuration to have it
 export to any backend which it supports. See the

--- a/linkerd.io/content/2.13/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.13/tasks/distributed-tracing.md
@@ -209,7 +209,7 @@ The YAML file is merged with the [Helm values.yaml][helm-values] which shows
 other possible values that can be configured.
 
 <!-- markdownlint-disable MD034 -->
-[helm-values]: https://github.com/linkerd/linkerd2/blob/stable-{{% latest-linkerd2-stable-version %}}.0/jaeger/charts/linkerd-jaeger/values.yaml
+[helm-values]: https://github.com/linkerd/linkerd2/blob/main/jaeger/charts/linkerd-jaeger/values.yaml
 
 It is also possible to manually edit the OpenCensus configuration to have it
 export to any backend which it supports. See the

--- a/linkerd.io/content/2.14/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.14/tasks/distributed-tracing.md
@@ -209,7 +209,7 @@ The YAML file is merged with the [Helm values.yaml][helm-values] which shows
 other possible values that can be configured.
 
 <!-- markdownlint-disable MD034 -->
-[helm-values]: https://github.com/linkerd/linkerd2/blob/stable-{{% latest-linkerd2-stable-version %}}.0/jaeger/charts/linkerd-jaeger/values.yaml
+[helm-values]: https://github.com/linkerd/linkerd2/blob/main/jaeger/charts/linkerd-jaeger/values.yaml
 
 It is also possible to manually edit the OpenCensus configuration to have it
 export to any backend which it supports. See the

--- a/linkerd.io/content/2.15/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.15/tasks/distributed-tracing.md
@@ -209,7 +209,7 @@ The YAML file is merged with the [Helm values.yaml][helm-values] which shows
 other possible values that can be configured.
 
 <!-- markdownlint-disable MD034 -->
-[helm-values]: https://github.com/linkerd/linkerd2/blob/stable-{{% latest-linkerd2-stable-version %}}.0/jaeger/charts/linkerd-jaeger/values.yaml
+[helm-values]: https://github.com/linkerd/linkerd2/blob/main/jaeger/charts/linkerd-jaeger/values.yaml
 
 It is also possible to manually edit the OpenCensus configuration to have it
 export to any backend which it supports. See the

--- a/linkerd.io/content/2.15/tasks/install-helm.md
+++ b/linkerd.io/content/2.15/tasks/install-helm.md
@@ -8,7 +8,7 @@ command. This is recommended for production, since it allows for repeatability.
 
 {{< releases >}}
 
-## Prerequisite: generate identity certificates
+## Prerequisite: generate mTLS certificates
 
 To do [automatic mutual TLS](../../features/automatic-mtls/), Linkerd requires
 trust anchor certificate and an issuer certificate and key pair. When you're
@@ -18,21 +18,12 @@ you will need to generate these yourself.
 Please follow the instructions in [Generating your own mTLS root
 certificates](../generate-certificates/) to generate these.
 
-## Helm install procedure for stable releases
+## Helm install procedure
 
 ```bash
-# To add the repo for Linkerd stable releases:
-helm repo add linkerd https://helm.linkerd.io/stable
-
-# To add the repo for Linkerd edge releases:
+# Add the Helm repo for Linkerd edge releases:
 helm repo add linkerd-edge https://helm.linkerd.io/edge
 ```
-
-The following instructions use the `linkerd` repo. For installing an edge
-release, just replace with `linkerd-edge`, and add the `--devel` flag to all
-commands.
-
-## Helm install procedure
 
 You need to install two separate charts in succession: first `linkerd-crds` and
 then `linkerd-control-plane`.
@@ -117,7 +108,7 @@ helm repo update
 helm search repo linkerd
 NAME                          CHART VERSION          APP VERSION              DESCRIPTION
 linkerd/linkerd-crds          <chart-semver-version>                          Linkerd gives you observability, reliability, and securit...
-linkerd/linkerd-control-plane <chart-semver-version> {{% latestversion %}}    Linkerd gives you observability, reliability, and securit...
+linkerd/linkerd-control-plane <chart-semver-version> {{% latestedge %}}       Linkerd gives you observability, reliability, and securit...
 ```
 
 During an upgrade, you must choose whether you want to reuse the values in the

--- a/linkerd.io/content/2.15/tasks/upgrade.md
+++ b/linkerd.io/content/2.15/tasks/upgrade.md
@@ -20,14 +20,12 @@ Read through this guide carefully. Additionally, before starting a specific
 upgrade, please read through the version-specific upgrade notices below, which
 may contain important information about your version.
 
-- [Upgrade notice: stable-2.14.0](#upgrade-notice-stable-2-14-0)
-- [Upgrade notice: stable-2.13.0](#upgrade-notice-stable-2-13-0)
-- [Upgrade notice: stable-2.12.0](#upgrade-notice-stable-2-12-0)
-- [Upgrade notice: stable-2.11.0](#upgrade-notice-stable-2-11-0)
-- [Upgrade notice: stable-2.10.0](#upgrade-notice-stable-2-10-0)
-- [Upgrade notice: stable-2.9.4](#upgrade-notice-stable-2-9-4)
-- [Upgrade notice: stable-2.9.3](#upgrade-notice-stable-2-9-3)
-- [Upgrade notice: stable-2.9.0](#upgrade-notice-stable-2-9-0)
+- [Upgrade notice: 2.15 and beyond](#upgrade-notice-stable-215-and-beyond)
+- [Upgrade notice: stable-2.14.0](#upgrade-notice-stable-2140)
+- [Upgrade notice: stable-2.13.0](#upgrade-notice-stable-2130)
+- [Upgrade notice: stable-2.12.0](#upgrade-notice-stable-2120)
+- [Upgrade notice: stable-2.11.0](#upgrade-notice-stable-2110)
+- [Upgrade notice: stable-2.10.0](#upgrade-notice-stable-2100)
 
 ## Version numbering
 
@@ -119,7 +117,7 @@ linkerd version --client
 
 ## Upgrading the control plane
 
-### With the Linkerd CLI
+### Upgrading the control plane with the CLI
 
 For users who have installed Linkerd via the CLI, the `linkerd upgrade` command
 will upgrade the control plane. This command ensures that all of the control
@@ -139,7 +137,7 @@ present in the previous version but should not be present in this one.
 linkerd prune | kubectl delete -f -
 ```
 
-### With Helm
+### Upgrading the control plane with Helm
 
 For Helm control plane installations, please follow the instructions at [Helm
 upgrade procedure](../install-helm/#helm-upgrade-procedure).
@@ -239,6 +237,17 @@ Congratulation! You have successfully upgraded your Linkerd to the newer
 version.
 
 ## Upgrade notices
+
+This section contains release-specific information about upgrading.
+
+### Upgrade notice: stable-2.15 and beyond
+
+As of February 2024, the Linkerd project is no longer producing open source
+stable release artifacts. Please read the [2.15
+announcement](/2024/02/21/announcing-linkerd-2.15/#a-new-model-for-stable-releases)
+for details.
+
+See [the full list of Linkerd releases](/releases/) for ways to get Linkerd.
 
 ### Upgrade notice: stable-2.14.0
 
@@ -628,78 +637,3 @@ you had customized there will need to be migrated; in particular
 `identityTrustAnchorsPEM` in order to conserve the value you set during
 install."
 
-### Upgrade notice: stable-2.9.4
-
-See upgrade notes for 2.9.3 below.
-
-### Upgrade notice: stable-2.9.3
-
-#### Linkerd Repair
-
-Due to a known issue in versions stable-2.9.0, stable-2.9.1, and stable-2.9.2,
-users who upgraded to one of those versions with the --prune flag (as described
-above) will have deleted the `secret/linkerd-config-overrides` resource which is
-necessary for performing any subsequent upgrades. Linkerd stable-2.9.3 includes
-a new `linkerd repair` command which restores this deleted resource. If you see
-unexpected error messages during upgrade such as "failed to read CA: not
-PEM-encoded", please upgrade your CLI to stable-2.9.3 and run:
-
-```bash
-linkerd repair | kubectl apply -f -
-```
-
-This will restore the `secret/linkerd-config-overrides` resource and allow you
-to proceed with upgrading your control plane.
-
-### Upgrade notice: stable-2.9.0
-
-#### Images are now hosted on ghcr.io
-
-As of this version images are now hosted under `ghcr.io` instead of `gcr.io`. If
-you're pulling images into a private repo please make the necessary changes.
-
-#### Upgrading multicluster environments
-
-Linkerd 2.9 changes the way that some of the multicluster components work and
-are installed compared to Linkerd 2.8.x. Users installing the multicluster
-components for the first time with Linkerd 2.9 can ignore these instructions and
-instead refer directly to the [installing
-multicluster instructions](../installing-multicluster/).
-
-Users who installed the multicluster component in Linkerd 2.8.x and wish to
-upgrade to Linkerd 2.9 should follow the [upgrade multicluster
-instructions](/2.11/tasks/upgrade-multicluster/).
-
-#### Ingress behavior changes
-
-In previous versions when you injected your ingress controller (Nginx, Traefik,
-Ambassador, etc), then the ingress' balancing/routing choices would be
-overridden with Linkerd's (using service profiles, traffic splits, etc.).
-
-As of 2.9 the ingress's choices are honored instead, which allows preserving
-things like session-stickiness. Note however that this means per-route metrics
-are not collected, traffic splits will not be honored and retries/timeouts are
-not applied.
-
-If you want to revert to the previous behavior, inject the proxy into the
-ingress controller using the annotation `linkerd.io/inject: ingress`, as
-explained in [using ingress](../using-ingress/)
-
-#### Breaking changes in Helm charts
-
-Some entries like `controllerLogLevel` and all the Prometheus config have
-changed their position in the settings hierarchy. To get a precise view of what
-has changed you can compare the
-[stable-2.8.1](https://github.com/linkerd/linkerd2/blob/stable-2.8.1/charts/linkerd2/values.yaml)
-and
-[stable-2.9.0](https://github.com/linkerd/linkerd2/blob/stable-2.9.0/charts/linkerd2/values.yaml)
-`values.yaml` files.
-
-#### Post-upgrade cleanup
-
-In order to better support cert-manager, the secrets
-`linkerd-proxy-injector-tls`, `linkerd-sp-validator-tls` and `linkerd-tap-tls`
-have been replaced by the secrets `linkerd-proxy-injector-k8s-tls`,
-`linkerd-sp-validator-k8s-tls` and `linkerd-tap-k8s-tls` respectively. If you
-upgraded through the CLI, please delete the old ones (if you upgraded through
-Helm the cleanup was automated).

--- a/linkerd.io/content/design-principles/_index.md
+++ b/linkerd.io/content/design-principles/_index.md
@@ -29,16 +29,14 @@ mean that Linkerd can't have powerful features, or that it has to have
 one-click wizards take care of everything for you. In fact, it means the
 opposite: every aspect of Linkerd's behavior should be explicit, clear,
 well-defined, bounded, understandable, and introspectable. For example,
-Linkerd's [control plane](/{{% latest-linkerd2-stable-version
-%}}/reference/architecture/#control-plane) is split into several operational
-components based on their functional boundaries ("web”, "api”, etc.) These
-components aren't just exposed directly to you in the Linkerd dashboard and CLI,
-they run on the same data plane as your application does, allowing you to use
-the same tooling to inspect their behavior.
+Linkerd's [control plane](/2/reference/architecture/#control-plane) is split
+into several operational components based on their functional boundaries ("web”,
+"api”, etc.) These components aren't just exposed directly to you in the Linkerd
+dashboard and CLI, they run on the same data plane as your application does,
+allowing you to use the same tooling to inspect their behavior.
 
 _Minimize resource requirements_ means that Linkerd, and especially Linkerd's
-[data plane proxies](/{{% latest-linkerd2-stable-version
-%}}/reference/architecture/#data-plane), should consume the smallest amount of
+[data plane proxies](/2/reference/architecture/#data-plane), should consume the smallest amount of
 memory and CPU possible. On the control plane side, we've taken care to ensure
 that components scale gracefully in the presence of traffic. On the data plane
 side, we've build Linkerd's proxy (called simply "linkerd-proxy”) for
@@ -51,10 +49,9 @@ Finally, _just work_ means that adding Linkerd to a functioning Kubernetes
 application shouldn't break anything, and shouldn't even require configuration.
 (Of course, configuration will be necessary to customize Linkerd's behavior--but
 it shouldn't be necessary simply to get things working.) To do this, we've
-invested heavily in things like [automatic L7 protocol detection](/{{%
-latest-linkerd2-stable-version %}}/features/protocol-detection/), and [automatic
-re-routing of TCP traffic within a pod](/{{% latest-linkerd2-stable-version
-%}}/features/proxy-injection/).
+invested heavily in things like [automatic L7 protocol
+detection](/2/features/protocol-detection/), and [automatic re-routing of TCP
+traffic within a pod](/2/features/proxy-injection/).
 
 Together, these three principles give us a framework for weighing product and
 engineering tradeoffs in Linkerd. We hope they're also useful for understanding

--- a/linkerd.io/content/releases/_index.md
+++ b/linkerd.io/content/releases/_index.md
@@ -6,7 +6,7 @@ weight = 18
 
 Releases and packages of Linkerd are available in several different forms.
 
-## Edge releases (latest version: {{% latestedge %}})
+## Edge releases
 
 All Linkerd development happens "on main": all changes, whether security
 patches, new features, refactors, bug fixes, or something else, land on the main
@@ -29,12 +29,14 @@ notes](https://github.com/linkerd/linkerd2/releases/tag/{{% latestedge %}})].
 
 ## Stable releases
 
-As of February 2024, the vendor community around Linkerd is responsible for
-supported, stable release artifacts. Known distributions of Linkerd with stable
-release artifacts are:
+As of February 2024, the Linkerd project is no longer producing open source
+stable release artifacts. Instead, the vendor community around Linkerd is
+responsible for supported, stable release artifacts.
+
+Known distributions of Linkerd with stable release artifacts include:
 
 * [Buoyant Enterprise for
   Linkerd](https://docs.buoyant.io/buoyant-enterprise-linkerd) from Buoyant,
-  creators of Linkerd. Latest version:
+  creators of Linkerd.<br/> Latest version:
   **enterprise-2.15.2** [[release
   notes](https://docs.buoyant.io/release-notes/buoyant-enterprise-linkerd/enterprise-2.15.2/)].

--- a/linkerd.io/layouts/shortcodes/latest-linkerd2-stable-version.html
+++ b/linkerd.io/layouts/shortcodes/latest-linkerd2-stable-version.html
@@ -1,1 +1,2 @@
+{{/* this shortcode is no longer in use... please don't reintroduce it */}}
 {{ site.Params.latest_linkerd2_stable_version -}}

--- a/linkerd.io/layouts/shortcodes/latestversion.html
+++ b/linkerd.io/layouts/shortcodes/latestversion.html
@@ -1,1 +1,2 @@
+{{/* this shortcode is deprecated and only used in pre-2.15 docs. */}}
 {{ if eq .Page.Section "1" }}{{ site.Params.latest_release_version }}{{ else }}L5D2_STABLE_VERSION{{ end }}{{- "" -}}


### PR DESCRIPTION
- Call out that there is no 2.15 or later stable release
- Prune upgrade instructions for 2.9 and earlier
- Clean up old shortcode usage
- Clean up maintainers
- Various other minor cleanups