### PR TITLE
remove deprecated --short arg to kubectl version

### DIFF
--- a/linkerd.io/content/2-edge/getting-started/_index.md
+++ b/linkerd.io/content/2-edge/getting-started/_index.md
@@ -42,7 +42,7 @@ more](https://kubernetes.io/docs/setup/).)
 Validate your Kubernetes setup by running:
 
 ```bash
-kubectl version --short
+kubectl version
 ```
 
 You should see output with both a `Client Version` and `Server Version`

--- a/linkerd.io/content/2.15/getting-started/_index.md
+++ b/linkerd.io/content/2.15/getting-started/_index.md
@@ -38,7 +38,7 @@ more](https://kubernetes.io/docs/setup/).)
 Validate your Kubernetes setup by running:
 
 ```bash
-kubectl version --short
+kubectl version
 ```
 
 You should see output with both a `Client Version` and `Server Version`


### PR DESCRIPTION
As of Kubernetes 1.27, the `--short` arg to kubectl version is deprecated and prints a warning. As of Kubernetes 1.28, using it results in an error.