### PR TITLE
Reordered frontmatter params in blog

### DIFF
--- a/linkerd.io/content/blog/2016/0316-beyond-round-robin-load-balancing-for-latency/index.md
+++ b/linkerd.io/content/blog/2016/0316-beyond-round-robin-load-balancing-for-latency/index.md
@@ -1,7 +1,7 @@
 ---
+date: 2016-03-16T00:00:00Z
 title: |-
   Beyond Round Robin: Load Balancing for Latency
-date: 2016-03-16T00:00:00Z
 keywords: [article, buoyant, education, linkerd]
 params:
   author: steve

--- a/linkerd.io/content/blog/2016/1210-slow-cooker-load-testing-for-tough-software/index.md
+++ b/linkerd.io/content/blog/2016/1210-slow-cooker-load-testing-for-tough-software/index.md
@@ -1,7 +1,7 @@
 ---
+date: 2016-12-10T00:00:00Z
 title: |-
   Slow Cooker: Load testing for tough software
-date: 2016-12-10T00:00:00Z
 tags: [buoyant, news, product, announcement]
 params:
   author: steve

--- a/linkerd.io/content/blog/2017/0124-linkerd-joins-the-cloud-native-computing-foundation/index.md
+++ b/linkerd.io/content/blog/2017/0124-linkerd-joins-the-cloud-native-computing-foundation/index.md
@@ -1,6 +1,6 @@
 ---
-title: Linkerd Joins the Cloud Native Computing Foundation
 date: 2017-01-24T00:00:00Z
+title: Linkerd Joins the Cloud Native Computing Foundation
 aliases:
   - /2017/01/23/linkerd-joins-the-cloud-native-computing-foundation/
 tags: [buoyant, linkerd, news]

--- a/linkerd.io/content/blog/2018/0918-announcing-linkerd-2-0/index.md
+++ b/linkerd.io/content/blog/2018/0918-announcing-linkerd-2-0/index.md
@@ -1,7 +1,7 @@
 ---
-title: Announcing Linkerd 2.0
 date: 2018-09-18T00:00:00Z
 slug: announcing-linkerd-2-0
+title: Announcing Linkerd 2.0
 keywords: [cloud-native, community, kubernetes, linkerd, microservices, news]
 params:
   author: william

--- a/linkerd.io/content/blog/2018/0921-tgikubernetesepisode051/index.md
+++ b/linkerd.io/content/blog/2018/0921-tgikubernetesepisode051/index.md
@@ -1,7 +1,7 @@
 ---
-title: TGI Kubernetes Features Linkerd 2.0
 date: 2018-09-21T00:00:00Z
 slug: tgikubernetesepisode051
+title: TGI Kubernetes Features Linkerd 2.0
 keywords: [community, events, linkerd, tutorials, webinars]
 params:
   author: kiersten

--- a/linkerd.io/content/blog/2018/1019-the-linkerd-enthusiasts-guide-to-kubecon-na-2018-2/index.md
+++ b/linkerd.io/content/blog/2018/1019-the-linkerd-enthusiasts-guide-to-kubecon-na-2018-2/index.md
@@ -1,7 +1,7 @@
 ---
-title: The Linkerd Enthusiast’s Guide to Kubecon NA 2018
 date: 2018-10-19T00:00:00Z
 slug: the-linkerd-enthusiasts-guide-to-kubecon-na-2018-2
+title: The Linkerd Enthusiast’s Guide to Kubecon NA 2018
 keywords: [buoyant, community, events, linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2018/1023-a-linkerd-2-0-deep-dive-unboxing-debugging-and-monitoring-kubernetes-services-on-azure/index.md
+++ b/linkerd.io/content/blog/2018/1023-a-linkerd-2-0-deep-dive-unboxing-debugging-and-monitoring-kubernetes-services-on-azure/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2018-10-23T00:00:00Z
+slug: a-linkerd-2-0-deep-dive-unboxing-debugging-and-monitoring-kubernetes-services-on-azure
 title: |-
   A Linkerd 2.0 Deep Dive Unboxing: Debugging and Monitoring Kubernetes Services
   on Azure
-date: 2018-10-23T00:00:00Z
-slug: a-linkerd-2-0-deep-dive-unboxing-debugging-and-monitoring-kubernetes-services-on-azure
 tags: [community, linkerd, tutorials, video]
 params:
   author: william

--- a/linkerd.io/content/blog/2018/1102-debugging-node-js-on-kubernetes-with-linkerd/index.md
+++ b/linkerd.io/content/blog/2018/1102-debugging-node-js-on-kubernetes-with-linkerd/index.md
@@ -1,7 +1,7 @@
 ---
-title: Debugging Node.js on Kubernetes with Linkerd
 date: 2018-11-02T00:00:00Z
 slug: debugging-node-js-on-kubernetes-with-linkerd
+title: Debugging Node.js on Kubernetes with Linkerd
 keyword: [community, events, linkerd, news]
 params:
   author: kiersten

--- a/linkerd.io/content/blog/2018/1105-debugging-and-monitoring-your-kubernetes-services-with-linkerd-2-0/index.md
+++ b/linkerd.io/content/blog/2018/1105-debugging-and-monitoring-your-kubernetes-services-with-linkerd-2-0/index.md
@@ -1,7 +1,7 @@
 ---
-title: Debugging and Monitoring your Kubernetes Services with Linkerd 2.0
 date: 2018-11-05T00:00:00Z
 slug: debugging-and-monitoring-your-kubernetes-services-with-linkerd-2-0
+title: Debugging and Monitoring your Kubernetes Services with Linkerd 2.0
 keywords: [community, events, linkerd, tutorials, webinars]
 params:
   author: kiersten

--- a/linkerd.io/content/blog/2018/1113-debugging-node-services-in-kubernetes-with-linkerd-2-0/index.md
+++ b/linkerd.io/content/blog/2018/1113-debugging-node-services-in-kubernetes-with-linkerd-2-0/index.md
@@ -1,7 +1,7 @@
 ---
-title: Debugging Node Services in Kubernetes With Linkerd 2.0
 date: 2018-11-13T00:00:00Z
 slug: debugging-node-services-in-kubernetes-with-linkerd-2-0
+title: Debugging Node Services in Kubernetes With Linkerd 2.0
 keywords: [community, linkerd, tutorials]
 params:
   author: thomas

--- a/linkerd.io/content/blog/2018/1114-grpc-load-balancing-on-kubernetes-without-tears/index.md
+++ b/linkerd.io/content/blog/2018/1114-grpc-load-balancing-on-kubernetes-without-tears/index.md
@@ -1,6 +1,6 @@
 ---
-title: gRPC Load Balancing on Kubernetes without Tears
 date: 2018-11-14T00:00:00Z
+title: gRPC Load Balancing on Kubernetes without Tears
 keywords: [community, industry perspectives, linkerd, tutorials]
 params:
   author: william

--- a/linkerd.io/content/blog/2018/1206-announcing-linkerd-2-1/index.md
+++ b/linkerd.io/content/blog/2018/1206-announcing-linkerd-2-1/index.md
@@ -1,7 +1,7 @@
 ---
-title: Announcing Linkerd 2.1
 date: 2018-12-06T00:00:00Z
 slug: announcing-linkerd-2-1
+title: Announcing Linkerd 2.1
 keywords: [news]
 params:
   author: william

--- a/linkerd.io/content/blog/2018/1208-service-profiles-for-per-route-metrics/index.md
+++ b/linkerd.io/content/blog/2018/1208-service-profiles-for-per-route-metrics/index.md
@@ -1,6 +1,6 @@
 ---
-title: Service Profiles for Per-Route Metrics
 date: 2018-12-08T00:00:00Z
+title: Service Profiles for Per-Route Metrics
 aliases:
   - /2018/12/07/service-profiles-for-per-route-metrics/
 keywords: [community, integrations, linkerd, news, "release notes", tutorials]

--- a/linkerd.io/content/blog/2019/0202-debugging-ruby-services-in-kubernetes-with-linkerd/index.md
+++ b/linkerd.io/content/blog/2019/0202-debugging-ruby-services-in-kubernetes-with-linkerd/index.md
@@ -1,6 +1,6 @@
 ---
-title: Debugging Ruby Services in Kubernetes With Linkerd
 date: 2019-02-02T00:00:00Z
+title: Debugging Ruby Services in Kubernetes With Linkerd
 aliases:
   - /2019/02/01/debugging-ruby-services-in-kubernetes-with-linkerd/
 keywords: [community, linkerd, tutorials]

--- a/linkerd.io/content/blog/2019/0212-announcing-linkerd-2-2/index.md
+++ b/linkerd.io/content/blog/2019/0212-announcing-linkerd-2-2/index.md
@@ -1,7 +1,7 @@
 ---
-title: Announcing Linkerd 2.2
 date: 2019-02-12T00:00:00Z
 slug: announcing-linkerd-2-2
+title: Announcing Linkerd 2.2
 keywords: [buoyant, linkerd, news]
 params:
   author: william

--- a/linkerd.io/content/blog/2019/0222-how-we-designed-retries-in-linkerd-2-2/index.md
+++ b/linkerd.io/content/blog/2019/0222-how-we-designed-retries-in-linkerd-2-2/index.md
@@ -1,7 +1,7 @@
 ---
-title: How we designed retries in Linkerd 2.2
 date: 2019-02-22T00:00:00Z
 slug: how-we-designed-retries-in-linkerd-2-2
+title: How we designed retries in Linkerd 2.2
 keywords: [news]
 params:
   author: alex

--- a/linkerd.io/content/blog/2019/0329-icymi-march-2019-san-francisco-linkerd-meetup/index.md
+++ b/linkerd.io/content/blog/2019/0329-icymi-march-2019-san-francisco-linkerd-meetup/index.md
@@ -1,7 +1,7 @@
 ---
+date: 2019-03-29T00:00:00Z
 title: |-
   ICYMI: March 2019 San Francisco Linkerd Meetup
-date: 2019-03-29T00:00:00Z
 params:
   author: kiersten
 ---

--- a/linkerd.io/content/blog/2019/0410-browser-testing-from-scratch-building-quick-and-easy-integration-tests-with-webdriverio-and-saucelabs/index.md
+++ b/linkerd.io/content/blog/2019/0410-browser-testing-from-scratch-building-quick-and-easy-integration-tests-with-webdriverio-and-saucelabs/index.md
@@ -1,8 +1,8 @@
 ---
+date: 2019-04-10T00:00:00Z
 title: |-
   Browser Testing from Scratch: Building Quick and Easy Integration Tests with
   WebdriverIO and SauceLabs
-date: 2019-04-10T00:00:00Z
 keywords: [linkerd, news, tutorials]
 params:
   author: carol

--- a/linkerd.io/content/blog/2019/0416-announcing-linkerd-2-3/index.md
+++ b/linkerd.io/content/blog/2019/0416-announcing-linkerd-2-3/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2019-04-16T00:00:00Z
+slug: announcing-linkerd-2.3
 title: |-
   Announcing Linkerd 2.3: Towards Zero-Touch Zero-Trust Networking for
   Kubernetes
-date: 2019-04-16T00:00:00Z
-slug: announcing-linkerd-2.3
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2019/0429-design-principles/index.md
+++ b/linkerd.io/content/blog/2019/0429-design-principles/index.md
@@ -1,7 +1,7 @@
 ---
-title: Linkerd's design principles
 date: 2019-04-29T00:00:00Z
 slug: linkerd-design-principles
+title: Linkerd's design principles
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2019/0512-icymi-may-2019-san-francisco-linkerd-meetup/index.md
+++ b/linkerd.io/content/blog/2019/0512-icymi-may-2019-san-francisco-linkerd-meetup/index.md
@@ -1,7 +1,7 @@
 ---
+date: 2019-05-12T00:00:00Z
 title: |-
   ICYMI: May 2019 San Francisco Linkerd Meetup
-date: 2019-05-12T00:00:00Z
 keywords: [community, linkerd]
 params:
   author: kiersten

--- a/linkerd.io/content/blog/2019/0518-linkerd-benchmarks/index.md
+++ b/linkerd.io/content/blog/2019/0518-linkerd-benchmarks/index.md
@@ -1,6 +1,6 @@
 ---
-title: Linkerd Benchmarks
 date: 2019-05-18T00:00:00Z
+title: Linkerd Benchmarks
 keywords: [community, linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2019/0524-smi/index.md
+++ b/linkerd.io/content/blog/2019/0524-smi/index.md
@@ -1,6 +1,6 @@
 ---
-title: Linkerd and SMI
 date: 2024-05-24T00:00:00Z
+title: Linkerd and SMI
 keywords: [community, linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2019/0531-kubecon-eu-2019-linkerd-roundup/index.md
+++ b/linkerd.io/content/blog/2019/0531-kubecon-eu-2019-linkerd-roundup/index.md
@@ -1,7 +1,7 @@
 ---
+date: 2019-05-31T00:00:00Z
 title: |-
   Linkerd at KubeCon EU 2019: Benchmarks, SMI, VSCode, and more
-date: 2019-05-31T00:00:00Z
 keywords: [community, linkerd, kubecon]
 params:
   author: william

--- a/linkerd.io/content/blog/2019/0711-announcing-linkerd-2-4/index.md
+++ b/linkerd.io/content/blog/2019/0711-announcing-linkerd-2-4/index.md
@@ -1,8 +1,8 @@
 ---
-title: |-
-  Announcing Linkerd 2.4: Traffic Splitting and SMI
 date: 2019-07-11T00:00:00Z
 slug: announcing-linkerd-2.4
+title: |-
+  Announcing Linkerd 2.4: Traffic Splitting and SMI
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2019/0718-failure-injection-using-the-service-mesh-interface-and-linkerd/index.md
+++ b/linkerd.io/content/blog/2019/0718-failure-injection-using-the-service-mesh-interface-and-linkerd/index.md
@@ -1,6 +1,6 @@
 ---
-title: Failure Injection using the Service Mesh Interface and Linkerd
 date: 2019-07-18T00:00:00Z
+title: Failure Injection using the Service Mesh Interface and Linkerd
 keywords: [linkerd]
 params:
   author: alex

--- a/linkerd.io/content/blog/2019/0731-icymi-july-linkerd-community-meetup/index.md
+++ b/linkerd.io/content/blog/2019/0731-icymi-july-linkerd-community-meetup/index.md
@@ -1,11 +1,11 @@
 ---
+date: 2019-07-31T00:00:00Z
 title: |-
   ICYMI 👉 July Linkerd Community Meetup
 description: |-
   In this month's community meeting, Oliver, Thomas, and special guests Stefan
   Prodan, creator of the project, and Carol Scott, Linkerd maintainer
   extraordinaire, discussed ...
-date: 2019-07-31T00:00:00Z
 keywords: [linkerd, community, meetup]
 params:
   author: kiersten

--- a/linkerd.io/content/blog/2019/0809-service-mesh-distributed-tracing-myths/index.md
+++ b/linkerd.io/content/blog/2019/0809-service-mesh-distributed-tracing-myths/index.md
@@ -1,4 +1,6 @@
 ---
+date: 2019-08-09T00:00:00Z
+slug: service-mesh-distributed-tracing-myths
 title: |-
   Distributed tracing in the service mesh: four myths
 description: |-
@@ -6,8 +8,6 @@ description: |-
   tracing. We're happy to report that this feature is on the near-term Linkerd
   roadmap. Unfortunately, we've found that many of the people asking for this
   feature don't quite understand what they're asking for.
-date: 2019-08-09T00:00:00Z
-slug: service-mesh-distributed-tracing-myths
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2019/0820-announcing-linkerd-2-5/index.md
+++ b/linkerd.io/content/blog/2019/0820-announcing-linkerd-2-5/index.md
@@ -1,8 +1,8 @@
 ---
-title: |-
-  Announcing Linkerd 2.5: Helm support and RBAC-aware tap
 date: 2019-08-20T00:00:00Z
 slug: announcing-linkerd-2.5
+title: |-
+  Announcing Linkerd 2.5: Helm support and RBAC-aware tap
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2019/0828-icymi-august-2019-linkerd-community-meetup/index.md
+++ b/linkerd.io/content/blog/2019/0828-icymi-august-2019-linkerd-community-meetup/index.md
@@ -1,7 +1,7 @@
 ---
+date: 2019-08-28T00:00:00Z
 title: |-
   ICYMI 👉 August Linkerd Community Meetup
-date: 2019-08-28T00:00:00Z
 params:
   author: kiersten
 ---

--- a/linkerd.io/content/blog/2019/0918-happy-birthday-linkerd/index.md
+++ b/linkerd.io/content/blog/2019/0918-happy-birthday-linkerd/index.md
@@ -1,7 +1,7 @@
 ---
-title: Linkerd 2.x turns one year old! 🎂
 date: 2019-09-18T00:00:00Z
 slug: happy-birthday-linkerd
+title: Linkerd 2.x turns one year old! 🎂
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2019/1003-linkerd-and-open-governance/index.md
+++ b/linkerd.io/content/blog/2019/1003-linkerd-and-open-governance/index.md
@@ -1,6 +1,6 @@
 ---
-title: Linkerd's Commitment to Open Governance
 date: 2019-10-03T00:00:00Z
+title: Linkerd's Commitment to Open Governance
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2019/1007-linkerd-distributed-tracing/index.md
+++ b/linkerd.io/content/blog/2019/1007-linkerd-distributed-tracing/index.md
@@ -1,6 +1,6 @@
 ---
-title: A guide to distributed tracing with Linkerd
 date: 2019-10-07T00:00:00Z
+title: A guide to distributed tracing with Linkerd
 keywords: [linkerd]
 params:
   author: alex

--- a/linkerd.io/content/blog/2019/1010-announcing-linkerd-2-6/index.md
+++ b/linkerd.io/content/blog/2019/1010-announcing-linkerd-2-6/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2019-10-10T00:00:00Z
+slug: announcing-linkerd-2.6
 title: |-
   Announcing Linkerd 2.6: Distributed tracing, live request headers, faster
   dashboard, and more!
-date: 2019-10-10T00:00:00Z
-slug: announcing-linkerd-2.6
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2019/1126-kubecon-na-2019-linkerd-roundup/index.md
+++ b/linkerd.io/content/blog/2019/1126-kubecon-na-2019-linkerd-roundup/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2019-11-26T00:00:00Z
+slug: linkerd-at-kubecon-na-2019-roundup
 title: |-
   Linkerd at Kubecon NA 2019 roundup: Nordstrom, Microsoft, OpenFaaS, PayBase,
   and lots of community!
-date: 2019-11-26T00:00:00Z
-slug: linkerd-at-kubecon-na-2019-roundup
 keywords: [community, linkerd, kubecon]
 params:
   author: william

--- a/linkerd.io/content/blog/2020/0210-announcing-linkerd-2-7/index.md
+++ b/linkerd.io/content/blog/2020/0210-announcing-linkerd-2-7/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2020-02-10T00:00:00Z
+slug: announcing-linkerd-2.7
 title: |-
   Announcing Linkerd 2.7: External PKI support, better gitops workflows,
   streamlined cert rotation, and more
-date: 2020-02-10T00:00:00Z
-slug: announcing-linkerd-2.7
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2020/0217-architecting-multicluster/index.md
+++ b/linkerd.io/content/blog/2020/0217-architecting-multicluster/index.md
@@ -1,6 +1,6 @@
 ---
-title: Architecting for Multicluster Kubernetes
 date: 2020-02-17T00:00:00Z
+title: Architecting for Multicluster Kubernetes
 keywords: [linkerd, multicluster]
 params:
   author: thomas

--- a/linkerd.io/content/blog/2020/0225-multicluster-kubernetes-with-service-mirroring/index.md
+++ b/linkerd.io/content/blog/2020/0225-multicluster-kubernetes-with-service-mirroring/index.md
@@ -1,6 +1,6 @@
 ---
-title: Multicluster Kubernetes with Service Mirroring
 date: 2020-02-25T00:00:00Z
+title: Multicluster Kubernetes with Service Mirroring
 keywords: [linkerd, multicluster]
 params:
   author: thomas

--- a/linkerd.io/content/blog/2020/0319-welcome-hema/index.md
+++ b/linkerd.io/content/blog/2020/0319-welcome-hema/index.md
@@ -1,6 +1,6 @@
 ---
-title: Welcome Hema Lee as our newest maintainer!
 date: 2020-03-19T00:00:00Z
+title: Welcome Hema Lee as our newest maintainer!
 keywords: [linkerd]
 params:
   author: thomas

--- a/linkerd.io/content/blog/2020/0323-serverless-service-mesh-with-knative/index.md
+++ b/linkerd.io/content/blog/2020/0323-serverless-service-mesh-with-knative/index.md
@@ -1,6 +1,6 @@
 ---
-title: Serverless Service Mesh with Knative and Linkerd
 date: 2020-03-23T00:00:00Z
+title: Serverless Service Mesh with Knative and Linkerd
 keywords: [linkerd, serverless, tutorials, knative]
 params:
   author: charles

--- a/linkerd.io/content/blog/2020/0408-linkerd-rfc-process/index.md
+++ b/linkerd.io/content/blog/2020/0408-linkerd-rfc-process/index.md
@@ -1,6 +1,6 @@
 ---
-title: Introducing Linkerd's RFC process
 date: 2020-04-08T00:00:00Z
+title: Introducing Linkerd's RFC process
 keywords: [linkerd]
 params:
   author: thomas

--- a/linkerd.io/content/blog/2020/0504-linkerd-gsoc-2020/index.md
+++ b/linkerd.io/content/blog/2020/0504-linkerd-gsoc-2020/index.md
@@ -1,6 +1,6 @@
 ---
-title: Linkerd GSoC 2020
 date: 2020-05-04T00:00:00Z
+title: Linkerd GSoC 2020
 keywords: [linkerd, gsoc]
 params:
   author: ivan

--- a/linkerd.io/content/blog/2020/0609-announcing-linkerd-2-8/index.md
+++ b/linkerd.io/content/blog/2020/0609-announcing-linkerd-2-8/index.md
@@ -1,8 +1,8 @@
 ---
-title: |-
-  Announcing Linkerd 2.8: simple, secure multi-cluster Kubernetes
 date: 2020-06-09T00:00:00Z
 slug: announcing-linkerd-2.8
+title: |-
+  Announcing Linkerd 2.8: simple, secure multi-cluster Kubernetes
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2020/0723-under-the-hood-of-linkerd-s-state-of-the-art-rust-proxy-linkerd2-proxy/index.md
+++ b/linkerd.io/content/blog/2020/0723-under-the-hood-of-linkerd-s-state-of-the-art-rust-proxy-linkerd2-proxy/index.md
@@ -1,6 +1,6 @@
 ---
-title: Under the hood of Linkerd's state-of-the-art Rust proxy, Linkerd2-proxy
 date: 2020-07-23T00:00:00Z
+title: Under the hood of Linkerd's state-of-the-art Rust proxy, Linkerd2-proxy
 keywords: [linkerd]
 params:
   author: eliza

--- a/linkerd.io/content/blog/2020/0902-the-roadmap-for-linkerd-proxy/index.md
+++ b/linkerd.io/content/blog/2020/0902-the-roadmap-for-linkerd-proxy/index.md
@@ -1,7 +1,7 @@
 ---
-title: The road ahead for Linkerd2-proxy, and how you can get involved
 date: 2020-09-02T00:00:00-08:00
 slug: the-road-ahead-for-linkerd2-proxy
+title: The road ahead for Linkerd2-proxy, and how you can get involved
 keywords: [linkerd]
 params:
   author: oliver

--- a/linkerd.io/content/blog/2020/1101-october-linkerd-community-meeting/index.md
+++ b/linkerd.io/content/blog/2020/1101-october-linkerd-community-meeting/index.md
@@ -1,6 +1,6 @@
 ---
-title: October Linkerd Community Meeting
 date: 2020-11-01T00:00:00Z
+title: October Linkerd Community Meeting
 keywords: [meeting, meetup]
 params:
   author: thomas

--- a/linkerd.io/content/blog/2020/1109-announcing-linkerd-2-9/index.md
+++ b/linkerd.io/content/blog/2020/1109-announcing-linkerd-2-9/index.md
@@ -1,8 +1,8 @@
 ---
-title: |-
-  Announcing Linkerd 2.9: mTLS for all, ARM support, and more!
 date: 2020-11-09T00:00:00Z
 slug: announcing-linkerd-2.9
+title: |-
+  Announcing Linkerd 2.9: mTLS for all, ARM support, and more!
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2020/1123-topology-aware-service-routing-on-kubernetes-with-linkerd/index.md
+++ b/linkerd.io/content/blog/2020/1123-topology-aware-service-routing-on-kubernetes-with-linkerd/index.md
@@ -1,6 +1,6 @@
 ---
-title: Topology-Aware Service Routing on Kubernetes with Linkerd
 date: 2020-11-23T00:00:00Z
+title: Topology-Aware Service Routing on Kubernetes with Linkerd
 keywords: ["service routing"]
 params:
   author: matei

--- a/linkerd.io/content/blog/2020/1202-vote-for-your-december-linkerd-hero/index.md
+++ b/linkerd.io/content/blog/2020/1202-vote-for-your-december-linkerd-hero/index.md
@@ -1,6 +1,6 @@
 ---
-title: Vote For Your December Linkerd Hero!
 date: 2020-12-02T00:00:00Z
+title: Vote For Your December Linkerd Hero!
 keywords: [heroes]
 params:
   author: charles

--- a/linkerd.io/content/blog/2020/1203-why-linkerd-doesnt-use-envoy/index.md
+++ b/linkerd.io/content/blog/2020/1203-why-linkerd-doesnt-use-envoy/index.md
@@ -1,6 +1,6 @@
 ---
-title: Why Linkerd doesn't use Envoy
 date: 2020-12-03T00:00:00Z
+title: Why Linkerd doesn't use Envoy
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2020/1215-december-linkerd-community-meeting/index.md
+++ b/linkerd.io/content/blog/2020/1215-december-linkerd-community-meeting/index.md
@@ -1,6 +1,6 @@
 ---
-title: December Linkerd Community Meeting
 date: 2020-12-15T00:00:00Z
+title: December Linkerd Community Meeting
 keywords: [meetup]
 params:
   author: charles

--- a/linkerd.io/content/blog/2021/0119-linkerd-hero-nomination/index.md
+++ b/linkerd.io/content/blog/2021/0119-linkerd-hero-nomination/index.md
@@ -1,6 +1,6 @@
 ---
-title: January 2021 Linkerd Hero Nomination
 date: 2021-01-19T00:00:00Z
+title: January 2021 Linkerd Hero Nomination
 keywords: [linkerd, community, hero]
 params:
   author: charles

--- a/linkerd.io/content/blog/2021/0128-linkerd-steering-committee/index.md
+++ b/linkerd.io/content/blog/2021/0128-linkerd-steering-committee/index.md
@@ -1,6 +1,6 @@
 ---
-title: Announcing the Linkerd Steering Committee
 date: 2021-01-28T00:00:00Z
+title: Announcing the Linkerd Steering Committee
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2021/0204-january-linkerd-community-meeting/index.md
+++ b/linkerd.io/content/blog/2021/0204-january-linkerd-community-meeting/index.md
@@ -1,6 +1,6 @@
 ---
-title: January Linkerd Community Meeting Recap
 date: 2021-02-04T00:00:00Z
+title: January Linkerd Community Meeting Recap
 keywords: [linkerd]
 params:
   author: charles

--- a/linkerd.io/content/blog/2021/0219-linkerd-hero-nomination/index.md
+++ b/linkerd.io/content/blog/2021/0219-linkerd-hero-nomination/index.md
@@ -1,6 +1,6 @@
 ---
-title: February 2021 Linkerd Hero Nomination
 date: 2021-02-19T00:00:00Z
+title: February 2021 Linkerd Hero Nomination
 keywords: [linkerd, community, hero]
 params:
   author: charles

--- a/linkerd.io/content/blog/2021/0223-protocol-detection-and-opaque-ports/index.md
+++ b/linkerd.io/content/blog/2021/0223-protocol-detection-and-opaque-ports/index.md
@@ -1,6 +1,6 @@
 ---
-title: Protocol Detection and Opaque Ports in Linkerd
 date: 2021-02-23T00:00:00Z
+title: Protocol Detection and Opaque Ports in Linkerd
 keywords: [linkerd, proxy, "Protocol Detection"]
 params:
   author: charles

--- a/linkerd.io/content/blog/2021/0301-linkerd-210-and-extensions/index.md
+++ b/linkerd.io/content/blog/2021/0301-linkerd-210-and-extensions/index.md
@@ -1,6 +1,6 @@
 ---
-title: Linkerd 2.10 and Extensions
 date: 2021-03-01T00:00:00Z
+title: Linkerd 2.10 and Extensions
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2021/0311-announcing-linkerd-2-10/index.md
+++ b/linkerd.io/content/blog/2021/0311-announcing-linkerd-2-10/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2021-03-11T00:00:00Z
+slug: announcing-linkerd-2.10
 title: |-
   Announcing Linkerd 2.10: Extensions, Opaque Ports, Multi-cluster TCP, and
   more!
-date: 2021-03-11T00:00:00Z
-slug: announcing-linkerd-2.10
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2021/0317-february-linkerd-community-meeting/index.md
+++ b/linkerd.io/content/blog/2021/0317-february-linkerd-community-meeting/index.md
@@ -1,10 +1,10 @@
 ---
+date: 2021-03-17T00:00:00.000Z
 title: February Linkerd Community Meeting Recap
 description: |-
   From the 2.9.3 edge release to Linkerd-await (a wrapper for your apps and
   jobs) to protocol detection, we covered a lot of ground in the February
   meeting.
-date: 2021-03-17T00:00:00.000Z
 keywords: [linkerd]
 params:
   author: charles

--- a/linkerd.io/content/blog/2021/0317-linkerd-hero-nomination/index.md
+++ b/linkerd.io/content/blog/2021/0317-linkerd-hero-nomination/index.md
@@ -1,6 +1,6 @@
 ---
-title: Vote for your March Hero
 date: 2021-03-17T00:00:00Z
+title: Vote for your March Hero
 keywords: [linkerd, community, hero]
 params:
   author: charles

--- a/linkerd.io/content/blog/2021/0331-introduccion-al-service-mesh-con-linkerd/index.md
+++ b/linkerd.io/content/blog/2021/0331-introduccion-al-service-mesh-con-linkerd/index.md
@@ -1,6 +1,6 @@
 ---
-title: Introduccion al service mesh con Linkerd
 date: 2021-03-31T00:00:00Z
+title: Introduccion al service mesh con Linkerd
 keywords: [linkerd, "how to"]
 params:
   author: alejandro

--- a/linkerd.io/content/blog/2021/0401-service-mesh-101-intro-with-linkerd/index.md
+++ b/linkerd.io/content/blog/2021/0401-service-mesh-101-intro-with-linkerd/index.md
@@ -1,7 +1,7 @@
 ---
-title: Introduction to the service mesh—the easy way
-slug: introduction-to-the-service-mesh
 date: 2021-04-01T00:00:00Z
+slug: introduction-to-the-service-mesh
+title: Introduction to the service mesh—the easy way
 keywords: [linkerd, community, hero]
 params:
   author: jason

--- a/linkerd.io/content/blog/2021/0405-march-linkerd-community-meeting/index.md
+++ b/linkerd.io/content/blog/2021/0405-march-linkerd-community-meeting/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2021-04-05T00:00:00Z
 title: March Linkerd Community Meeting Recap
 description: |-
   In this month's community meeting, we discussed what's on the roadmap, what's
   new with Linkerd 2.10, and announced the Linkerd Hero of the month.
-date: 2021-04-05T00:00:00Z
 keywords: [linkerd]
 params:
   author: jason

--- a/linkerd.io/content/blog/2021/0421-linkerd-hero-nomination/index.md
+++ b/linkerd.io/content/blog/2021/0421-linkerd-hero-nomination/index.md
@@ -1,6 +1,6 @@
 ---
-title: Vote for your April Hero
 date: 2021-04-21T00:00:00Z
+title: Vote for your April Hero
 keywords: [linkerd, community, hero]
 params:
   author: charles

--- a/linkerd.io/content/blog/2021/0507-introducing-fuzz-testing-to-linkerd/index.md
+++ b/linkerd.io/content/blog/2021/0507-introducing-fuzz-testing-to-linkerd/index.md
@@ -1,7 +1,7 @@
 ---
-title: Introducing fuzz testing for Linkerd
 date: 2021-05-07T00:00:00Z
 slug: fuzz-testing-for-linkerd
+title: Introducing fuzz testing for Linkerd
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2021/0514-april-linkerd-community-meeting/index.md
+++ b/linkerd.io/content/blog/2021/0514-april-linkerd-community-meeting/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2021-05-14T00:00:00Z
 title: April Linkerd Community Meeting Recap
 description: |-
   We chatted with Fredrik Klingenberg about his experience implementing Linkerd
   at Elkjøp, talked about our roadmap, and much more.
-date: 2021-05-14T00:00:00Z
 keywords: [linkerd]
 params:
   author: jason

--- a/linkerd.io/content/blog/2021/0527-linkerd-vs-istio-benchmarks/index.md
+++ b/linkerd.io/content/blog/2021/0527-linkerd-vs-istio-benchmarks/index.md
@@ -1,7 +1,7 @@
 ---
-title: Benchmarking Linkerd and Istio
 date: 2021-05-27T00:00:00
 slug: linkerd-vs-istio-benchmarks
+title: Benchmarking Linkerd and Istio
 thumbnail: latency-2000rps.png
 keywords: [linkerd]
 params:

--- a/linkerd.io/content/blog/2021/0617-may-community-meeting-recap-part-1/index.md
+++ b/linkerd.io/content/blog/2021/0617-may-community-meeting-recap-part-1/index.md
@@ -1,10 +1,10 @@
 ---
+date: 2021-06-17T00:00:00Z
 title: Linkerd at KubeCon EU
 description: |-
   May's Community Meeting was a little different than our typical meetups. Hot
   off a successful KubeCon EU, we chose to recap the great Linkerd stories told
   during the conference"
-date: 2021-06-17T00:00:00Z
 keywords: [community]
 params:
   author: jason

--- a/linkerd.io/content/blog/2021/0624-announcing-junes-linkerd-heroes/index.md
+++ b/linkerd.io/content/blog/2021/0624-announcing-junes-linkerd-heroes/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2021-06-24T00:00:00Z
 title: Announcing June's Linkerd Heroes!
 description: |-
   If you attended this month's Linkerd Community meeting, you've already heard
   the news: this month's Linkerd Heroes are Steve Gray and Steve Reardon.
-date: 2021-06-24T00:00:00Z
 keywords: [linkerd, community, heroes]
 params:
   author: jason

--- a/linkerd.io/content/blog/2021/0624-multi-cluster-kubernetes-with-headless-services/index.md
+++ b/linkerd.io/content/blog/2021/0624-multi-cluster-kubernetes-with-headless-services/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2021-06-24T00:00:00Z
 title: Multi-Cluster Kubernetes with Headless Services
 description: |-
   We'll discuss two Linkerd features eagerly awaited by the community: support
   for headless services and StatefulSets in multi-cluster environments.
-date: 2021-06-24T00:00:00Z
 keywords: [community, tutorials]
 params:
   author: matei

--- a/linkerd.io/content/blog/2021/0712-june-linkerd-community-meeting-recap/index.md
+++ b/linkerd.io/content/blog/2021/0712-june-linkerd-community-meeting-recap/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2021-07-12T00:00:00Z
 title: June Linkerd Community Meeting Recap
 description: |-
   Missed the June Linkerd Community Meeting? Here's our recap and the full
   recording.
-date: 2021-07-12T00:00:00Z
 keywords: [community]
 params:
   author: charles

--- a/linkerd.io/content/blog/2021/0728-announcing-cncf-graduation/index.md
+++ b/linkerd.io/content/blog/2021/0728-announcing-cncf-graduation/index.md
@@ -1,7 +1,7 @@
 ---
-title: Announcing Linkerd's Graduation
 date: 2021-07-28T00:00:00Z
 slug: announcing-cncf-graduation
+title: Announcing Linkerd's Graduation
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2021/0729-announcing-julys-hero/index.md
+++ b/linkerd.io/content/blog/2021/0729-announcing-julys-hero/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2021-07-29T00:00:00Z
 title: Announcing July's Linkerd Hero
 description: |-
   This month's hero is Sanskar Jaiswal. In a short amount of time, Sanskar has
   made his presence felt through his thoughtful code contributions
-date: 2021-07-29T00:00:00Z
 keywords: [linkerd, community, hero]
 params:
   author: charles

--- a/linkerd.io/content/blog/2021/0805-announcing-the-linkerd-ambassador-program/index.md
+++ b/linkerd.io/content/blog/2021/0805-announcing-the-linkerd-ambassador-program/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2021-08-05T00:00:00Z
 title: Announcing the Linkerd Ambassador program
 description: |-
   Linkerd Ambassadors are community members who have demonstrated passion,
   engagement, and a commitment to sharing their Linkerd experience.
-date: 2021-08-05T00:00:00Z
 keywords: [community]
 params:
   author: catherine

--- a/linkerd.io/content/blog/2021/0816-july-linkerd-community-meeting-recap/index.md
+++ b/linkerd.io/content/blog/2021/0816-july-linkerd-community-meeting-recap/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2021-08-16T00:00:00Z
 title: July Linkerd Community Meeting Recap
 description: |-
   The big news this month is Linkerd's CNCF graduation! As you can imagine, the
   entire Linkerd team is very excited and we hope you are too.
-date: 2021-08-16T00:00:00Z
 keywords: [community]
 params:
   author: matei

--- a/linkerd.io/content/blog/2021/0826-announcing-augusts-linkerd-hero/index.md
+++ b/linkerd.io/content/blog/2021/0826-announcing-augusts-linkerd-hero/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2021-08-26T00:00:00Z
 title: Announcing August's Linkerd Hero
 description: |-
   If you attended this month's Linkerd Community meeting, you've already heard
   the news: this month's Linkerd Hero is Dom DePasquale Congrats, Dom!
-date: 2021-08-26T00:00:00Z
 keywords: [linkerd, community, hero]
 params:
   author: catherine

--- a/linkerd.io/content/blog/2021/0827-august-linkerd-community-meeting-recap/index.md
+++ b/linkerd.io/content/blog/2021/0827-august-linkerd-community-meeting-recap/index.md
@@ -1,10 +1,10 @@
 ---
+date: 2021-08-27T00:00:00Z
 title: August Linkerd Community Meeting Recap
 description: |-
   We are pushing towards the 2.11 release and our next edge release is the first
   with policy support! We recently updated our ingress documentation which will
   hopefully result in an easier getting-started process.
-date: 2021-08-27T00:00:00Z
 keywords: [linkerd, community]
 params:
   author: kevinl

--- a/linkerd.io/content/blog/2021/0923-linkerd-uses-iptables-to-route-kubernetes-traffic-transparently/index.md
+++ b/linkerd.io/content/blog/2021/0923-linkerd-uses-iptables-to-route-kubernetes-traffic-transparently/index.md
@@ -1,10 +1,10 @@
 ---
+date: 2021-09-23T00:00:00Z
 title: How Linkerd uses iptables to transparently route Kubernetes traffic
 description: |-
   This blog post will look at how Linkerd uses iptables to intercept the TCP
   traffic to and from Kubernetes pods and route it through "sidecar" proxies
   without the application knowing.
-date: 2021-09-23T00:00:00Z
 keywords: [tutorials, iptables]
 params:
   author: matei

--- a/linkerd.io/content/blog/2021/0930-announcing-linkerd-2-11/index.md
+++ b/linkerd.io/content/blog/2021/0930-announcing-linkerd-2-11/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2021-09-30T00:00:00Z
+slug: announcing-linkerd-2.11
 title: |-
   Announcing Linkerd 2.11: Policy, gRPC retries, performance improvements, and
   more!
-date: 2021-09-30T00:00:00Z
-slug: announcing-linkerd-2.11
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2021/0930-linkerd-hero/index.md
+++ b/linkerd.io/content/blog/2021/0930-linkerd-hero/index.md
@@ -1,10 +1,10 @@
 ---
+date: 2021-09-30T00:00:00Z
 title: |-
   Announcing September's Linkerd Hero
 description: |-
   An enthusiastic Linkerd contributor, Ujjwal raised issues and contributed code
   to the website repository and Linkerd's multicluster capabilities.
-date: 2021-09-30T00:00:00Z
 keywords: [linkerd, community, hero]
 params:
   author: catherine

--- a/linkerd.io/content/blog/2021/1026-linkerd-retries-http-requests-with-bodies/index.md
+++ b/linkerd.io/content/blog/2021/1026-linkerd-retries-http-requests-with-bodies/index.md
@@ -1,10 +1,10 @@
 ---
+date: 2021-10-26T00:00:00Z
 title: How Linkerd retries HTTP requests with bodies
 description: |-
   Linkerd 2.11 is here and with it are some cool new updates.  One I am
   particularly excited about (full disclosure: I worked on it), is retries or
   HTTP requests with bodies.
-date: 2021-10-26T00:00:00Z
 keywords: [http, retries]
 params:
   author: eliza

--- a/linkerd.io/content/blog/2021/1026-september-linkerd-community-meeting/index.md
+++ b/linkerd.io/content/blog/2021/1026-september-linkerd-community-meeting/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2021-10-26T00:00:00Z
 title: September Linkerd community meeting recap 
 description: |-
   The Linkerd 2.11 docs are live and you'll see lots of small changes. The
   Linkerd team and the community have been working on 2.11 since May.
-date: 2021-10-26T00:00:00Z
 keywords: [meetup, community, meeting]
 params:
   author: matei

--- a/linkerd.io/content/blog/2021/1028-linkerd-hero/index.md
+++ b/linkerd.io/content/blog/2021/1028-linkerd-hero/index.md
@@ -1,10 +1,10 @@
 ---
+date: 2021-10-28T00:00:00Z
 title: Announcing October's Linkerd hero
 description: |-
   As a new member of the Linkerd community, Alberto jumped right into the spirit
   of the community and helped someone out on Slack when they posted a question
   in the linkerd2 channel.
-date: 2021-10-28T00:00:00Z
 keywords: [linkerd, community, hero]
 params:
   author: catherine

--- a/linkerd.io/content/blog/2021/1110-october-linkerd-community-meeting-recap/index.md
+++ b/linkerd.io/content/blog/2021/1110-october-linkerd-community-meeting-recap/index.md
@@ -1,10 +1,10 @@
 ---
+date: 2021-11-10T00:00:00Z
 title: October Linkerd community meeting recap
 description: |-
   The world's first hybrid KubeCon turned out great for Linkerd.Fascinating
   talks, a big announcement around Linkerd 2.11, and, best of all, we got to see
   real people again.
-date: 2021-11-10T00:00:00Z
 keywords: [community, meeting, meetup]
 params:
   author: tarun

--- a/linkerd.io/content/blog/2021/1129-linkerd-vs-istio-benchmarks/index.md
+++ b/linkerd.io/content/blog/2021/1129-linkerd-vs-istio-benchmarks/index.md
@@ -1,8 +1,8 @@
 ---
-title: |-
-  Benchmarking Linkerd and Istio: 2021 Redux
 date: 2021-11-29T00:00:00
 slug: linkerd-vs-istio-benchmarks-2021
+title: |-
+  Benchmarking Linkerd and Istio: 2021 Redux
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2021/1209-linkerd-hero/index.md
+++ b/linkerd.io/content/blog/2021/1209-linkerd-hero/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2021-12-09T00:00:00Z
 title: Announcing December's Linkerd Hero
 description: |-
   Aleksandr is Director of Engineering at ANNA Money and recently wrote three
   great Linkerd blog posts.
-date: 2021-12-09T00:00:00Z
 keywords: [hero, meetup, community]
 params:
   author: catherine

--- a/linkerd.io/content/blog/2021/1222-december-linkerd-community-meeting-recap/index.md
+++ b/linkerd.io/content/blog/2021/1222-december-linkerd-community-meeting-recap/index.md
@@ -1,6 +1,6 @@
 ---
-title: December Linkerd community meeting recap
 date: 2021-12-22T00:00:00Z
+title: December Linkerd community meeting recap
 description: |-
   We hosted our very first hands-on workshop on mTLS with Matei David. It was
   such a success that we decided to do these regularly so we launched a Service

--- a/linkerd.io/content/blog/2021/1228-linkerd-service-account-tokens/index.md
+++ b/linkerd.io/content/blog/2021/1228-linkerd-service-account-tokens/index.md
@@ -1,10 +1,10 @@
 ---
+date: 2021-12-28T00:00:00Z
 title: Using Kubernetes's new Bound Service Account Tokens for secure workload identity
 description: |-
   Linkerd recently moved to using bound service account tokens to further
   improve security  for Kubernetes users. What are these, and why are they
   important?
-date: 2021-12-28T00:00:00Z
 keywords: [identity, service-accounts]
 params:
   author: tarun

--- a/linkerd.io/content/blog/2021/1229-the-service-mesh-in-2022/index.md
+++ b/linkerd.io/content/blog/2021/1229-the-service-mesh-in-2022/index.md
@@ -1,8 +1,8 @@
 ---
-title: |-
-  The service mesh in 2022: What's next for Linkerd?
 date: 2021-12-29T00:00:00+00:00
 slug: the-service-mesh-in-2022
+title: |-
+  The service mesh in 2022: What's next for Linkerd?
 keywords: [lLinkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2022/0127-linkerd-hero/index.md
+++ b/linkerd.io/content/blog/2022/0127-linkerd-hero/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2022-01-27T00:00:00Z
 title: Announcing January's Linkerd Hero
 description: |-
   As a community member and Linkerd user, Krzysztof has continuously and
   enthusiastically helped fix issues and improve the Linkerd project.
-date: 2022-01-27T00:00:00Z
 keywords: [hero, community]
 params:
   author: catherine

--- a/linkerd.io/content/blog/2022/0216-linkerd-istio-adoption/index.md
+++ b/linkerd.io/content/blog/2022/0216-linkerd-istio-adoption/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2022-02-16T00:00:00+00:00
+slug: linkerd-istio-adoption
 title: |-
   Linkerd surpasses Istio adoption in Europe and North America with 118% growth
   in 2021
-date: 2022-02-16T00:00:00+00:00
-slug: linkerd-istio-adoption
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2022/0309-linkerd-multi-cluster-failover/index.md
+++ b/linkerd.io/content/blog/2022/0309-linkerd-multi-cluster-failover/index.md
@@ -1,6 +1,6 @@
 ---
-title: Announcing automated multi-cluster failover for Kubernetes
 date: 2022-03-09T00:00:00+00:00
+title: Announcing automated multi-cluster failover for Kubernetes
 keywords: [linkerd]
 params:
   author: alejandro

--- a/linkerd.io/content/blog/2022/0405-linkerd-hero/index.md
+++ b/linkerd.io/content/blog/2022/0405-linkerd-hero/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2022-04-05T00:00:00Z
 title: Announcing March's Linkerd Hero
 description: |-
   We are excited to announce that this month's Linkerd Hero is Naveen Nalam.
   Congrats, Naveen!
-date: 2022-04-05T00:00:00Z
 keywords: [hero, community]
 params:
   author: catherine

--- a/linkerd.io/content/blog/2022/0608-linkerd-hero/index.md
+++ b/linkerd.io/content/blog/2022/0608-linkerd-hero/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2022-06-08T00:00:00Z
 title: Announcing June's Linkerd Hero
 description: |-
   We are excited to announce this month's Linkerd Hero: Chris Voss.
   Congrats, Chris!
-date: 2022-06-08T00:00:00Z
 keywords: [community, hero]
 params:
   author: catherine

--- a/linkerd.io/content/blog/2022/0627-security-audit/index.md
+++ b/linkerd.io/content/blog/2022/0627-security-audit/index.md
@@ -1,6 +1,6 @@
 ---
-title: Announcing the completion of Linkerd's 2022 Security Audit
 date: 2022-06-27T00:00:00+00:00
+title: Announcing the completion of Linkerd's 2022 Security Audit
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2022/0727-linkerd-hero/index.md
+++ b/linkerd.io/content/blog/2022/0727-linkerd-hero/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2022-07-27T00:00:00Z
 title: Announcing July's Linkerd Hero
 description: |-
   We are excited to announce this month's Linkerd Hero: Dominik Táskai.
   Congrats, Dominik!
-date: 2022-07-27T00:00:00Z
 keywords: [hero, community]
 params:
   author: catherine

--- a/linkerd.io/content/blog/2022/0824-linkerd-hero/index.md
+++ b/linkerd.io/content/blog/2022/0824-linkerd-hero/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2022-08-24T00:00:00Z
 title: Announcing August's Linkerd Hero
 description: |-
   We are excited to announce this month's Linkerd Hero: Dani Baeyens.
   Congrats, Dani!
-date: 2022-08-24T00:00:00Z
 keywords: [hero, community]
 params:
   author: catherine

--- a/linkerd.io/content/blog/2022/0923-linkerd-hero/index.md
+++ b/linkerd.io/content/blog/2022/0923-linkerd-hero/index.md
@@ -1,10 +1,10 @@
 ---
+date: 2022-09-23T00:00:00Z
 title: Announcing September's Linkerd Hero
 description: |-
   We are excited to announce this month's Linkerd Hero: Dan Williams. Congrats,
   Dan! Linkerd Heroes are community members who best represent the spirit of the
   Linkerd community.
-date: 2022-09-23T00:00:00Z
 keywords: [hero, community]
 params:
   author: catherine

--- a/linkerd.io/content/blog/2022/1122-linkerd-hero/index.md
+++ b/linkerd.io/content/blog/2022/1122-linkerd-hero/index.md
@@ -1,10 +1,10 @@
 ---
+date: 2022-11-22T00:00:00Z
 title: Announcing November's Linkerd Hero
 description: |-
   We are excited to announce this month's Linkerd Hero: Steve Reardon. Steve is
   a two-time winner, nominated this time for helping his peers on Slack time and
   again.
-date: 2022-11-22T00:00:00Z
 keywords: [hero, community]
 params:
   author: catherine

--- a/linkerd.io/content/blog/2022/1201-startup-deep-dive/index.md
+++ b/linkerd.io/content/blog/2022/1201-startup-deep-dive/index.md
@@ -1,8 +1,8 @@
 ---
-title: |-
-  What really happens at startup: Linkerd, init containers, the CNI, and more
 date: 2022-12-01T00:00:00Z
 slug: what-really-happens-at-startup-a-deep-dive-into-linkerd-init-containers-cni-plugins-and-more
+title: |-
+  What really happens at startup: Linkerd, init containers, the CNI, and more
 keywords: [linkerd, init, cni, startup, tutorials]
 params:
   author: flynn

--- a/linkerd.io/content/blog/2022/1228-service-mesh-2022-recap-ebpf-gateway-api/index.md
+++ b/linkerd.io/content/blog/2022/1228-service-mesh-2022-recap-ebpf-gateway-api/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2022-12-28T00:00:00+00:00
+slug: service-mesh-2022-recap-ebpf-gateway-api
 title: |-
   Service mesh 2022 recap: Linkerd adoption doubled, and what we learned about
   eBPF, the Gateway API, and more
-date: 2022-12-28T00:00:00+00:00
-slug: service-mesh-2022-recap-ebpf-gateway-api
 keywords: [Linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2023/0120-announcing-linkerd-day-2023/index.md
+++ b/linkerd.io/content/blog/2023/0120-announcing-linkerd-day-2023/index.md
@@ -1,7 +1,7 @@
 ---
-title: Announcing Linkerd Day 2023 at Kubecon EU!
 date: 2023-01-20T00:00:00+00:00
 slug: announcing-linkerd-day-2023
+title: Announcing Linkerd Day 2023 at Kubecon EU!
 keywords: [linkerd]
 params:
   author: catherine

--- a/linkerd.io/content/blog/2023/0130-mtls-and-linkerd/index.md
+++ b/linkerd.io/content/blog/2023/0130-mtls-and-linkerd/index.md
@@ -1,8 +1,8 @@
 ---
-title: |-
-  Workshop recap: A deep dive into Kubernetes mTLS with Linkerd
 date: 2023-01-30T00:00:00+00:00
 slug: mtls-and-linkerd
+title: |-
+  Workshop recap: A deep dive into Kubernetes mTLS with Linkerd
 params:
   author: flynn
   showCover: true

--- a/linkerd.io/content/blog/2023/0213-linkerd-hero/index.md
+++ b/linkerd.io/content/blog/2023/0213-linkerd-hero/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2023-02-10T00:00:00Z
 title: Announcing the February 2023 Linkerd Hero!
 description: |-
   We are excited to announce this month's Linkerd Hero: Yu Cao, for
   contributing to Linkerd and making it better for the entire community!
-date: 2023-02-10T00:00:00Z
 keywords: [hero, community, contributor, code]
 params:
   author: flynn

--- a/linkerd.io/content/blog/2023/0221-linkerd-and-ingress/index.md
+++ b/linkerd.io/content/blog/2023/0221-linkerd-and-ingress/index.md
@@ -1,8 +1,8 @@
 ---
-title: |-
-  Workshop recap: Linkerd and Ingress Controllers: Bringing the Outside World In
 date: 2023-02-21T00:00:00Z
 slug: linkerd-and-ingress
+title: |-
+  Workshop recap: Linkerd and Ingress Controllers: Bringing the Outside World In
 keywords: [linkerd, mtls, tls, ingress, emissary, nginx, envoy gateway]
 params:
   author: flynn

--- a/linkerd.io/content/blog/2023/0505-welcome-osm/index.md
+++ b/linkerd.io/content/blog/2023/0505-welcome-osm/index.md
@@ -1,7 +1,7 @@
 ---
+date: 2023-05-05T00:00:00Z
 title: |-
   Welcome to Linkerd, Open Service Mesh adopters!
-date: 2023-05-05T00:00:00Z
 keywords: [linkerd, OpenServiceMesh]
 params:
   author: william

--- a/linkerd.io/content/blog/2023/0515-real-world-gitops/index.md
+++ b/linkerd.io/content/blog/2023/0515-real-world-gitops/index.md
@@ -1,8 +1,8 @@
 ---
-title: |-
-  Workshop recap: Real-World GitOps with Flux, Flagger, and Linkerd
 date: 2023-05-15T00:00:00Z
 slug: real-world-gitops
+title: |-
+  Workshop recap: Real-World GitOps with Flux, Flagger, and Linkerd
 keywords: [linkerd, gitops, flux, flagger]
 params:
   author: flynn

--- a/linkerd.io/content/blog/2023/0526-osm-migration/index.md
+++ b/linkerd.io/content/blog/2023/0526-osm-migration/index.md
@@ -1,6 +1,6 @@
 ---
-title: Migrating from OpenServiceMesh to Linkerd
 date: 2023-05-26T00:00:00Z
+title: Migrating from OpenServiceMesh to Linkerd
 keywords: [linkerd, OpenServiceMesh]
 params:
   author: flynn

--- a/linkerd.io/content/blog/2023/0613-dynamic-request-routing-circuit-breaking/index.md
+++ b/linkerd.io/content/blog/2023/0613-dynamic-request-routing-circuit-breaking/index.md
@@ -1,8 +1,8 @@
 ---
-title: |-
-  Workshop recap: Dynamic Request Routing and Circuit Breaking
 date: 2023-06-13T00:00:00Z
 slug: dynamic-request-routing-circuit-breaking
+title: |-
+  Workshop recap: Dynamic Request Routing and Circuit Breaking
 keywords: [linkerd, gitops, flux, flagger]
 params:
   author: flynn

--- a/linkerd.io/content/blog/2023/0621-edge-roundup/index.md
+++ b/linkerd.io/content/blog/2023/0621-edge-roundup/index.md
@@ -1,8 +1,8 @@
 ---
-title: |-
-  Linkerd Edge Release Roundup: 21 June 2023
 date: 2023-06-21T00:00:00Z
 slug: linkerd-edge-roundup
+title: |-
+  Linkerd Edge Release Roundup: 21 June 2023
 keywords: [linkerd, gitops, flux, flagger]
 params:
   author: matei

--- a/linkerd.io/content/blog/2023/0713-linkerd-in-production/index.md
+++ b/linkerd.io/content/blog/2023/0713-linkerd-in-production/index.md
@@ -1,8 +1,8 @@
 ---
-title: |-
-  Workshop recap: Running Linkerd in Production
 date: 2023-07-13T00:00:00Z
 slug: linkerd-in-production
+title: |-
+  Workshop recap: Running Linkerd in Production
 keywords:
   - linkerd
   - helm

--- a/linkerd.io/content/blog/2023/0720-flat-networks/index.md
+++ b/linkerd.io/content/blog/2023/0720-flat-networks/index.md
@@ -1,7 +1,7 @@
 ---
+date: 2023-07-20T00:00:00Z
 title: |-
   Enterprise multi-cluster at scale: supporting flat networks in Linkerd
-date: 2023-07-20T00:00:00Z
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2023/0725-linkerd-hero/index.md
+++ b/linkerd.io/content/blog/2023/0725-linkerd-hero/index.md
@@ -1,10 +1,10 @@
 ---
+date: 2023-07-25T00:00:00Z
 title: Announcing the July 2023 Linkerd Hero!
 description: |-
   The votes are in! This month's Linkerd Hero is Mikael Fridh for fixing an
   incompatibility between Linkerd's CNI plugin and newer versions of EKS's
   VPC CNI plugin.
-date: 2023-07-25T00:00:00Z
 keywords: [hero, community, contributor, code]
 params:
   author: catherine

--- a/linkerd.io/content/blog/2023/0807-edge-release-roundup/index.md
+++ b/linkerd.io/content/blog/2023/0807-edge-release-roundup/index.md
@@ -1,8 +1,8 @@
 ---
-title: |-
-  Linkerd Edge Release Roundup: August 2023
 date: 2023-08-07T00:00:00Z
 slug: linkerd-edge-release-roundup
+title: |-
+  Linkerd Edge Release Roundup: August 2023
 keywords: [linkerd, edge, release, roundup]
 params:
   author: alejandro

--- a/linkerd.io/content/blog/2023/0823-announcing-linkerd-2-14/index.md
+++ b/linkerd.io/content/blog/2023/0823-announcing-linkerd-2-14/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2023-08-23T00:00:00+00:00
+slug: announcing-linkerd-2.14
 title: |-
   Announcing Linkerd 2.14: Improved enterprise multi-cluster, Gateway API
   conformance, and more!
-date: 2023-08-23T00:00:00+00:00
-slug: announcing-linkerd-2.14
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2023/0912-linkerd-214/index.md
+++ b/linkerd.io/content/blog/2023/0912-linkerd-214/index.md
@@ -1,8 +1,8 @@
 ---
-title: |-
-  Workshop Recap: A closer look at flat-network multicluster and HTTPRoute timeouts with Linkerd 2.14
 date: 2023-09-12T00:00:00Z
 slug: linkerd-214
+title: |-
+  Workshop Recap: A closer look at flat-network multicluster and HTTPRoute timeouts with Linkerd 2.14
 keywords: [linkerd, "2.14", features]
 params:
   author: flynn

--- a/linkerd.io/content/blog/2023/0930-linkerd-hero/index.md
+++ b/linkerd.io/content/blog/2023/0930-linkerd-hero/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2023-09-30T00:00:00Z
 title: Announcing the September 2023 Linkerd Hero!
 description: |-
   We are excited to announce this month's Linkerd Hero: Cameron Boulton, for
   investigating and debugging issues within Linkerd!
-date: 2023-09-30T00:00:00Z
 keywords: [hero, community, debugging, contributor, code]
 params:
   author: flynn

--- a/linkerd.io/content/blog/2023/1011-cve-2023-44487/index.md
+++ b/linkerd.io/content/blog/2023/1011-cve-2023-44487/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2023-10-12T00:00:00+00:00
+slug: linkerd-cve-2023-44487
 title: |-
   How Linkerd became resilient to CVE-2023-44487, a HTTP/2 DDOS vulnerability,
   six months prior to its disclosure
-date: 2023-10-12T00:00:00+00:00
-slug: linkerd-cve-2023-44487
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2023/1107-mesh-expansion/index.md
+++ b/linkerd.io/content/blog/2023/1107-mesh-expansion/index.md
@@ -1,7 +1,7 @@
 ---
-title: Mesh expansion and SPIFFE support arriving in the upcoming Linkerd 2.15
 date: 2023-11-07T00:00:00+00:00
 slug: linkerd-mesh-expansion
+title: Mesh expansion and SPIFFE support arriving in the upcoming Linkerd 2.15
 keywords: [linkerd]
 params:
   author: william

--- a/linkerd.io/content/blog/2023/1122-linkerd-hero/index.md
+++ b/linkerd.io/content/blog/2023/1122-linkerd-hero/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2023-11-22T00:00:00Z
 title: Announcing the November 2023 Linkerd Hero!
 description: |-
   We are excited to announce this month's Linkerd Hero: Takumi Sue, for
   contributing to Linkerd and making it better for the entire community!
-date: 2023-11-22T00:00:00Z
 keywords: [community, hero, contributor, code]
 params:
   author: flynn

--- a/linkerd.io/content/blog/2023/1227-linkerd-hero/index.md
+++ b/linkerd.io/content/blog/2023/1227-linkerd-hero/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2023-12-22T00:00:00Z
 title: Announcing the December 2023 Linkerd Hero!
 description: |-
   We are excited to announce this month's Linkerd Hero: TJ Miller, for
   contributing to Linkerd and making it better for the entire community!
-date: 2023-12-22T00:00:00Z
 keywords: [community, hero, contributor, code]
 params:
   author: flynn

--- a/linkerd.io/content/blog/2024/0206-linkerd-certificates-with-vault/index.md
+++ b/linkerd.io/content/blog/2024/0206-linkerd-certificates-with-vault/index.md
@@ -1,8 +1,8 @@
 ---
-title: |-
-  Workshop Recap: Linkerd Certificate Management with Vault
 date: 2024-02-06T00:00:00Z
 slug: linkerd-certificates-with-vault
+title: |-
+  Workshop Recap: Linkerd Certificate Management with Vault
 keywords: [linkerd, "2.14", features, vault]
 params:
   author: flynn

--- a/linkerd.io/content/blog/2024/0221-announcing-linkerd-2.15/index.md
+++ b/linkerd.io/content/blog/2024/0221-announcing-linkerd-2.15/index.md
@@ -1,7 +1,7 @@
 ---
-title: Announcing Linkerd 2.15 with mesh expansion, native sidecars, and SPIFFE
 date: 2024-02-21T00:00:00Z
 slug: announcing-linkerd-2.15
+title: Announcing Linkerd 2.15 with mesh expansion, native sidecars, and SPIFFE
 keywords: [linkerd, "2.15", features, vault]
 params:
   author: william

--- a/linkerd.io/content/blog/2024/0312-edge-release-roundup/index.md
+++ b/linkerd.io/content/blog/2024/0312-edge-release-roundup/index.md
@@ -1,11 +1,11 @@
 ---
+date: 2024-03-12T00:00:00Z
+slug: linkerd-edge-release-roundup
 title: |-
   Linkerd Edge Release Roundup: March 2024
 description: |-
   What you need to know about the most recent Linkerd edge releases, March 2024
   edition!
-date: 2024-03-12T00:00:00Z
-slug: linkerd-edge-release-roundup
 keywords: [linkerd, edge, release, roundup]
 params:
   author: flynn

--- a/linkerd.io/content/blog/2024/0425-edge-release-roundup/index.md
+++ b/linkerd.io/content/blog/2024/0425-edge-release-roundup/index.md
@@ -1,11 +1,11 @@
 ---
+date: 2024-04-25T00:00:00Z
+slug: linkerd-edge-release-roundup
 title: |-
   Linkerd Edge Release Roundup: April 2024
 description: |-
   What you need to know about the most recent Linkerd edge releases, April 2024
   edition!
-date: 2024-04-25T00:00:00Z
-slug: linkerd-edge-release-roundup
 keywords: [linkerd, edge, release, roundup]
 params:
   author: flynn

--- a/linkerd.io/content/blog/2024/0524-backstage-and-linkerd/index.md
+++ b/linkerd.io/content/blog/2024/0524-backstage-and-linkerd/index.md
@@ -1,10 +1,10 @@
 ---
+date: 2024-05-23T00:00:00Z
 title: Building a Secure, Reliable, Observable IDP with Backstage & Linkerd
 description: |-
   This CNCF Cloud Native Live session explores building a rock-solid Internal
   Developer Platform (IDP) Backstage that empowers developers with self-service
   tools while streamlining security and observability.
-date: 2024-05-23T00:00:00Z
 keywords: [backstage]
 params:
   author: catherine

--- a/linkerd.io/content/blog/2024/0606-edge-release-roundup/index.md
+++ b/linkerd.io/content/blog/2024/0606-edge-release-roundup/index.md
@@ -1,11 +1,11 @@
 ---
+date: 2024-06-06T00:00:00Z
+slug: linkerd-edge-release-roundup
 title: |-
   Linkerd Edge Release Roundup: June 2024
 description: |-
   What you need to know about the most recent Linkerd edge releases, June 2024
   edition!
-date: 2024-06-06T00:00:00Z
-slug: linkerd-edge-release-roundup
 keywords: [linkerd, edge, release, roundup]
 params:
   author: flynn

--- a/linkerd.io/content/blog/2024/0701-edge-release-roundup/index.md
+++ b/linkerd.io/content/blog/2024/0701-edge-release-roundup/index.md
@@ -1,11 +1,11 @@
 ---
+date: 2024-07-01T00:00:00Z
+slug: linkerd-edge-release-roundup
 title: |-
   Linkerd Edge Release Roundup: July 2024
 description: |-
   What you need to know about the most recent Linkerd edge releases, July 2024
   edition!
-date: 2024-07-01T00:00:00Z
-slug: linkerd-edge-release-roundup
 keywords: [linkerd, edge, release, roundup]
 params:
   author: flynn

--- a/linkerd.io/content/blog/2024/0805-edge-release-roundup/index.md
+++ b/linkerd.io/content/blog/2024/0805-edge-release-roundup/index.md
@@ -1,11 +1,11 @@
 ---
+date: 2024-08-05T00:00:00Z
+slug: linkerd-edge-release-roundup
 title: |-
   Linkerd Edge Release Roundup: August 2024
 description: |-
   What you need to know about the most recent Linkerd edge releases, August 2024
   edition!
-date: 2024-08-05T00:00:00Z
-slug: linkerd-edge-release-roundup
 keywords: [linkerd, edge, release, roundup]
 params:
   author: flynn

--- a/linkerd.io/content/blog/2024/0813-announcing-linkerd-2.16/index.md
+++ b/linkerd.io/content/blog/2024/0813-announcing-linkerd-2.16/index.md
@@ -1,9 +1,9 @@
 ---
+date: 2024-08-13T00:00:00Z
+slug: announcing-linkerd-2.16
 title: |-
   Announcing Linkerd 2.16! Metrics, retries, and timeouts for HTTP and gRPC
   routes; IPv6 support; policy audit mode; and lots more
-date: 2024-08-13T00:00:00Z
-slug: announcing-linkerd-2.16
 keywords: [linkerd, "2.16", features]
 params:
   author: william

--- a/linkerd.io/content/blog/2024/0906-edge-release-roundup/index.md
+++ b/linkerd.io/content/blog/2024/0906-edge-release-roundup/index.md
@@ -1,11 +1,11 @@
 ---
+date: 2024-09-06T00:00:00Z
+slug: linkerd-edge-release-roundup
 title: |-
   Linkerd Edge Release Roundup: September 2024
 description: |-
   What you need to know about the most recent Linkerd edge releases, September
   2024 edition!
-date: 2024-09-06T00:00:00Z
-slug: linkerd-edge-release-roundup
 keywords: [linkerd, edge, release, roundup]
 params:
   author: flynn

--- a/linkerd.io/content/blog/2024/1015-edge-release-roundup/index.md
+++ b/linkerd.io/content/blog/2024/1015-edge-release-roundup/index.md
@@ -1,11 +1,11 @@
 ---
+date: 2024-10-15T00:00:00Z
+slug: linkerd-edge-release-roundup
 title: |-
   Linkerd Edge Release Roundup: October 2024
 description: |-
   What you need to know about the most recent Linkerd edge releases, October
   2024 edition!
-date: 2024-10-15T00:00:00Z
-slug: linkerd-edge-release-roundup
 keywords: [linkerd, edge, release, roundup]
 params:
   author: flynn

--- a/linkerd.io/content/blog/2024/1023-sustainable-service-mesh/index.md
+++ b/linkerd.io/content/blog/2024/1023-sustainable-service-mesh/index.md
@@ -1,7 +1,7 @@
 ---
-title: Towards a Sustainable Service Mesh
 date: 2024-10-23T00:00:00Z
 slug: making-linkerd-sustainable
+title: Towards a Sustainable Service Mesh
 keywords: [linkerd]
 params:
   author: william


### PR DESCRIPTION
The frontmatter params in blog have been reordered:

1. The date is now the first param
2. The `slug` is now next to the `title` so it's easier to spot the differences between the two
