### PR TITLE
Fix Kustomize for multicluster demo

### DIFF
--- a/multicluster/base/kustomization.yml
+++ b/multicluster/base/kustomization.yml
@@ -1,9 +1,12 @@
-bases:
-  - github.com/stefanprodan/podinfo/kustomize?ref=4.0.2
-
 resources:
+  - github.com/stefanprodan/podinfo/kustomize?ref=4.0.2
   - frontend.yml
   - ns.yml
 
 patches:
-  - patch.yml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: podinfo
+    path: patch-deployment.yml

--- a/multicluster/base/patch-deployment.yml
+++ b/multicluster/base/patch-deployment.yml
@@ -13,13 +13,3 @@ spec:
         - name: podinfod
           securityContext:
             runAsUser: 1337
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: podinfo
----
-apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-metadata:
-  name: podinfo

--- a/multicluster/east/kustomization.yml
+++ b/multicluster/east/kustomization.yml
@@ -1,6 +1,16 @@
-bases:
+resources:
   - ../base
 
 patches:
-  - podinfo.yml
-  - frontend.yml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: podinfo
+    path: podinfo.yml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: frontend
+    path: frontend.yml

--- a/multicluster/west/kustomization.yml
+++ b/multicluster/west/kustomization.yml
@@ -1,6 +1,16 @@
-bases:
+resources:
   - ../base
 
 patches:
-  - podinfo.yml
-  - frontend.yml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: podinfo
+    path: podinfo.yml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: frontend
+    path: frontend.yml


### PR DESCRIPTION
Addresses Issue #1722
Updates the multicluster demo to work with newer versions of kustomize.
This was tested by installing kubectl-v1.26.12  and generating the resulting manifeststs.
Next, I updated the files to work with kubectl-v1.28.3.
Finally, I diffed the resulting manifests to ensure that there was no differences.

**NOTE** there was a couple of difference due to order of containers and environment variables being generated.
But nothing that should impact the result.
