### PR TITLE
docs(reference): fix broken lints and address `markdownlint` warnings

### DIFF
--- a/linkerd.io/content/2-edge/reference/httproute.md
+++ b/linkerd.io/content/2-edge/reference/httproute.md
@@ -3,6 +3,10 @@ title = "HTTPRoute"
 description = "Reference guide to HTTPRoute resources."
 +++
 
+<!-- markdownlint-disable-file blanks-around-tables -->
+<!-- markdownlint-disable-file table-column-count -->
+<!-- markdownlint-disable-file table-pipe-style -->
+
 ## Linkerd and Gateway API HTTPRoutes
 
 The HTTPRoute resource was originally specified by the Kubernetes [Gateway API]

--- a/linkerd.io/content/2-edge/reference/httproute.md
+++ b/linkerd.io/content/2-edge/reference/httproute.md
@@ -40,7 +40,7 @@ An HTTPRoute spec may contain the following top level fields:
 {{< table >}}
 | field| value |
 |------|-------|
-| `parentRefs`| A set of [ParentReference](#parentreference)s which indicate which [Servers](#server) or Services this HTTPRoute attaches to.|
+| `parentRefs`| A set of [ParentReference](#parentreference)s which indicate which [Server]s or Services this HTTPRoute attaches to.|
 | `hostnames`| A set of hostnames that should match against the HTTP Host header.|
 | `rules`| An array of [HTTPRouteRules](#httprouterule).|
 {{< /table >}}
@@ -49,24 +49,21 @@ An HTTPRoute spec may contain the following top level fields:
 
 A reference to the parent resource this HTTPRoute is a part of.
 
-HTTPRoutes can be attached to a [Server](../authorization-policy/#server) to
-allow defining an [authorization
-policy](../authorization-policy/#authorizationpolicy) for specific routes served
-on that Server.
+HTTPRoutes can be attached to a [Server] to allow defining an [authorization
+policy](../authorization-policy/#authorizationpolicy) for specific routes
+served on that Server.
 
 HTTPRoutes can also be attached to a Service, in order to route requests
 depending on path, headers, query params, and/or verb. Requests can then be
 rerouted to different backend services. This can be used to perform [dynamic
 request routing](../../tasks/configuring-dynamic-request-routing/).
 
-{{< warning >}}
-**Outbound HTTPRoutes and [ServiceProfile](../../features/service-profiles/)s
-provide overlapping configuration.** For backwards-compatibility reasons, a
-ServiceProfile will take precedence over HTTPRoutes which configure the same
-Service. If a ServiceProfile is defined for the parent Service of an HTTPRoute,
-proxies will use the ServiceProfile configuration, rather than the HTTPRoute
-configuration, as long as the ServiceProfile exists.
-{{< /warning >}}
+{{< warning >}} **Outbound HTTPRoutes and [ServiceProfile]s provide overlapping
+configuration.** For backwards-compatibility reasons, a ServiceProfile will
+take precedence over HTTPRoutes which configure the same Service. If a
+ServiceProfile is defined for the parent Service of an HTTPRoute, proxies will
+use the ServiceProfile configuration, rather than the HTTPRoute configuration,
+as long as the ServiceProfile exists. {{< /warning >}}
 
 ParentReferences are namespaced, and may reference either a parent in the same
 namespace as the HTTPRoute, or one in a different namespace. As described in
@@ -222,7 +219,7 @@ A filter which modifies HTTP request or response headers.
 ### httpBackendRef
 
 `HTTPBackendRef` defines the list of objects where matching requests should be
-sent to. Only allowed when a route has Service [parentRefs](#parentReference).
+sent to. Only allowed when a route has Service [parentRefs](#parentreference).
 
 {{< table >}}
 | field| value |
@@ -318,4 +315,5 @@ spec:
 
 [ServiceProfile]: ../../features/service-profiles/
 [Gateway API]: https://gateway-api.sigs.k8s.io/
-[GEP-1426]: https://gateway-api.sigs.k8s.io/geps/gep-1426/#namespace-boundaries
+[ns-boundaries]: https://gateway-api.sigs.k8s.io/geps/gep-1426/#namespace-boundaries
+[Server]: ../authorization-policy/#server

--- a/linkerd.io/content/2.13/reference/httproute.md
+++ b/linkerd.io/content/2.13/reference/httproute.md
@@ -3,6 +3,10 @@ title = "HTTPRoute"
 description = "Reference guide to HTTPRoute resources."
 +++
 
+<!-- markdownlint-disable-file blanks-around-tables -->
+<!-- markdownlint-disable-file table-column-count -->
+<!-- markdownlint-disable-file table-pipe-style -->
+
 ## HTTPRoute Spec
 
 An HTTPRoute spec may contain the following top level fields:

--- a/linkerd.io/content/2.13/reference/httproute.md
+++ b/linkerd.io/content/2.13/reference/httproute.md
@@ -14,7 +14,7 @@ An HTTPRoute spec may contain the following top level fields:
 {{< table >}}
 | field| value |
 |------|-------|
-| `parentRefs`| A set of [ParentReference](#parentreference)s which indicate which [Servers](#server) or Services this HTTPRoute attaches to.|
+| `parentRefs`| A set of [ParentReference](#parentreference)s which indicate which [Server]s or Services this HTTPRoute attaches to.|
 | `hostnames`| A set of hostnames that should match against the HTTP Host header.|
 | `rules`| An array of [HTTPRouteRules](#httprouterule).|
 {{< /table >}}
@@ -23,10 +23,9 @@ An HTTPRoute spec may contain the following top level fields:
 
 A reference to the parent resource this HTTPRoute is a part of.
 
-HTTPRoutes can be attached to a [Server](../authorization-policy/#server) to
-allow defining an [authorization
-policy](../authorization-policy/#authorizationpolicy) for specific routes served
-on that Server.
+HTTPRoutes can be attached to a [Server] to allow defining an [authorization
+policy](../authorization-policy/#authorizationpolicy) for specific routes
+served on that Server.
 
 HTTPRoutes can also be attached to a Service, in order to route requests
 depending on path, headers, query params, and/or verb. Requests can then be
@@ -182,7 +181,7 @@ A filter which modifies request headers.
 ### httpBackendRef
 
 `HTTPBackendRef` defines the list of objects where matching requests should be
-sent to. Only allowed when a route has Service [parentRefs](#parentReference).
+sent to. Only allowed when a route has Service [parentRefs](#parentreference).
 
 {{< table >}}
 | field| value |
@@ -249,3 +248,5 @@ spec:
       - name: smiley
         port: 80
 ```
+
+[Server]: ../authorization-policy/#server

--- a/linkerd.io/content/2.14/reference/httproute.md
+++ b/linkerd.io/content/2.14/reference/httproute.md
@@ -3,6 +3,10 @@ title = "HTTPRoute"
 description = "Reference guide to HTTPRoute resources."
 +++
 
+<!-- markdownlint-disable-file blanks-around-tables -->
+<!-- markdownlint-disable-file table-column-count -->
+<!-- markdownlint-disable-file table-pipe-style -->
+
 ## Linkerd and Gateway API HTTPRoutes
 
 The HTTPRoute resource was originally specified by the Kubernetes [Gateway API]

--- a/linkerd.io/content/2.14/reference/httproute.md
+++ b/linkerd.io/content/2.14/reference/httproute.md
@@ -215,7 +215,7 @@ A filter which modifies HTTP request or response headers.
 ### httpBackendRef
 
 `HTTPBackendRef` defines the list of objects where matching requests should be
-sent to. Only allowed when a route has Service [parentRefs](#parentReference).
+sent to. Only allowed when a route has Service [parentRefs](#parentreference).
 
 {{< table >}}
 | field| value |
@@ -311,4 +311,4 @@ spec:
 
 [ServiceProfile]: ../../features/service-profiles/
 [Gateway API]: https://gateway-api.sigs.k8s.io/
-[GEP-1426]: https://gateway-api.sigs.k8s.io/geps/gep-1426/#namespace-boundaries
+[ns-boundaries]: https://gateway-api.sigs.k8s.io/geps/gep-1426/#namespace-boundaries

--- a/linkerd.io/content/2.15/reference/httproute.md
+++ b/linkerd.io/content/2.15/reference/httproute.md
@@ -3,6 +3,10 @@ title = "HTTPRoute"
 description = "Reference guide to HTTPRoute resources."
 +++
 
+<!-- markdownlint-disable-file blanks-around-tables -->
+<!-- markdownlint-disable-file table-column-count -->
+<!-- markdownlint-disable-file table-pipe-style -->
+
 ## Linkerd and Gateway API HTTPRoutes
 
 The HTTPRoute resource was originally specified by the Kubernetes [Gateway API]

--- a/linkerd.io/content/2.15/reference/httproute.md
+++ b/linkerd.io/content/2.15/reference/httproute.md
@@ -215,7 +215,7 @@ A filter which modifies HTTP request or response headers.
 ### httpBackendRef
 
 `HTTPBackendRef` defines the list of objects where matching requests should be
-sent to. Only allowed when a route has Service [parentRefs](#parentReference).
+sent to. Only allowed when a route has Service [parentRefs](#parentreference).
 
 {{< table >}}
 | field| value |
@@ -311,4 +311,5 @@ spec:
 
 [ServiceProfile]: ../../features/service-profiles/
 [Gateway API]: https://gateway-api.sigs.k8s.io/
+[ns-boundaries]: https://gateway-api.sigs.k8s.io/geps/gep-1426/#namespace-boundaries
 [GEP-1426]: https://gateway-api.sigs.k8s.io/geps/gep-1426/#namespace-boundaries

--- a/linkerd.io/content/2.16/reference/httproute.md
+++ b/linkerd.io/content/2.16/reference/httproute.md
@@ -40,7 +40,7 @@ An HTTPRoute spec may contain the following top level fields:
 {{< table >}}
 | field| value |
 |------|-------|
-| `parentRefs`| A set of [ParentReference](#parentreference)s which indicate which [Servers](#server) or Services this HTTPRoute attaches to.|
+| `parentRefs`| A set of [ParentReference](#parentreference)s which indicate which [Server]s or Services this HTTPRoute attaches to.|
 | `hostnames`| A set of hostnames that should match against the HTTP Host header.|
 | `rules`| An array of [HTTPRouteRules](#httprouterule).|
 {{< /table >}}
@@ -59,14 +59,12 @@ depending on path, headers, query params, and/or verb. Requests can then be
 rerouted to different backend services. This can be used to perform [dynamic
 request routing](../../tasks/configuring-dynamic-request-routing/).
 
-{{< warning >}}
-**Outbound HTTPRoutes and [ServiceProfile](../../features/service-profiles/)s
-provide overlapping configuration.** For backwards-compatibility reasons, a
-ServiceProfile will take precedence over HTTPRoutes which configure the same
-Service. If a ServiceProfile is defined for the parent Service of an HTTPRoute,
-proxies will use the ServiceProfile configuration, rather than the HTTPRoute
-configuration, as long as the ServiceProfile exists.
-{{< /warning >}}
+{{< warning >}} **Outbound HTTPRoutes and [ServiceProfile]s provide overlapping
+configuration.** For backwards-compatibility reasons, a ServiceProfile will
+take precedence over HTTPRoutes which configure the same Service. If a
+ServiceProfile is defined for the parent Service of an HTTPRoute, proxies will
+use the ServiceProfile configuration, rather than the HTTPRoute configuration,
+as long as the ServiceProfile exists. {{< /warning >}}
 
 ParentReferences are namespaced, and may reference either a parent in the same
 namespace as the HTTPRoute, or one in a different namespace. As described in
@@ -222,7 +220,7 @@ A filter which modifies HTTP request or response headers.
 ### httpBackendRef
 
 `HTTPBackendRef` defines the list of objects where matching requests should be
-sent to. Only allowed when a route has Service [parentRefs](#parentReference).
+sent to. Only allowed when a route has Service [parentRefs](#parentreference).
 
 {{< table >}}
 | field| value |
@@ -318,4 +316,5 @@ spec:
 
 [ServiceProfile]: ../../features/service-profiles/
 [Gateway API]: https://gateway-api.sigs.k8s.io/
-[GEP-1426]: https://gateway-api.sigs.k8s.io/geps/gep-1426/#namespace-boundaries
+[ns-boundaries]: https://gateway-api.sigs.k8s.io/geps/gep-1426/#namespace-boundaries
+[Server]: ../authorization-policy/#server

--- a/linkerd.io/content/2.16/reference/httproute.md
+++ b/linkerd.io/content/2.16/reference/httproute.md
@@ -3,6 +3,10 @@ title = "HTTPRoute"
 description = "Reference guide to HTTPRoute resources."
 +++
 
+<!-- markdownlint-disable-file blanks-around-tables -->
+<!-- markdownlint-disable-file table-column-count -->
+<!-- markdownlint-disable-file table-pipe-style -->
+
 ## Linkerd and Gateway API HTTPRoutes
 
 The HTTPRoute resource was originally specified by the Kubernetes [Gateway API]


### PR DESCRIPTION
while reviewing the documentation for `HTTPRoute` i found a number of broken links, a few of which were visibly misrendering on the website. this addresses most of these warnings (_i refrained from addressing `line-length` warnings_) and fixes the broken links. these fixes are applied to `2-edge` and backported to `2.13`, `2.14`, `2.15`, and `2.16` releases.

- fix broken `GEP-1426` links
- fix links to `#parentreference` anchor
- fix links to `Server` authorization policy
