### PR TITLE
gh-api: list more releaeses per page

### DIFF
--- a/bin/export-channel-versions
+++ b/bin/export-channel-versions
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-releases_url="https://api.github.com/repos/linkerd/linkerd2/releases"
+releases_url="https://api.github.com/repos/linkerd/linkerd2/releases?per_page=100"
 
 # Match examples: `"tag_name": "stable-2.7.0",`
 stable_tag_regex="\"tag_name\": \"stable-[0-9]+\.[0-9]+\.[0-9]+\""


### PR DESCRIPTION
To grab the latest public stable, we need to go back quite a bit in time. The default pagination of 30 was not enough to include the latest stable. Eventually, this will cause trouble again so we need to figure out what to do with this logic. For now, this should unblock the edge release that was failing: https://github.com/linkerd/linkerd2/actions/runs/10826210923/job/30038512028