### PR TITLE
Add Note that informs the user about non injection for default namespaces

### DIFF
--- a/linkerd.io/content/2.15/tasks/using-ingress.md
+++ b/linkerd.io/content/2.15/tasks/using-ingress.md
@@ -61,6 +61,11 @@ header was *required* in ingress mode, or the request would fail. This bug was
 fixed in 2.13.5, and was not present prior to 2.13.0.
 {{< /note >}}
 
+{{< note >}}
+Be sure to not deploy the ingress controller in the `kube-system` or `cert-manager`
+namespace as linkerd ignores these namespaces by default for injection.
+{{< /note >}}
+
 For more on ingress mode and why it's necessary, see [Ingress
 details](#ingress-details) below.
 


### PR DESCRIPTION
First of all great project :-)

While installing from a `rancher` instance where the ingress controller is installed in the `kube-system` namespace, I figured that this information would be well placed at this position in the docs.

https://github.com/linkerd/linkerd2/blob/2142e7bc17e6961c5ab82449ebb45c09dde1fd17/charts/linkerd-control-plane/values.yaml#L449-L451