### PR TITLE
Audit mode

### DIFF
--- a/linkerd.io/content/2.15/features/server-policy.md
+++ b/linkerd.io/content/2.15/features/server-policy.md
@@ -46,7 +46,7 @@ policy at that point in the hierarchy. Valid default policies include:
 
 - `all-unauthenticated`: allow all requests. This is the default.
 - `all-authenticated`: allow requests from meshed clients only.
-- `cluster-authenticated`: allow requests form meshed clients in the same
+- `cluster-authenticated`: allow requests from meshed clients in the same
   cluster.
 - `deny`: deny all requests.
 

--- a/linkerd.io/content/2.16/features/server-policy.md
+++ b/linkerd.io/content/2.16/features/server-policy.md
@@ -46,9 +46,11 @@ policy at that point in the hierarchy. Valid default policies include:
 
 - `all-unauthenticated`: allow all requests. This is the default.
 - `all-authenticated`: allow requests from meshed clients only.
-- `cluster-authenticated`: allow requests form meshed clients in the same
+- `cluster-authenticated`: allow requests from meshed clients in the same
   cluster.
 - `deny`: deny all requests.
+- `audit`: Same as `all-unauthenticated` but requests get flagged in logs and
+  metrics.
 
 As well as several other default policies—see the [Policy
 reference](../../reference/authorization-policy/) for more.
@@ -127,6 +129,37 @@ be denied at the TCP level, i.e. by refusing the connection.
 
 Note that dynamically changing the policy to deny existing connections may
 result in an abrupt termination of those connections.
+
+## Audit mode
+
+A [`Server`]'s default policy is declared in its `accessPolicy` field, which
+defaults to `deny`. That means that, by default, traffic that doesn't conform to
+the rules associated to that Server is denied (the same applies to `Servers` that
+don't have associated rules yet). This can inadvertently sever traffic if you
+apply rules that don't account for all the possible sources/routes for your
+services.
+
+This is why we recommend that when setting authorization policies for the first
+time for complex-enough services, to explicitly set `accessPolicy:audit` for
+your `Servers`. In this mode, if a request doesn't abide to the policy rules, it
+won't get blocked, but it will generate a log entry in the proxy at the INFO
+level with the tag `authz.name=audit` along with other useful information.
+Likewise, the proxy will add entries to metrics like `request_total` with the
+label `authz_name=audit`. So when you're in the process of fine-tuning a new
+authorization policy, you can filter by those tags/labels in your observability
+stack to keep an eye on requests which weren't caught by the policy.
+
+### Audit mode for default policies
+
+The cluster-level setting `proxy.defaultInboundPolicy` and the namespace and
+workload-level annotation `config.linkerd.io/default-inbound-policy` declare the
+policy to apply when there is no authorization policy associated to a port (via
+a `Server`). They also admit the `audit` value liked just explained. If for
+example you had `config.linkerd.io/default-inbound-policy:all_authenticated` for
+a namespace and no `Servers` declared, all unmeshed traffic would be denied. By
+using `config.linkerd.io/default-inbound-policy:audit` instead, unmeshed traffic
+would be allowed but it would be logged and surfaced in metrics as detailed
+above.
 
 ## Learning more
 

--- a/linkerd.io/content/2.16/features/server-policy.md
+++ b/linkerd.io/content/2.16/features/server-policy.md
@@ -132,34 +132,33 @@ result in an abrupt termination of those connections.
 
 ## Audit mode
 
-A [`Server`]'s default policy is declared in its `accessPolicy` field, which
+A [`Server`]'s default policy is defined in its `accessPolicy` field, which
 defaults to `deny`. That means that, by default, traffic that doesn't conform to
-the rules associated to that Server is denied (the same applies to `Servers` that
-don't have associated rules yet). This can inadvertently sever traffic if you
-apply rules that don't account for all the possible sources/routes for your
+the rules associated to that Server is denied (the same applies to `Servers`
+that don't have associated rules yet). This can inadvertently prevent traffic if
+you apply rules that don't account for all the possible sources/routes for your
 services.
 
-This is why we recommend that when setting authorization policies for the first
-time for complex-enough services, to explicitly set `accessPolicy:audit` for
-your `Servers`. In this mode, if a request doesn't abide to the policy rules, it
-won't get blocked, but it will generate a log entry in the proxy at the INFO
-level with the tag `authz.name=audit` along with other useful information.
-Likewise, the proxy will add entries to metrics like `request_total` with the
-label `authz_name=audit`. So when you're in the process of fine-tuning a new
-authorization policy, you can filter by those tags/labels in your observability
-stack to keep an eye on requests which weren't caught by the policy.
+This is why we recommend that when first setting authorization policies, you
+explicitly set `accessPolicy:audit` for complex-enough services. In this mode,
+if a request doesn't abide to the policy rules, it won't get blocked, but it
+will generate a log entry in the proxy at the INFO level with the tag
+`authz.name=audit` along with other useful information. Likewise, the proxy will
+add entries to metrics like `request_total` with the label `authz_name=audit`.
+So when you're in the process of fine-tuning a new authorization policy, you can
+filter by those tags/labels in your observability stack to keep an eye on
+requests which weren't caught by the policy.
 
 ### Audit mode for default policies
 
-The cluster-level setting `proxy.defaultInboundPolicy` and the namespace and
-workload-level annotation `config.linkerd.io/default-inbound-policy` declare the
-policy to apply when there is no authorization policy associated to a port (via
-a `Server`). They also admit the `audit` value liked just explained. If for
-example you had `config.linkerd.io/default-inbound-policy:all_authenticated` for
-a namespace and no `Servers` declared, all unmeshed traffic would be denied. By
-using `config.linkerd.io/default-inbound-policy:audit` instead, unmeshed traffic
-would be allowed but it would be logged and surfaced in metrics as detailed
-above.
+Audit mode is also supported at cluster, namespace, or workload level. To set
+the whole cluster to audit mode, set `proxy.defaultInboundPolicy=audit` when
+installing Linkerd; for a namespace or a workload, use the annotation
+`config.linkerd.io/default-inbound-policy:audit`. For example, if you had
+`config.linkerd.io/default-inbound-policy:all_authenticated` for a namespace and
+no `Servers` declared, all unmeshed traffic would be denied. By using
+`config.linkerd.io/default-inbound-policy:audit` instead, unmeshed traffic would
+be allowed but it would be logged and surfaced in metrics as detailed above.
 
 ## Learning more
 

--- a/linkerd.io/content/2.16/reference/authorization-policy.md
+++ b/linkerd.io/content/2.16/reference/authorization-policy.md
@@ -27,6 +27,8 @@ specify the cluster-wide default policy. This field can be one of the following:
 - `cluster-unauthenticated`: allow traffic from both meshed and non-meshed clients
   in the same cluster.
 - `deny`: all traffic are denied.
+- `audit`: Same as `all-unauthenticated` but requests get flagged in logs and
+  metrics.
 
 This cluster-wide default can be overridden for specific resources by setting
 the annotation `config.linkerd.io/default-inbound-policy` on either a pod spec
@@ -62,9 +64,10 @@ overlapping `Server`s from being created.
 
 {{< note >}}
 When a Server resource is present, all traffic to the port on its pods will be
-denied (regardless of the default policy) unless explicitly authorized. Thus,
-Servers are typically paired with e.g. an AuthorizationPolicy that references
-the Server, or that reference an HTTPRoute that in turn references the Server.
+denied unless explicitly authorized or audit mode is enabled (with
+`accessPolicy:audit`). Thus, Servers are typically paired with e.g. an
+AuthorizationPolicy that references the Server, or that reference an HTTPRoute
+that in turn references the Server.
 {{< /note >}}
 
 ### Server Spec
@@ -74,10 +77,20 @@ A `Server` spec may contain the following top level fields:
 {{< table >}}
 | field| value |
 |------|-------|
+| `accessPolicy`| [accessPolicy](#accessPolicy) declares the policy applied to traffic not matching any associated authorization policies (defaults to `deny`). |
 | `podSelector`| A [podSelector](#podselector) selects pods in the same namespace. |
 | `port`| A port name or number. Only ports in a pod spec's `ports` are considered. |
 | `proxyProtocol`| Configures protocol discovery for inbound connections. Supersedes the `config.linkerd.io/opaque-ports` annotation. Must be one of `unknown`,`HTTP/1`,`HTTP/2`,`gRPC`,`opaque`,`TLS`. Defaults to `unknown` if not set. |
 {{< /table >}}
+
+#### accessPolicy
+
+Traffic that doesn't conform to the authorization policies associated to the
+Server are denied by default. You can alter that behavior by overriding the
+`accessPolicy` field, which accepts the same values as the [default
+policies](#default-policies). Of particular interest is the `audit` value, which
+enables [audit mode](../../features/server-policy/#audit-mode), that you can use
+to test policies before enforcing them.
 
 #### podSelector
 

--- a/linkerd.io/content/2.16/tasks/restricting-access.md
+++ b/linkerd.io/content/2.16/tasks/restricting-access.md
@@ -167,14 +167,16 @@ explicitly create an authorization to allow those probe requests. For more
 information about adding route-scoped authorizations, see
 [Configuring Per-Route Policy](../configuring-per-route-policy/).
 
-## Further Considerations
+## Further Considerations - Audit Mode
 
 You may have noticed that there was a period of time after we created the
 `Server` resource but before we created the `ServerAuthorization` where all
 requests were being rejected. To avoid this situation in live systems, we
-recommend you either create the policy resources before deploying your services
-or to create the `ServiceAuthorizations` BEFORE creating the `Server` so that
-clients will be authorized immediately.
+recommend that you enable [audit mode](../../features/server-policy/#audit-mode)
+in the `Server` resource (via `accessPolicy:audit`) and check the proxy
+logs/metrics in the target services to see if traffic would get inadvertently
+denied. Afterwards, when you're sure about your policy rules, you can fully
+enable them by resetting `accessPolicy` back to `deny`.
 
 ## Per-Route Policy
 


### PR DESCRIPTION
- Added Audit Mode section to the Authorization Policy feature article.
- Expanded the reference doc for `Servers` to include the new `accessPolicy` field.
- Updated the "Further Considerations" section in the Restricting Access To Services article to account for audit mode.
