### PR TITLE
Fix 2 potencial bugs in docs

### DIFF
--- a/linkerd.io/layouts/docs/_docs-nav.html
+++ b/linkerd.io/layouts/docs/_docs-nav.html
@@ -54,7 +54,7 @@
         <a href="{{ .RelPermalink }}">
           {{ .LinkTitle }}
         </a>
-        {{ if and .IsSection .RegularPages }}
+        {{ if and .IsSection .Pages }}
           <input class="toggle__input" type="checkbox" id="toggle-{{ .File.UniqueID }}" {{ if $selected }}checked="checked"{{ end }}>
           <label class="toggle__label" for="toggle-{{ .File.UniqueID }}">
             {{ partial "components/icon" (dict "name" "chevron-right" "variant" "secondary") }}

--- a/linkerd.io/layouts/shortcodes/docs/section-toc.html
+++ b/linkerd.io/layouts/shortcodes/docs/section-toc.html
@@ -1,4 +1,5 @@
-{{- with .Page.Pages }}
+{{- $pages := where .Page.Pages "Params.unlisted" "ne" true }}
+{{- with $pages }}
   <ul>
     {{- range . }}
       <li>


### PR DESCRIPTION
## Bug 1

Currently, if a section in the Docs sidenav only contains child sections and not any regular pages, the submenu will not be displayed for that section. The submenu should still be displayed in this case.

With this PR, the sidenav has been fixed to show a submenu of a section, if it only contains child sections. 

There are currently not any sections in the Docs sidenav that only contain other sections, but I'm fixing this bug just in case we do in the future.

## Bug 2

Currently, the `section-toc` shortcode is incorrectly listing pages that have the `unlisted` param set.

With this PR, unlisted pages will not be shown when using the `section-toc` shortcode. 

There are currently not any index pages that use the `section-toc` shortcode and also have unlisted pages.
