### PR TITLE
document namespaces excluded from injection 

### DIFF
--- a/linkerd.io/content/2.15/features/ha.md
+++ b/linkerd.io/content/2.15/features/ha.md
@@ -79,26 +79,6 @@ See the Kubernetes
 for more information on the admission webhook failure policy.
 {{< /note >}}
 
-## Exclude the kube-system namespace
-
-Per recommendation from the Kubernetes
-[documentation](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#avoiding-operating-on-the-kube-system-namespace),
-the proxy injector should be disabled for the `kube-system` namespace.
-
-This can be done by labeling the `kube-system` namespace with the following
-label:
-
-```bash
-kubectl label namespace kube-system config.linkerd.io/admission-webhooks=disabled
-```
-
-The Kubernetes API server will not call the proxy injector during the admission
-phase of workloads in namespace with this label.
-
-If your Kubernetes cluster have built-in reconcilers that would revert any changes
-made to the `kube-system` namespace, you should loosen the proxy injector
-failure policy following these [instructions](#proxy-injector-failure-policy).
-
 ## Pod anti-affinity rules
 
 All critical control plane components are deployed with pod anti-affinity rules

--- a/linkerd.io/content/2.15/features/proxy-injection.md
+++ b/linkerd.io/content/2.15/features/proxy-injection.md
@@ -34,7 +34,7 @@ For each pod, two containers are injected:
    Container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
    that configures `iptables` to automatically forward all incoming and
    outgoing TCP traffic through the proxy. (Note that this container is not
-   present if the [Linkerd CNI Plugin](../cni/) has been enabled.)
+   injected if the [Linkerd CNI Plugin](../cni/) has been enabled.)
 1. `linkerd-proxy`, the Linkerd data plane proxy itself.
 
 Note that simply adding the annotation to a resource with pre-existing pods
@@ -42,6 +42,16 @@ will not automatically inject those pods. You will need to update the pods
 (e.g. with `kubectl rollout restart` etc.) for them to be injected. This is
 because Kubernetes does not call the webhook until it needs to update the
 underlying resources.
+
+## Exclusions
+
+At install time, Kubernetes is configured to avoid calling Linkerd's proxy
+injector for resources in the `kube-system` and `cert-manager` namespaces. This
+is to prevent injection on components that are themselves required for Linkerd
+to function.
+
+The injector will not run on components in these namespaces, regardless of any
+`linkerd.io/inject` annotations.
 
 ## Overriding injection
 

--- a/linkerd.io/content/2.15/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.15/tasks/troubleshooting.md
@@ -1087,31 +1087,6 @@ the Pod and Service. See
 
 These checks are ran if Linkerd has been installed in HA mode.
 
-### √ pod injection disabled on kube-system {#l5d-injection-disabled}
-
-Example warning:
-
-```bash
-‼ pod injection disabled on kube-system
-    kube-system namespace needs to have the label config.linkerd.io/admission-webhooks: disabled if HA mode is enabled
-    see https://linkerd.io/checks/#l5d-injection-disabled for hints
-```
-
-Ensure the kube-system namespace has the
-`config.linkerd.io/admission-webhooks:disabled` label:
-
-```bash
-$ kubectl get namespace kube-system -oyaml
-kind: Namespace
-apiVersion: v1
-metadata:
-  name: kube-system
-  annotations:
-    linkerd.io/inject: disabled
-  labels:
-    config.linkerd.io/admission-webhooks: disabled
-```
-
 ### √ multiple replicas of control plane pods {#l5d-control-plane-replicas}
 
 Example warning:


### PR DESCRIPTION
This is now done by default and the check has been removed (see
https://github.com/linkerd/linkerd2/issues/12233). Update the docs accordingly.
