### PR TITLE
Fix deprecated warnings for .Site.Social and .Site.Authors

### DIFF
--- a/linkerd.io/hugo.toml
+++ b/linkerd.io/hugo.toml
@@ -104,6 +104,8 @@ title = "Linkerd"
   latest_release_version = "1.7.5"
   latest_linkerd2_stable_version = "2.15"
   logo = "/images/identity/png/transparent_background/1x/linkerd_primary_color_black_transparent.png"
+  [params.social]
+    twitter = "linkerd"
 [permalinks]
   blog = "/:year/:month/:day/:slug/"
 [privacy.twitter]

--- a/linkerd.io/hugo.toml
+++ b/linkerd.io/hugo.toml
@@ -105,7 +105,7 @@ title = "Linkerd"
   latest_linkerd2_stable_version = "2.15"
   logo = "/images/identity/png/transparent_background/1x/linkerd_primary_color_black_transparent.png"
   [params.social]
-    twitter = "linkerd"
+    twitter = "Linkerd"
 [permalinks]
   blog = "/:year/:month/:day/:slug/"
 [privacy.twitter]

--- a/linkerd.io/themes/buoyant/layouts/partials/twitter-cards.html
+++ b/linkerd.io/themes/buoyant/layouts/partials/twitter-cards.html
@@ -24,13 +24,14 @@
 {{ end }}
 <meta name="twitter:title" content="{{ .Title }}"/>
 <meta name="twitter:description" content="{{ partial "description.html" . }}" />
-{{ with .Site.Social.twitter -}}
-  <meta name="twitter:site" content="@{{ . }}"/>
-{{ end -}}
-{{ range .Site.Authors }}
-  {{ with .twitter -}}
-    <meta name="twitter:creator" content="@{{ . }}"/>
-  {{ end -}}
-{{ end -}}
-
-
+{{ with site.Params.social }}
+  {{ if reflect.IsMap . }}
+    {{ with .twitter }}
+      {{ $content := . }}
+      {{ if not (strings.HasPrefix . "@") }}
+        {{ $content = printf "@%v" . }}
+      {{ end }}
+      <meta name="twitter:site" content="{{ $content }}">
+    {{ end }}
+  {{ end }}
+{{ end }}


### PR DESCRIPTION
In the latest release of Hugo, there's a couple warnings about deprecated collections that are being referenced:

```
WARN  deprecated: .Site.Social was deprecated in Hugo v0.124.0 and will be removed in a future release. Use .Site.Params instead.
WARN  deprecated: .Site.Authors was deprecated in Hugo v0.124.0 and will be removed in a future release. Use taxonomies instead.
```

Currently, neither one of these collections are configured in `hugo.toml`, so the meta tag for `twitter:site` and `twitter:creator` are not being rendered.

This PR addresses these warnings, with the following changes: 

`.Site.Social.twitter` has been updated to use `site.Params.social.twitter`, and this property has been set in `hugo.toml`, so `twitter:site` will now be rendered.

Support for `twitter:creator` has been removed, since Twitter usernames for blog authors are not present in `authors.json`. I don't think we need to add support for this either.
