### PR TITLE
Update description about proxy wait

### DIFF
--- a/linkerd.io/data/cli-2-10.yaml
+++ b/linkerd.io/data/cli-2-10.yaml
@@ -61,7 +61,7 @@ AnnotationsReference:
   Name: config.linkerd.io/enable-debug-sidecar
 - Description: Used to configure the outbound TCP connection timeout in the proxy
   Name: config.linkerd.io/proxy-outbound-connect-timeout
-- Description: The proxy sidecar will stay alive for at least the given period before
+- Description: Adds a preStop hook to the proxy container to delay
     receiving SIGTERM signal from Kubernetes but no longer than pod's `terminationGracePeriodSeconds`.
     If not provided, it will be defaulted to `0`
   Name: config.alpha.linkerd.io/proxy-wait-before-exit-seconds
@@ -2785,4 +2785,3 @@ CLIReference:
   SeeAlso: null
   Synopsis: |
     viz manages the linkerd-viz extension of Linkerd service mesh
-

--- a/linkerd.io/data/cli-2-11.yaml
+++ b/linkerd.io/data/cli-2-11.yaml
@@ -61,7 +61,7 @@ AnnotationsReference:
   Name: config.linkerd.io/enable-debug-sidecar
 - Description: Used to configure the outbound TCP connection timeout in the proxy
   Name: config.linkerd.io/proxy-outbound-connect-timeout
-- Description: The proxy sidecar will stay alive for at least the given period before
+- Description: Adds a preStop hook to the proxy container to delay
     receiving SIGTERM signal from Kubernetes but no longer than pod's `terminationGracePeriodSeconds`.
     If not provided, it will be defaulted to `0`
   Name: config.alpha.linkerd.io/proxy-wait-before-exit-seconds
@@ -2815,4 +2815,3 @@ CLIReference:
   SeeAlso: null
   Synopsis: |
     viz manages the linkerd-viz extension of Linkerd service mesh
-

--- a/linkerd.io/data/cli-2-12.yaml
+++ b/linkerd.io/data/cli-2-12.yaml
@@ -75,7 +75,7 @@ AnnotationsReference:
   Name: config.linkerd.io/proxy-outbound-connect-timeout
 - Description: Inbound TCP connection timeout in the proxy
   Name: config.linkerd.io/proxy-inbound-connect-timeout
-- Description: The proxy sidecar will stay alive for at least the given period before
+- Description: Adds a preStop hook to the proxy container to delay
     receiving SIGTERM signal from Kubernetes but no longer than pod's `terminationGracePeriodSeconds`.
     Defaults to `0`
   Name: config.alpha.linkerd.io/proxy-wait-before-exit-seconds

--- a/linkerd.io/data/cli-2-12.yaml
+++ b/linkerd.io/data/cli-2-12.yaml
@@ -75,7 +75,7 @@ AnnotationsReference:
   Name: config.linkerd.io/proxy-outbound-connect-timeout
 - Description: Inbound TCP connection timeout in the proxy
   Name: config.linkerd.io/proxy-inbound-connect-timeout
-- Description: The proxy sidecar will stay alive for at least the given period after
+- Description: The proxy sidecar will stay alive for at least the given period before
     receiving SIGTERM signal from Kubernetes but no longer than pod's `terminationGracePeriodSeconds`.
     Defaults to `0`
   Name: config.alpha.linkerd.io/proxy-wait-before-exit-seconds
@@ -2321,4 +2321,3 @@ CLIReference:
   SeeAlso: null
   Synopsis: |
     viz manages the linkerd-viz extension of Linkerd service mesh
-

--- a/linkerd.io/data/cli-2-13.yaml
+++ b/linkerd.io/data/cli-2-13.yaml
@@ -81,7 +81,7 @@ AnnotationsReference:
 - Description: Maximum time allowed before an unused inbound discovery result is evicted
     from the cache. Defaults to `90s`
   Name: config.linkerd.io/proxy-inbound-discovery-cache-unused-timeout
-- Description: The proxy sidecar will stay alive for at least the given period after
+- Description: The proxy sidecar will stay alive for at least the given period before
     receiving SIGTERM signal from Kubernetes but no longer than pod's `terminationGracePeriodSeconds`.
     Defaults to `0`
   Name: config.alpha.linkerd.io/proxy-wait-before-exit-seconds
@@ -2552,4 +2552,3 @@ CLIReference:
   SeeAlso: null
   Synopsis: |
     viz manages the linkerd-viz extension of Linkerd service mesh
-

--- a/linkerd.io/data/cli-2-13.yaml
+++ b/linkerd.io/data/cli-2-13.yaml
@@ -81,7 +81,7 @@ AnnotationsReference:
 - Description: Maximum time allowed before an unused inbound discovery result is evicted
     from the cache. Defaults to `90s`
   Name: config.linkerd.io/proxy-inbound-discovery-cache-unused-timeout
-- Description: The proxy sidecar will stay alive for at least the given period before
+- Description: Adds a preStop hook to the proxy container to delay
     receiving SIGTERM signal from Kubernetes but no longer than pod's `terminationGracePeriodSeconds`.
     Defaults to `0`
   Name: config.alpha.linkerd.io/proxy-wait-before-exit-seconds

--- a/linkerd.io/data/cli-2-14.yaml
+++ b/linkerd.io/data/cli-2-14.yaml
@@ -87,7 +87,7 @@ AnnotationsReference:
 - Description: When set to true, disables the protocol detection timeout on the inbound
     side of the proxy by setting it to a very high value
   Name: config.linkerd.io/proxy-disable-inbound-protocol-detect-timeout
-- Description: The proxy sidecar will stay alive for at least the given period before
+- Description: Adds a preStop hook to the proxy container to delay
     receiving SIGTERM signal from Kubernetes but no longer than pod's `terminationGracePeriodSeconds`.
     Defaults to `0`
   Name: config.alpha.linkerd.io/proxy-wait-before-exit-seconds

--- a/linkerd.io/data/cli-2-14.yaml
+++ b/linkerd.io/data/cli-2-14.yaml
@@ -87,7 +87,7 @@ AnnotationsReference:
 - Description: When set to true, disables the protocol detection timeout on the inbound
     side of the proxy by setting it to a very high value
   Name: config.linkerd.io/proxy-disable-inbound-protocol-detect-timeout
-- Description: The proxy sidecar will stay alive for at least the given period after
+- Description: The proxy sidecar will stay alive for at least the given period before
     receiving SIGTERM signal from Kubernetes but no longer than pod's `terminationGracePeriodSeconds`.
     Defaults to `0`
   Name: config.alpha.linkerd.io/proxy-wait-before-exit-seconds
@@ -2603,4 +2603,3 @@ CLIReference:
   SeeAlso: null
   Synopsis: |
     viz manages the linkerd-viz extension of Linkerd service mesh
-

--- a/linkerd.io/data/cli-2-15.yaml
+++ b/linkerd.io/data/cli-2-15.yaml
@@ -87,7 +87,7 @@ AnnotationsReference:
 - Description: When set to true, disables the protocol detection timeout on the inbound
     side of the proxy by setting it to a very high value
   Name: config.linkerd.io/proxy-disable-inbound-protocol-detect-timeout
-- Description: The proxy sidecar will stay alive for at least the given period after
+- Description: The proxy sidecar will stay alive for at least the given period before
     receiving SIGTERM signal from Kubernetes but no longer than pod's `terminationGracePeriodSeconds`.
     Defaults to `0`
   Name: config.alpha.linkerd.io/proxy-wait-before-exit-seconds
@@ -2620,4 +2620,3 @@ CLIReference:
   SeeAlso: null
   Synopsis: |
     viz manages the linkerd-viz extension of Linkerd service mesh
-

--- a/linkerd.io/data/cli-2-15.yaml
+++ b/linkerd.io/data/cli-2-15.yaml
@@ -87,7 +87,7 @@ AnnotationsReference:
 - Description: When set to true, disables the protocol detection timeout on the inbound
     side of the proxy by setting it to a very high value
   Name: config.linkerd.io/proxy-disable-inbound-protocol-detect-timeout
-- Description: The proxy sidecar will stay alive for at least the given period before
+- Description: Adds a preStop hook to the proxy container to delay
     receiving SIGTERM signal from Kubernetes but no longer than pod's `terminationGracePeriodSeconds`.
     Defaults to `0`
   Name: config.alpha.linkerd.io/proxy-wait-before-exit-seconds

--- a/linkerd.io/data/cli-2-16.yaml
+++ b/linkerd.io/data/cli-2-16.yaml
@@ -90,7 +90,7 @@ AnnotationsReference:
 - Description: When set to true, disables the protocol detection timeout on the inbound
     side of the proxy by setting it to a very high value
   Name: config.linkerd.io/proxy-disable-inbound-protocol-detect-timeout
-- Description: The proxy sidecar will stay alive for at least the given period before
+- Description: Adds a preStop hook to the proxy container to delay
     receiving SIGTERM signal from Kubernetes but no longer than pod's `terminationGracePeriodSeconds`.
     Defaults to `0`
   Name: config.alpha.linkerd.io/proxy-wait-before-exit-seconds

--- a/linkerd.io/data/cli-2-16.yaml
+++ b/linkerd.io/data/cli-2-16.yaml
@@ -90,7 +90,7 @@ AnnotationsReference:
 - Description: When set to true, disables the protocol detection timeout on the inbound
     side of the proxy by setting it to a very high value
   Name: config.linkerd.io/proxy-disable-inbound-protocol-detect-timeout
-- Description: The proxy sidecar will stay alive for at least the given period after
+- Description: The proxy sidecar will stay alive for at least the given period before
     receiving SIGTERM signal from Kubernetes but no longer than pod's `terminationGracePeriodSeconds`.
     Defaults to `0`
   Name: config.alpha.linkerd.io/proxy-wait-before-exit-seconds
@@ -2760,4 +2760,3 @@ CLIReference:
   SeeAlso: null
   Synopsis: |
     viz manages the linkerd-viz extension of Linkerd service mesh
-

--- a/linkerd.io/data/cli-2-edge.yaml
+++ b/linkerd.io/data/cli-2-edge.yaml
@@ -87,7 +87,7 @@ AnnotationsReference:
 - Description: When set to true, disables the protocol detection timeout on the inbound
     side of the proxy by setting it to a very high value
   Name: config.linkerd.io/proxy-disable-inbound-protocol-detect-timeout
-- Description: The proxy sidecar will stay alive for at least the given period after
+- Description: The proxy sidecar will stay alive for at least the given period before
     receiving SIGTERM signal from Kubernetes but no longer than pod's `terminationGracePeriodSeconds`.
     Defaults to `0`
   Name: config.alpha.linkerd.io/proxy-wait-before-exit-seconds
@@ -2620,4 +2620,3 @@ CLIReference:
   SeeAlso: null
   Synopsis: |
     viz manages the linkerd-viz extension of Linkerd service mesh
-

--- a/linkerd.io/data/cli-2-edge.yaml
+++ b/linkerd.io/data/cli-2-edge.yaml
@@ -87,7 +87,7 @@ AnnotationsReference:
 - Description: When set to true, disables the protocol detection timeout on the inbound
     side of the proxy by setting it to a very high value
   Name: config.linkerd.io/proxy-disable-inbound-protocol-detect-timeout
-- Description: The proxy sidecar will stay alive for at least the given period before
+- Description: Adds a preStop hook to the proxy container to delay
     receiving SIGTERM signal from Kubernetes but no longer than pod's `terminationGracePeriodSeconds`.
     Defaults to `0`
   Name: config.alpha.linkerd.io/proxy-wait-before-exit-seconds

--- a/linkerd.io/data/cli.yaml
+++ b/linkerd.io/data/cli.yaml
@@ -52,7 +52,7 @@ AnnotationsReference:
 - Description: The trace collector's service account name. E.g., `tracing-service-account`.
     If not provided, it will be defaulted to `default`.
   Name: config.alpha.linkerd.io/trace-collector-service-account
-- Description: The proxy sidecar will stay alive for at least the given period before
+- Description: Adds a preStop hook to the proxy container to delay
     receiving SIGTERM signal from Kubernetes but no longer than pod's `terminationGracePeriodSeconds`.
     If not provided, it will be defaulted to `0`
   Name: config.alpha.linkerd.io/proxy-wait-before-exit-seconds
@@ -1890,4 +1890,3 @@ CLIReference:
     Usage: Print the version number(s) only, with no additional output
   SeeAlso: null
   Synopsis: Print the client and server version information
-


### PR DESCRIPTION
While reading https://linkerd.io/2.16/tasks/graceful-shutdown/ 
and https://linkerd.io/2.16/reference/proxy-configuration/ , 
I was a little confused about `config.alpha.linkerd.io/proxy-wait-before-exit-seconds`.

So let me suggest new description about it.

I think it's important when SIGTERM is received.
>When the Linkerd proxy sidecar receives this signal, it will **immediately begin a graceful shutdown where it refuses all new requests** and allows existing requests to complete before shutting down.