### PR TITLE
Use "--dry-run=client"

### DIFF
--- a/linkerd.io/content/2-edge/tasks/configuring-dynamic-request-routing.md
+++ b/linkerd.io/content/2-edge/tasks/configuring-dynamic-request-routing.md
@@ -30,7 +30,7 @@ First we create the `test` namespace, annotated by linkerd so all pods that get
 created there get injected with the linkerd proxy:
 
 ``` bash
-kubectl create ns test --dry-run -o yaml \
+kubectl create ns test --dry-run=client -o yaml \
   | linkerd inject - \
   | kubectl apply -f -
 ```

--- a/linkerd.io/content/2.13/tasks/configuring-dynamic-request-routing.md
+++ b/linkerd.io/content/2.13/tasks/configuring-dynamic-request-routing.md
@@ -30,7 +30,7 @@ First we create the `test` namespace, annotated by linkerd so all pods that get
 created there get injected with the linkerd proxy:
 
 ``` bash
-kubectl create ns test --dry-run -o yaml \
+kubectl create ns test --dry-run=client -o yaml \
   | linkerd inject - \
   | kubectl apply -f -
 ```

--- a/linkerd.io/content/2.14/tasks/configuring-dynamic-request-routing.md
+++ b/linkerd.io/content/2.14/tasks/configuring-dynamic-request-routing.md
@@ -30,7 +30,7 @@ First we create the `test` namespace, annotated by linkerd so all pods that get
 created there get injected with the linkerd proxy:
 
 ``` bash
-kubectl create ns test --dry-run -o yaml \
+kubectl create ns test --dry-run=client -o yaml \
   | linkerd inject - \
   | kubectl apply -f -
 ```

--- a/linkerd.io/content/2.15/tasks/configuring-dynamic-request-routing.md
+++ b/linkerd.io/content/2.15/tasks/configuring-dynamic-request-routing.md
@@ -30,7 +30,7 @@ First we create the `test` namespace, annotated by linkerd so all pods that get
 created there get injected with the linkerd proxy:
 
 ``` bash
-kubectl create ns test --dry-run -o yaml \
+kubectl create ns test --dry-run=client -o yaml \
   | linkerd inject - \
   | kubectl apply -f -
 ```

--- a/linkerd.io/content/2.16/tasks/configuring-dynamic-request-routing.md
+++ b/linkerd.io/content/2.16/tasks/configuring-dynamic-request-routing.md
@@ -30,7 +30,7 @@ First we create the `test` namespace, annotated by linkerd so all pods that get
 created there get injected with the linkerd proxy:
 
 ``` bash
-kubectl create ns test --dry-run -o yaml \
+kubectl create ns test --dry-run=client -o yaml \
   | linkerd inject - \
   | kubectl apply -f -
 ```


### PR DESCRIPTION
`--dry-run` is deprecated

These were the only missing instances in the repository.