### PR TITLE
Add missing \

### DIFF
--- a/linkerd.io/content/2-edge/tasks/automatically-rotating-webhook-tls-credentials.md
+++ b/linkerd.io/content/2-edge/tasks/automatically-rotating-webhook-tls-credentials.md
@@ -282,7 +282,7 @@ linkerd viz install \
   | kubectl apply -f -
 
 # ignore if not using the jaeger extension
-linkerd jaeger install
+linkerd jaeger install \
   --set webhook.externalSecret=true \
   --set-file webhook.caBundle=ca.crt \
   | kubectl apply -f -


### PR DESCRIPTION
```
linkerd jaeger install
  --set webhook.externalSecret=true \
  --set-file webhook.caBundle=ca.crt \
  | kubectl apply -f -
```

this command is missing a `\` at the end of the first line.