### PR TITLE
Apply misc. fixes to `Server` documentation

### DIFF
--- a/linkerd.io/content/2-edge/reference/authorization-policy.md
+++ b/linkerd.io/content/2-edge/reference/authorization-policy.md
@@ -43,7 +43,7 @@ policy in the cluster: [Server], [HTTPRoute], [ServerAuthorization],
 
 The general pattern for authorization is:
 
-- A `Server` describes and a set of pods, and a single port on those pods.
+- A `Server` describes a set of pods, and a single port on those pods.
 - Optionally, an `HTTPRoute` references that `Server` and describes a
   subset of HTTP traffic to it.
 - A `MeshTLSAuthentication` or `NetworkAuthentication` decribes who

--- a/linkerd.io/content/2-edge/reference/authorization-policy.md
+++ b/linkerd.io/content/2-edge/reference/authorization-policy.md
@@ -77,7 +77,7 @@ A `Server` spec may contain the following top level fields:
 {{< table >}}
 | field| value |
 |------|-------|
-| `accessPolicy`| [accessPolicy](#accessPolicy) declares the policy applied to traffic not matching any associated authorization policies (defaults to `deny`). |
+| `accessPolicy`| [accessPolicy](#accesspolicy) declares the policy applied to traffic not matching any associated authorization policies (defaults to `deny`). |
 | `podSelector`| A [podSelector](#podselector) selects pods in the same namespace. |
 | `port`| A port name or number. Only ports in a pod spec's `ports` are considered. |
 | `proxyProtocol`| Configures protocol discovery for inbound connections. Supersedes the `config.linkerd.io/opaque-ports` annotation. Must be one of `unknown`,`HTTP/1`,`HTTP/2`,`gRPC`,`opaque`,`TLS`. Defaults to `unknown` if not set. |

--- a/linkerd.io/content/2.12/reference/authorization-policy.md
+++ b/linkerd.io/content/2.12/reference/authorization-policy.md
@@ -41,7 +41,7 @@ policy in the cluster: [Server], [HTTPRoute], [ServerAuthorization],
 
 The general pattern for authorization is:
 
-- A `Server` describes and a set of pods, and a single port on those pods.
+- A `Server` describes a set of pods, and a single port on those pods.
 - Optionally, an `HTTPRoute` references that `Server` and describes a
   subset of HTTP traffic to it.
 - A `MeshTLSAuthentication` or `NetworkAuthentication` decribes who

--- a/linkerd.io/content/2.13/reference/authorization-policy.md
+++ b/linkerd.io/content/2.13/reference/authorization-policy.md
@@ -41,7 +41,7 @@ policy in the cluster: [Server], [HTTPRoute], [ServerAuthorization],
 
 The general pattern for authorization is:
 
-- A `Server` describes and a set of pods, and a single port on those pods.
+- A `Server` describes a set of pods, and a single port on those pods.
 - Optionally, an `HTTPRoute` references that `Server` and describes a
   subset of HTTP traffic to it.
 - A `MeshTLSAuthentication` or `NetworkAuthentication` decribes who

--- a/linkerd.io/content/2.14/reference/authorization-policy.md
+++ b/linkerd.io/content/2.14/reference/authorization-policy.md
@@ -41,7 +41,7 @@ policy in the cluster: [Server], [HTTPRoute], [ServerAuthorization],
 
 The general pattern for authorization is:
 
-- A `Server` describes and a set of pods, and a single port on those pods.
+- A `Server` describes a set of pods, and a single port on those pods.
 - Optionally, an `HTTPRoute` references that `Server` and describes a
   subset of HTTP traffic to it.
 - A `MeshTLSAuthentication` or `NetworkAuthentication` decribes who

--- a/linkerd.io/content/2.15/reference/authorization-policy.md
+++ b/linkerd.io/content/2.15/reference/authorization-policy.md
@@ -41,7 +41,7 @@ policy in the cluster: [Server], [HTTPRoute], [ServerAuthorization],
 
 The general pattern for authorization is:
 
-- A `Server` describes and a set of pods, and a single port on those pods.
+- A `Server` describes a set of pods, and a single port on those pods.
 - Optionally, an `HTTPRoute` references that `Server` and describes a
   subset of HTTP traffic to it.
 - A `MeshTLSAuthentication` or `NetworkAuthentication` decribes who

--- a/linkerd.io/content/2.16/reference/authorization-policy.md
+++ b/linkerd.io/content/2.16/reference/authorization-policy.md
@@ -43,7 +43,7 @@ policy in the cluster: [Server], [HTTPRoute], [ServerAuthorization],
 
 The general pattern for authorization is:
 
-- A `Server` describes and a set of pods, and a single port on those pods.
+- A `Server` describes a set of pods, and a single port on those pods.
 - Optionally, an `HTTPRoute` references that `Server` and describes a
   subset of HTTP traffic to it.
 - A `MeshTLSAuthentication` or `NetworkAuthentication` decribes who

--- a/linkerd.io/content/2.16/reference/authorization-policy.md
+++ b/linkerd.io/content/2.16/reference/authorization-policy.md
@@ -77,7 +77,7 @@ A `Server` spec may contain the following top level fields:
 {{< table >}}
 | field| value |
 |------|-------|
-| `accessPolicy`| [accessPolicy](#accessPolicy) declares the policy applied to traffic not matching any associated authorization policies (defaults to `deny`). |
+| `accessPolicy`| [accessPolicy](#accesspolicy) declares the policy applied to traffic not matching any associated authorization policies (defaults to `deny`). |
 | `podSelector`| A [podSelector](#podselector) selects pods in the same namespace. |
 | `port`| A port name or number. Only ports in a pod spec's `ports` are considered. |
 | `proxyProtocol`| Configures protocol discovery for inbound connections. Supersedes the `config.linkerd.io/opaque-ports` annotation. Must be one of `unknown`,`HTTP/1`,`HTTP/2`,`gRPC`,`opaque`,`TLS`. Defaults to `unknown` if not set. |


### PR DESCRIPTION
i noticed while perusing the reference pages for authorization policy types that the `accessPolicy` links were broken. this branch fixes that, and a typo i noticed along the way.