### PR TITLE
add Versions section

### DIFF
--- a/linkerd.io/content/releases/_index.md
+++ b/linkerd.io/content/releases/_index.md
@@ -50,5 +50,19 @@ artifacts.
 
 <!-- markdownlint-disable MD034 -->
 
-Latest version: **{{% latestedge %}}** [[release
-notes](https://github.com/linkerd/linkerd2/releases/tag/{{% latestedge %}})].
+## Versions
+
+Like many projects, Linkerd publishes and announces major *versions* that
+correspond to specific project milestones and sets of new features.
+
+### Linkerd 2.15
+
+The latest major version is Linkerd 2.15.
+
+* Release date: February 21, 2024.
+* Full announcement: [Announcing Linkerd 2.15 with mesh expansion, native
+sidecars, and SPIFFE ](/2024/02/21/announcing-linkerd-2.15/).
+* Edge releases:
+[edge-24.2.4](https://github.com/linkerd/linkerd2/releases/tag/edge-24.2.4)
+through [{{% latestedge %}}](https://github.com/linkerd/linkerd2/releases/tag/{{%
+latestedge %}}).

--- a/linkerd.io/content/releases/_index.md
+++ b/linkerd.io/content/releases/_index.md
@@ -4,67 +4,66 @@ aliases = [ "edge" ]
 weight = 18
 +++
 
-Releases of Linkerd are available in several different forms.
+Linkerd publishes and announces *versions* that correspond to specific project
+milestones and sets of new features. These versions are available in different
+types of *release artifacts*.
 
-## Stable releases
+## Recent versions
 
-Stable release artifacts of Linkerd follow semantic versioning, whereby changes
-in major version denote large feature additions and possible breaking changes
-and changes in minor versions denote safe upgrades without breaking changes.
+### Linkerd 2.15
 
-As of February 2024, Linkerd no longer provides stable release artifacts in the
-open source project itself. Instead, the vendor community around Linkerd is
-responsible for creating stable release artifacts. Known distributions of
-Linkerd with stable release artifacts include:
+Linkerd 2.15 was announced on February 21, 2024.
 
-- [Buoyant Enterprise for Linkerd](https://docs.buoyant.io/buoyant-enterprise-linkerd)
-  from Buoyant, creators of Linkerd.
-  Latest version: **enterprise-2.15.3**
-  [[release notes](https://docs.buoyant.io/release-notes/buoyant-enterprise-linkerd/enterprise-2.15.3/)].
+- **Announcement**: [Announcing Linkerd 2.15 with mesh expansion, native
+sidecars, and SPIFFE](/2024/02/21/announcing-linkerd-2.15/)
+- **Code tag**:
+[version-2.15](https://github.com/linkerd/linkerd2/releases/tag/version-2.15)
+- **Corresponding edge release**: [edge-24.2.4](https://github.com/linkerd/linkerd2/releases/tag/edge-24.2.4)
 
-## Edge releases
+Known distributions of Linkerd 2.15:
+- [Buoyant Enterprise for
+  Linkerd](https://docs.buoyant.io/buoyant-enterprise-linkerd) from Buoyant,
+  creators of Linkerd. Latest version: **enterprise-2.15.3** ([release
+  notes](https://docs.buoyant.io/release-notes/buoyant-enterprise-linkerd/enterprise-2.15.3/)).
+
+## Types of release artifacts
+
+### Edge releases
 
 Edge release artifacts are published on a weekly or near-weekly basis as part of
-the open source project. The full list of edge release artifacts can be found on
-[the Linkerd GitHub releases
-page](https://github.com/linkerd/linkerd2/releases).
+the open source project. The latest edge release is [{{% latestedge
+%}}](https://github.com/linkerd/linkerd2/releases/tag/{{% latestedge %}}).
+and the full list of edge release artifacts can be found on [the Linkerd GitHub
+releases page](https://github.com/linkerd/linkerd2/releases).
 
 Edge release artifacts contain the code in from the _main_ branch at the point
 in time when they were cut. This means they always have the latest features and
-fixes, and have undergone automated testing as well as maintianer code review.
+fixes, and have undergone automated testing as well as maintainer code review.
 Edge releases may involve partial features that are later modified or backed
 out. They may also involve breaking changes—of course, we do our best to avoid
 this.
 
+Edge releases are generally considered *production ready*, and the project will
+mark specific releases as "not recommended" if bugs are discovered after
+release.
+
 Edge release versioning follows the form `edge-y.m.n`, where `y` is the last two
 digits of the year, `m` is the numeric month, and `n` is numeric edge release
-count for that month. For example:
-
-- `edge-23.9.1`: the first edge release shipped in September 2023
-- `edge-24.1.3`: the third edge release shipped in January 2024
+count for that month. For example, `edge-24.1.3` is the third edge release
+shipped in January 2024.
 
 Using edge release artifacts and reporting bugs helps us ensure a rapid pace of
 development and is a great way to help Linkerd. We publish edge release guidance
 as part of the release notes and strive to always provide production-ready
 artifacts.
 
-<!-- markdownlint-disable MD034 -->
+### Stable releases
 
-## Versions
+Stable release artifacts of Linkerd follow semantic versioning, whereby changes
+in major version denote large feature additions and possible breaking changes
+and changes in minor versions denote safe upgrades without breaking changes.
 
-Like many projects, Linkerd publishes and announces major *versions* that
-correspond to specific project milestones and sets of new features.
+As of February 2024, the Linkerd open source project itself no longer provides
+stable release artifacts. Instead, the vendor community around Linkerd is
+responsible for creating stable release artifacts.
 
-### Linkerd 2.15
-
-The latest major version is Linkerd 2.15.
-
-- Release date: February 21, 2024.
-- Announcement post: [Announcing Linkerd 2.15 with mesh expansion, native
-sidecars, and SPIFFE](/2024/02/21/announcing-linkerd-2.15/).
-- Code tag:
-[version-2.15](https://github.com/linkerd/linkerd2/releases/tag/version-2.15).
-- Edge releases:
-[edge-24.2.4](https://github.com/linkerd/linkerd2/releases/tag/edge-24.2.4)
-through [{{% latestedge
-%}}](https://github.com/linkerd/linkerd2/releases/tag/{{% latestedge %}}).

--- a/linkerd.io/content/releases/_index.md
+++ b/linkerd.io/content/releases/_index.md
@@ -21,6 +21,7 @@ sidecars, and SPIFFE](/2024/02/21/announcing-linkerd-2.15/)
 - **Corresponding edge release**: [edge-24.2.4](https://github.com/linkerd/linkerd2/releases/tag/edge-24.2.4)
 
 Known distributions of Linkerd 2.15:
+
 - [Buoyant Enterprise for
   Linkerd](https://docs.buoyant.io/buoyant-enterprise-linkerd) from Buoyant,
   creators of Linkerd. Latest version: **enterprise-2.15.3** ([release
@@ -30,6 +31,7 @@ Known distributions of Linkerd 2.15:
 
 ### Edge releases
 
+<!-- markdownlint-disable MD034 -->
 Edge release artifacts are published on a weekly or near-weekly basis as part of
 the open source project. The latest edge release is [{{% latestedge
 %}}](https://github.com/linkerd/linkerd2/releases/tag/{{% latestedge %}}).
@@ -66,4 +68,3 @@ and changes in minor versions denote safe upgrades without breaking changes.
 As of February 2024, the Linkerd open source project itself no longer provides
 stable release artifacts. Instead, the vendor community around Linkerd is
 responsible for creating stable release artifacts.
-

--- a/linkerd.io/content/releases/_index.md
+++ b/linkerd.io/content/releases/_index.md
@@ -62,6 +62,8 @@ The latest major version is Linkerd 2.15.
 - Release date: February 21, 2024.
 - Announcement post: [Announcing Linkerd 2.15 with mesh expansion, native
 sidecars, and SPIFFE](/2024/02/21/announcing-linkerd-2.15/).
+- Code tag:
+[version-2.15](https://github.com/linkerd/linkerd2/releases/tag/version-2.15).
 - Edge releases:
 [edge-24.2.4](https://github.com/linkerd/linkerd2/releases/tag/edge-24.2.4)
 through [{{% latestedge

--- a/linkerd.io/content/releases/_index.md
+++ b/linkerd.io/content/releases/_index.md
@@ -60,8 +60,9 @@ correspond to specific project milestones and sets of new features.
 The latest major version is Linkerd 2.15.
 
 - Release date: February 21, 2024.
-- Full announcement: [Announcing Linkerd 2.15 with mesh expansion, native sidecars, and SPIFFE](/2024/02/21/announcing-linkerd-2.15/).
+- Announcement post: [Announcing Linkerd 2.15 with mesh expansion, native
+sidecars, and SPIFFE](/2024/02/21/announcing-linkerd-2.15/).
 - Edge releases:
 [edge-24.2.4](https://github.com/linkerd/linkerd2/releases/tag/edge-24.2.4)
-through [{{% latestedge %}}](https://github.com/linkerd/linkerd2/releases/tag/{{%
-latestedge %}}).
+through [{{% latestedge
+%}}](https://github.com/linkerd/linkerd2/releases/tag/{{% latestedge %}}).

--- a/linkerd.io/content/releases/_index.md
+++ b/linkerd.io/content/releases/_index.md
@@ -59,10 +59,9 @@ correspond to specific project milestones and sets of new features.
 
 The latest major version is Linkerd 2.15.
 
-* Release date: February 21, 2024.
-* Full announcement: [Announcing Linkerd 2.15 with mesh expansion, native
-sidecars, and SPIFFE ](/2024/02/21/announcing-linkerd-2.15/).
-* Edge releases:
+- Release date: February 21, 2024.
+- Full announcement: [Announcing Linkerd 2.15 with mesh expansion, native sidecars, and SPIFFE](/2024/02/21/announcing-linkerd-2.15/).
+- Edge releases:
 [edge-24.2.4](https://github.com/linkerd/linkerd2/releases/tag/edge-24.2.4)
 through [{{% latestedge %}}](https://github.com/linkerd/linkerd2/releases/tag/{{%
 latestedge %}}).


### PR DESCRIPTION
Add a versions section at the bottom of Releases and Versions. @kflynn at the risk of conflicting again with your PR, what do you think about something like this to capture the mapping between versions and release artifacts?