### PR TITLE
Prometheus basic-auth fixes

### DIFF
--- a/linkerd.io/content/2-edge/tasks/external-prometheus.md
+++ b/linkerd.io/content/2-edge/tasks/external-prometheus.md
@@ -161,7 +161,7 @@ The `prometheusUrl` field gives you a single place through which all these
 components can be configured to an external Prometheus URL. This is allowed
 both through Helm and the CLI. Additionally, if the external Prometheus is
 secured with basic auth, you can retrieve those credentials from a Secret or
-include them credentials in the URL.
+include the credentials in the URL.
 
 ### Helm
 

--- a/linkerd.io/content/2-edge/tasks/external-prometheus.md
+++ b/linkerd.io/content/2-edge/tasks/external-prometheus.md
@@ -200,7 +200,7 @@ prometheusUrl: http://username:password@existing-prometheus.namespace:9090
 ```
 
 Finally, when using an external Prometheus and configuring the `prometheusUrl`
-field, Linkerd's Prometheus will still be included in installation unless you
+field, Linkerd's Prometheus will still be included in the installation unless you
 disable it:
 
 ```yaml

--- a/linkerd.io/content/2-edge/tasks/external-prometheus.md
+++ b/linkerd.io/content/2-edge/tasks/external-prometheus.md
@@ -26,7 +26,7 @@ Prometheus instance.
 {{< note >}}
 The below scrape configuration is a [subset of the full `linkerd-prometheus`
 scrape
-configuration](https://github.com/linkerd/linkerd2/blob/main/viz/charts/linkerd-viz/templates/prometheus.yaml#L47-L151).
+configuration](https://github.com/linkerd/linkerd2/blob/main/viz/charts/linkerd-viz/templates/prometheus.yaml#L60-L139).
 {{< /note >}}
 
 Before applying, it is important to replace templated values (present in `{{}}`)
@@ -54,7 +54,7 @@ with direct values for the below configuration to work.
       - role: pod
       relabel_configs:
       - source_labels:
-        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_label_component
         - __meta_kubernetes_pod_container_port_name
         action: keep
         regex: linkerd-service-mirror;admin-http$

--- a/linkerd.io/content/2-edge/tasks/external-prometheus.md
+++ b/linkerd.io/content/2-edge/tasks/external-prometheus.md
@@ -130,25 +130,6 @@ scrape interval:
     evaluation_interval: 10s
 ```
 
-Finally, you need to apply the following policy.
-
-```yaml
-apiVersion: policy.linkerd.io/v1alpha1
-kind: AuthorizationPolicy
-metadata:
-  name: prometheus-admin-federate
-  namespace: linkerd-viz
-spec:
-  targetRef:
-    group: policy.linkerd.io
-    kind: Server
-    name: prometheus-admin
-  requiredAuthenticationRefs:
-    - group: policy.linkerd.io
-      kind: NetworkAuthentication
-      name: kubelet
-```
-
 The running configuration of the builtin prometheus can be used as a reference.
 
 ```bash

--- a/linkerd.io/content/2-edge/tasks/external-prometheus.md
+++ b/linkerd.io/content/2-edge/tasks/external-prometheus.md
@@ -7,9 +7,10 @@ Even though [the linkerd-viz extension](../../features/dashboard/) comes with
 its own Prometheus instance, there can be cases where using an external
 instance makes more sense for various reasons.
 
-This tutorial shows how to configure an external Prometheus instance to scrape both
-the control plane as well as the proxy's metrics in a format that is consumable
-both by a user as well as Linkerd control plane components like web, etc.
+This tutorial shows how to configure an external Prometheus instance to scrape
+both the control plane as well as the proxy's metrics in a format that is
+consumable both by a user as well as Linkerd control plane components like
+web, etc.
 
 {{< docs/production-note >}}
 
@@ -24,13 +25,15 @@ The following scrape configuration has to be applied to the external
 Prometheus instance.
 
 {{< note >}}
+
 The below scrape configuration is a [subset of the full `linkerd-prometheus`
 scrape
 configuration](https://github.com/linkerd/linkerd2/blob/main/viz/charts/linkerd-viz/templates/prometheus.yaml#L60-L139).
+
 {{< /note >}}
 
-Before applying, it is important to replace templated values (present in `{{}}`)
-with direct values for the below configuration to work.
+Before applying, it is important to replace templated values (present in
+`{{}}`) with direct values for the below configuration to work.
 
 ```yaml
     - job_name: 'linkerd-controller'
@@ -154,8 +157,8 @@ kubectl -n linkerd-viz  get configmap prometheus-config -o yaml
 
 ## Linkerd-Viz Extension Configuration
 
-Linkerd's viz extension components like `metrics-api`, etc depend
-on the Prometheus instance to power the dashboard and CLI.
+Linkerd's viz extension components like `metrics-api`, etc depend on the
+Prometheus instance to power the dashboard and CLI.
 
 The `prometheusUrl` field gives you a single place through which all these
 components can be configured to an external Prometheus URL. This is allowed
@@ -200,16 +203,16 @@ prometheusUrl: http://username:password@existing-prometheus.namespace:9090
 ```
 
 Finally, when using an external Prometheus and configuring the `prometheusUrl`
-field, Linkerd's Prometheus will still be included in the installation unless you
-disable it:
+field, Linkerd's Prometheus will still be included in the installation unless
+you disable it:
 
 ```yaml
 prometheus:
   enabled: false
 ```
 
-This configuration is **not** persistent across installs: you'll need to
-pass the same `values.yaml` for re-installs, upgrades, etc.
+This configuration is **not** persistent across installs: you'll need to pass
+the same `values.yaml` for re-installs, upgrades, etc.
 
 More information on installation through Helm can be found
 [here](../install-helm/)

--- a/linkerd.io/content/2.13/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.13/tasks/external-prometheus.md
@@ -140,7 +140,7 @@ on the Prometheus instance to power the dashboard and CLI.
 
 The `prometheusUrl` field gives you a single place through
 which all these components can be configured to an external Prometheus URL.
-This is allowed both through the CLI and Helm.
+This is allowed both through the CLI and Helm. If the external Prometheus is secured with basic auth, you can include the credentials in the URL as well.
 
 ### CLI
 
@@ -148,7 +148,7 @@ This can be done by passing a file with the above field to the `values` flag,
 which is available through `linkerd viz install` command.
 
 ```yaml
-prometheusUrl: existing-prometheus.xyz:9090
+prometheusUrl: http://username:password@existing-prometheus.namespace:9090
 ```
 
 Once applied, this configuration is not persistent across installs.

--- a/linkerd.io/content/2.13/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.13/tasks/external-prometheus.md
@@ -140,14 +140,13 @@ on the Prometheus instance to power the dashboard and CLI.
 
 The `prometheusUrl` field gives you a single place through
 which all these components can be configured to an external Prometheus URL.
-This is allowed both through the CLI and Helm.
-If the external Prometheus is secured with basic auth,
-you can include the credentials in the URL as well.
+This is allowed both through Helm and the CLI. If the external Prometheus is
+secured with basic auth, you can include the credentials in the URL as well.
 
-### CLI
+### Helm
 
-This can be done by passing a file with the above field to the `values` flag,
-which is available through `linkerd viz install` command.
+To configure an external Prometheus instance through Helm, you'll set
+`prometheusUrl` in your `values.yaml` file:
 
 ```yaml
 prometheusUrl: http://existing-prometheus.namespace:9090
@@ -160,9 +159,6 @@ credentials in the URL as well.
 prometheusUrl: http://username:password@existing-prometheus.namespace:9090
 ```
 
-Once applied, this configuration is not persistent across installs.
-The same has to be passed again by the user during re-installs, upgrades, etc.
-
 When using an external Prometheus and configuring the `prometheusUrl`
 field, Linkerd's Prometheus will still be included in installation.
 If you wish to disable it, be sure to include the
@@ -173,11 +169,20 @@ prometheus:
   enabled: false
 ```
 
-### Helm
-
-The same configuration can be applied through `values.yaml` when using Helm.
-Once applied, Helm makes sure that the configuration is
-persistent across upgrades.
+This configuration is **not** persistent across installs: you'll need to
+pass the same `values.yaml` for re-installs, upgrades, etc.
 
 More information on installation through Helm can be found
 [here](../install-helm/)
+
+### CLI
+
+When installing using the CLI, you can use the `--values` switch to use the
+same `values.yaml` that you would with Helm, or you can set the
+`prometheusUrl` directly, for example:
+
+```bash
+linkerd viz install \
+    --set prometheus.enabled=false \
+    --set prometheusUrl=http://existing-prometheus.namespace:9090
+```

--- a/linkerd.io/content/2.13/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.13/tasks/external-prometheus.md
@@ -26,7 +26,7 @@ Prometheus instance.
 {{< note >}}
 The below scrape configuration is a [subset of the full `linkerd-prometheus`
 scrape
-configuration](https://github.com/linkerd/linkerd2/blob/main/viz/charts/linkerd-viz/templates/prometheus.yaml#L47-L151).
+configuration](https://github.com/linkerd/linkerd2/blob/main/viz/charts/linkerd-viz/templates/prometheus.yaml#L60-L139).
 {{< /note >}}
 
 Before applying, it is important to replace templated values (present in `{{}}`)
@@ -54,7 +54,7 @@ with direct values for the below configuration to work.
       - role: pod
       relabel_configs:
       - source_labels:
-        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_label_component
         - __meta_kubernetes_pod_container_port_name
         action: keep
         regex: linkerd-service-mirror;admin-http$

--- a/linkerd.io/content/2.13/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.13/tasks/external-prometheus.md
@@ -7,9 +7,10 @@ Even though [the linkerd-viz extension](../../features/dashboard/) comes with
 its own Prometheus instance, there can be cases where using an external
 instance makes more sense for various reasons.
 
-This tutorial shows how to configure an external Prometheus instance to scrape both
-the control plane as well as the proxy's metrics in a format that is consumable
-both by a user as well as Linkerd control plane components like web, etc.
+This tutorial shows how to configure an external Prometheus instance to scrape
+both the control plane as well as the proxy's metrics in a format that is
+consumable both by a user as well as Linkerd control plane components like
+web, etc.
 
 {{< docs/production-note >}}
 
@@ -24,13 +25,15 @@ The following scrape configuration has to be applied to the external
 Prometheus instance.
 
 {{< note >}}
+
 The below scrape configuration is a [subset of the full `linkerd-prometheus`
 scrape
 configuration](https://github.com/linkerd/linkerd2/blob/main/viz/charts/linkerd-viz/templates/prometheus.yaml#L60-L139).
+
 {{< /note >}}
 
-Before applying, it is important to replace templated values (present in `{{}}`)
-with direct values for the below configuration to work.
+Before applying, it is important to replace templated values (present in
+`{{}}`) with direct values for the below configuration to work.
 
 ```yaml
     - job_name: 'linkerd-controller'
@@ -135,13 +138,13 @@ kubectl -n linkerd-viz  get configmap prometheus-config -o yaml
 
 ## Linkerd-Viz Extension Configuration
 
-Linkerd's viz extension components like `metrics-api`, etc depend
-on the Prometheus instance to power the dashboard and CLI.
+Linkerd's viz extension components like `metrics-api`, etc depend on the
+Prometheus instance to power the dashboard and CLI.
 
-The `prometheusUrl` field gives you a single place through
-which all these components can be configured to an external Prometheus URL.
-This is allowed both through Helm and the CLI. If the external Prometheus is
-secured with basic auth, you can include the credentials in the URL as well.
+The `prometheusUrl` field gives you a single place through which all these
+components can be configured to an external Prometheus URL. This is allowed
+both through Helm and the CLI. If the external Prometheus is secured with
+basic auth, you can include the credentials in the URL as well.
 
 ### Helm
 
@@ -159,18 +162,17 @@ credentials in the URL as well.
 prometheusUrl: http://username:password@existing-prometheus.namespace:9090
 ```
 
-When using an external Prometheus and configuring the `prometheusUrl`
-field, Linkerd's Prometheus will still be included in the installation.
-If you wish to disable it, be sure to include the
-following configuration as well:
+When using an external Prometheus and configuring the `prometheusUrl` field,
+Linkerd's Prometheus will still be included in the installation. If you wish
+to disable it, be sure to include the following configuration as well:
 
 ```yaml
 prometheus:
   enabled: false
 ```
 
-This configuration is **not** persistent across installs: you'll need to
-pass the same `values.yaml` for re-installs, upgrades, etc.
+This configuration is **not** persistent across installs: you'll need to pass
+the same `values.yaml` for re-installs, upgrades, etc.
 
 More information on installation through Helm can be found
 [here](../install-helm/)

--- a/linkerd.io/content/2.13/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.13/tasks/external-prometheus.md
@@ -140,12 +140,21 @@ on the Prometheus instance to power the dashboard and CLI.
 
 The `prometheusUrl` field gives you a single place through
 which all these components can be configured to an external Prometheus URL.
-This is allowed both through the CLI and Helm. If the external Prometheus is secured with basic auth, you can include the credentials in the URL as well.
+This is allowed both through the CLI and Helm.
+If the external Prometheus is secured with basic auth,
+you can include the credentials in the URL as well.
 
 ### CLI
 
 This can be done by passing a file with the above field to the `values` flag,
 which is available through `linkerd viz install` command.
+
+```yaml
+prometheusUrl: http://existing-prometheus.namespace:9090
+```
+
+If the external Prometheus is secured with basic auth, you can include the
+credentials in the URL as well.
 
 ```yaml
 prometheusUrl: http://username:password@existing-prometheus.namespace:9090

--- a/linkerd.io/content/2.13/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.13/tasks/external-prometheus.md
@@ -160,7 +160,7 @@ prometheusUrl: http://username:password@existing-prometheus.namespace:9090
 ```
 
 When using an external Prometheus and configuring the `prometheusUrl`
-field, Linkerd's Prometheus will still be included in installation.
+field, Linkerd's Prometheus will still be included in the installation.
 If you wish to disable it, be sure to include the
 following configuration as well:
 

--- a/linkerd.io/content/2.14/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.14/tasks/external-prometheus.md
@@ -141,6 +141,8 @@ on the Prometheus instance to power the dashboard and CLI.
 The `prometheusUrl` field gives you a single place through
 which all these components can be configured to an external Prometheus URL.
 This is allowed both through the CLI and Helm.
+If the external Prometheus is secured with basic auth,
+you can include the credentials in the URL as well.
 
 ### CLI
 
@@ -148,7 +150,14 @@ This can be done by passing a file with the above field to the `values` flag,
 which is available through `linkerd viz install` command.
 
 ```yaml
-prometheusUrl: existing-prometheus.xyz:9090
+prometheusUrl: http://existing-prometheus.namespace:9090
+```
+
+If the external Prometheus is secured with basic auth, you can include the
+credentials in the URL as well.
+
+```yaml
+prometheusUrl: http://username:password@existing-prometheus.namespace:9090
 ```
 
 Once applied, this configuration is not persistent across installs.

--- a/linkerd.io/content/2.14/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.14/tasks/external-prometheus.md
@@ -140,14 +140,13 @@ on the Prometheus instance to power the dashboard and CLI.
 
 The `prometheusUrl` field gives you a single place through
 which all these components can be configured to an external Prometheus URL.
-This is allowed both through the CLI and Helm.
-If the external Prometheus is secured with basic auth,
-you can include the credentials in the URL as well.
+This is allowed both through Helm and the CLI. If the external Prometheus is
+secured with basic auth, you can include the credentials in the URL as well.
 
-### CLI
+### Helm
 
-This can be done by passing a file with the above field to the `values` flag,
-which is available through `linkerd viz install` command.
+To configure an external Prometheus instance through Helm, you'll set
+`prometheusUrl` in your `values.yaml` file:
 
 ```yaml
 prometheusUrl: http://existing-prometheus.namespace:9090
@@ -160,9 +159,6 @@ credentials in the URL as well.
 prometheusUrl: http://username:password@existing-prometheus.namespace:9090
 ```
 
-Once applied, this configuration is not persistent across installs.
-The same has to be passed again by the user during re-installs, upgrades, etc.
-
 When using an external Prometheus and configuring the `prometheusUrl`
 field, Linkerd's Prometheus will still be included in installation.
 If you wish to disable it, be sure to include the
@@ -173,11 +169,20 @@ prometheus:
   enabled: false
 ```
 
-### Helm
-
-The same configuration can be applied through `values.yaml` when using Helm.
-Once applied, Helm makes sure that the configuration is
-persistent across upgrades.
+This configuration is **not** persistent across installs: you'll need to
+pass the same `values.yaml` for re-installs, upgrades, etc.
 
 More information on installation through Helm can be found
 [here](../install-helm/)
+
+### CLI
+
+When installing using the CLI, you can use the `--values` switch to use the
+same `values.yaml` that you would with Helm, or you can set the
+`prometheusUrl` directly, for example:
+
+```bash
+linkerd viz install \
+    --set prometheus.enabled=false \
+    --set prometheusUrl=http://existing-prometheus.namespace:9090
+```

--- a/linkerd.io/content/2.14/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.14/tasks/external-prometheus.md
@@ -26,7 +26,7 @@ Prometheus instance.
 {{< note >}}
 The below scrape configuration is a [subset of the full `linkerd-prometheus`
 scrape
-configuration](https://github.com/linkerd/linkerd2/blob/main/viz/charts/linkerd-viz/templates/prometheus.yaml#L47-L151).
+configuration](https://github.com/linkerd/linkerd2/blob/main/viz/charts/linkerd-viz/templates/prometheus.yaml#L60-L139).
 {{< /note >}}
 
 Before applying, it is important to replace templated values (present in `{{}}`)
@@ -54,7 +54,7 @@ with direct values for the below configuration to work.
       - role: pod
       relabel_configs:
       - source_labels:
-        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_label_component
         - __meta_kubernetes_pod_container_port_name
         action: keep
         regex: linkerd-service-mirror;admin-http$

--- a/linkerd.io/content/2.14/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.14/tasks/external-prometheus.md
@@ -7,9 +7,10 @@ Even though [the linkerd-viz extension](../../features/dashboard/) comes with
 its own Prometheus instance, there can be cases where using an external
 instance makes more sense for various reasons.
 
-This tutorial shows how to configure an external Prometheus instance to scrape both
-the control plane as well as the proxy's metrics in a format that is consumable
-both by a user as well as Linkerd control plane components like web, etc.
+This tutorial shows how to configure an external Prometheus instance to scrape
+both the control plane as well as the proxy's metrics in a format that is
+consumable both by a user as well as Linkerd control plane components like
+web, etc.
 
 {{< docs/production-note >}}
 
@@ -24,13 +25,15 @@ The following scrape configuration has to be applied to the external
 Prometheus instance.
 
 {{< note >}}
+
 The below scrape configuration is a [subset of the full `linkerd-prometheus`
 scrape
 configuration](https://github.com/linkerd/linkerd2/blob/main/viz/charts/linkerd-viz/templates/prometheus.yaml#L60-L139).
+
 {{< /note >}}
 
-Before applying, it is important to replace templated values (present in `{{}}`)
-with direct values for the below configuration to work.
+Before applying, it is important to replace templated values (present in
+`{{}}`) with direct values for the below configuration to work.
 
 ```yaml
     - job_name: 'linkerd-controller'
@@ -135,13 +138,13 @@ kubectl -n linkerd-viz  get configmap prometheus-config -o yaml
 
 ## Linkerd-Viz Extension Configuration
 
-Linkerd's viz extension components like `metrics-api`, etc depend
-on the Prometheus instance to power the dashboard and CLI.
+Linkerd's viz extension components like `metrics-api`, etc depend on the
+Prometheus instance to power the dashboard and CLI.
 
-The `prometheusUrl` field gives you a single place through
-which all these components can be configured to an external Prometheus URL.
-This is allowed both through Helm and the CLI. If the external Prometheus is
-secured with basic auth, you can include the credentials in the URL as well.
+The `prometheusUrl` field gives you a single place through which all these
+components can be configured to an external Prometheus URL. This is allowed
+both through Helm and the CLI. If the external Prometheus is secured with
+basic auth, you can include the credentials in the URL as well.
 
 ### Helm
 
@@ -159,18 +162,17 @@ credentials in the URL as well.
 prometheusUrl: http://username:password@existing-prometheus.namespace:9090
 ```
 
-When using an external Prometheus and configuring the `prometheusUrl`
-field, Linkerd's Prometheus will still be included in the installation.
-If you wish to disable it, be sure to include the
-following configuration as well:
+When using an external Prometheus and configuring the `prometheusUrl` field,
+Linkerd's Prometheus will still be included in the installation. If you wish
+to disable it, be sure to include the following configuration as well:
 
 ```yaml
 prometheus:
   enabled: false
 ```
 
-This configuration is **not** persistent across installs: you'll need to
-pass the same `values.yaml` for re-installs, upgrades, etc.
+This configuration is **not** persistent across installs: you'll need to pass
+the same `values.yaml` for re-installs, upgrades, etc.
 
 More information on installation through Helm can be found
 [here](../install-helm/)

--- a/linkerd.io/content/2.14/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.14/tasks/external-prometheus.md
@@ -160,7 +160,7 @@ prometheusUrl: http://username:password@existing-prometheus.namespace:9090
 ```
 
 When using an external Prometheus and configuring the `prometheusUrl`
-field, Linkerd's Prometheus will still be included in installation.
+field, Linkerd's Prometheus will still be included in the installation.
 If you wish to disable it, be sure to include the
 following configuration as well:
 

--- a/linkerd.io/content/2.15/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.15/tasks/external-prometheus.md
@@ -26,7 +26,7 @@ Prometheus instance.
 {{< note >}}
 The below scrape configuration is a [subset of the full `linkerd-prometheus`
 scrape
-configuration](https://github.com/linkerd/linkerd2/blob/main/viz/charts/linkerd-viz/templates/prometheus.yaml#L47-L151).
+configuration](https://github.com/linkerd/linkerd2/blob/main/viz/charts/linkerd-viz/templates/prometheus.yaml#L60-L139).
 {{< /note >}}
 
 Before applying, it is important to replace templated values (present in `{{}}`)
@@ -54,7 +54,7 @@ with direct values for the below configuration to work.
       - role: pod
       relabel_configs:
       - source_labels:
-        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_label_component
         - __meta_kubernetes_pod_container_port_name
         action: keep
         regex: linkerd-service-mirror;admin-http$

--- a/linkerd.io/content/2.15/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.15/tasks/external-prometheus.md
@@ -7,9 +7,10 @@ Even though [the linkerd-viz extension](../../features/dashboard/) comes with
 its own Prometheus instance, there can be cases where using an external
 instance makes more sense for various reasons.
 
-This tutorial shows how to configure an external Prometheus instance to scrape both
-the control plane as well as the proxy's metrics in a format that is consumable
-both by a user as well as Linkerd control plane components like web, etc.
+This tutorial shows how to configure an external Prometheus instance to scrape
+both the control plane as well as the proxy's metrics in a format that is
+consumable both by a user as well as Linkerd control plane components like
+web, etc.
 
 {{< docs/production-note >}}
 
@@ -24,13 +25,15 @@ The following scrape configuration has to be applied to the external
 Prometheus instance.
 
 {{< note >}}
+
 The below scrape configuration is a [subset of the full `linkerd-prometheus`
 scrape
 configuration](https://github.com/linkerd/linkerd2/blob/main/viz/charts/linkerd-viz/templates/prometheus.yaml#L60-L139).
+
 {{< /note >}}
 
-Before applying, it is important to replace templated values (present in `{{}}`)
-with direct values for the below configuration to work.
+Before applying, it is important to replace templated values (present in
+`{{}}`) with direct values for the below configuration to work.
 
 ```yaml
     - job_name: 'linkerd-controller'
@@ -135,13 +138,13 @@ kubectl -n linkerd-viz  get configmap prometheus-config -o yaml
 
 ## Linkerd-Viz Extension Configuration
 
-Linkerd's viz extension components like `metrics-api`, etc depend
-on the Prometheus instance to power the dashboard and CLI.
+Linkerd's viz extension components like `metrics-api`, etc depend on the
+Prometheus instance to power the dashboard and CLI.
 
-The `prometheusUrl` field gives you a single place through
-which all these components can be configured to an external Prometheus URL.
-This is allowed both through Helm and the CLI. If the external Prometheus is
-secured with basic auth, you can include the credentials in the URL as well.
+The `prometheusUrl` field gives you a single place through which all these
+components can be configured to an external Prometheus URL. This is allowed
+both through Helm and the CLI. If the external Prometheus is secured with
+basic auth, you can include the credentials in the URL as well.
 
 ### Helm
 
@@ -159,18 +162,17 @@ credentials in the URL as well.
 prometheusUrl: http://username:password@existing-prometheus.namespace:9090
 ```
 
-When using an external Prometheus and configuring the `prometheusUrl`
-field, Linkerd's Prometheus will still be included in the installation.
-If you wish to disable it, be sure to include the
-following configuration as well:
+When using an external Prometheus and configuring the `prometheusUrl` field,
+Linkerd's Prometheus will still be included in the installation. If you wish
+to disable it, be sure to include the following configuration as well:
 
 ```yaml
 prometheus:
   enabled: false
 ```
 
-This configuration is **not** persistent across installs: you'll need to
-pass the same `values.yaml` for re-installs, upgrades, etc.
+This configuration is **not** persistent across installs: you'll need to pass
+the same `values.yaml` for re-installs, upgrades, etc.
 
 More information on installation through Helm can be found
 [here](../install-helm/)

--- a/linkerd.io/content/2.15/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.15/tasks/external-prometheus.md
@@ -160,7 +160,7 @@ prometheusUrl: http://username:password@existing-prometheus.namespace:9090
 ```
 
 When using an external Prometheus and configuring the `prometheusUrl`
-field, Linkerd's Prometheus will still be included in installation.
+field, Linkerd's Prometheus will still be included in the installation.
 If you wish to disable it, be sure to include the
 following configuration as well:
 

--- a/linkerd.io/content/2.15/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.15/tasks/external-prometheus.md
@@ -140,19 +140,24 @@ on the Prometheus instance to power the dashboard and CLI.
 
 The `prometheusUrl` field gives you a single place through
 which all these components can be configured to an external Prometheus URL.
-This is allowed both through the CLI and Helm.
+This is allowed both through Helm and the CLI. If the external Prometheus is
+secured with basic auth, you can include the credentials in the URL as well.
 
-### CLI
+### Helm
 
-This can be done by passing a file with the above field to the `values` flag,
-which is available through `linkerd viz install` command.
+To configure an external Prometheus instance through Helm, you'll set
+`prometheusUrl` in your `values.yaml` file:
 
 ```yaml
-prometheusUrl: existing-prometheus.xyz:9090
+prometheusUrl: http://existing-prometheus.namespace:9090
 ```
 
-Once applied, this configuration is not persistent across installs.
-The same has to be passed again by the user during re-installs, upgrades, etc.
+If the external Prometheus is secured with basic auth, you can include the
+credentials in the URL as well.
+
+```yaml
+prometheusUrl: http://username:password@existing-prometheus.namespace:9090
+```
 
 When using an external Prometheus and configuring the `prometheusUrl`
 field, Linkerd's Prometheus will still be included in installation.
@@ -164,11 +169,20 @@ prometheus:
   enabled: false
 ```
 
-### Helm
-
-The same configuration can be applied through `values.yaml` when using Helm.
-Once applied, Helm makes sure that the configuration is
-persistent across upgrades.
+This configuration is **not** persistent across installs: you'll need to
+pass the same `values.yaml` for re-installs, upgrades, etc.
 
 More information on installation through Helm can be found
 [here](../install-helm/)
+
+### CLI
+
+When installing using the CLI, you can use the `--values` switch to use the
+same `values.yaml` that you would with Helm, or you can set the
+`prometheusUrl` directly, for example:
+
+```bash
+linkerd viz install \
+    --set prometheus.enabled=false \
+    --set prometheusUrl=http://existing-prometheus.namespace:9090
+```

--- a/linkerd.io/content/2.16/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.16/tasks/external-prometheus.md
@@ -26,7 +26,7 @@ Prometheus instance.
 {{< note >}}
 The below scrape configuration is a [subset of the full `linkerd-prometheus`
 scrape
-configuration](https://github.com/linkerd/linkerd2/blob/main/viz/charts/linkerd-viz/templates/prometheus.yaml#L47-L151).
+configuration](https://github.com/linkerd/linkerd2/blob/main/viz/charts/linkerd-viz/templates/prometheus.yaml#L60-L139).
 {{< /note >}}
 
 Before applying, it is important to replace templated values (present in `{{}}`)
@@ -54,7 +54,7 @@ with direct values for the below configuration to work.
       - role: pod
       relabel_configs:
       - source_labels:
-        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_label_component
         - __meta_kubernetes_pod_container_port_name
         action: keep
         regex: linkerd-service-mirror;admin-http$

--- a/linkerd.io/content/2.16/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.16/tasks/external-prometheus.md
@@ -7,9 +7,10 @@ Even though [the linkerd-viz extension](../../features/dashboard/) comes with
 its own Prometheus instance, there can be cases where using an external
 instance makes more sense for various reasons.
 
-This tutorial shows how to configure an external Prometheus instance to scrape both
-the control plane as well as the proxy's metrics in a format that is consumable
-both by a user as well as Linkerd control plane components like web, etc.
+This tutorial shows how to configure an external Prometheus instance to scrape
+both the control plane as well as the proxy's metrics in a format that is
+consumable both by a user as well as Linkerd control plane components like
+web, etc.
 
 {{< docs/production-note >}}
 
@@ -24,13 +25,15 @@ The following scrape configuration has to be applied to the external
 Prometheus instance.
 
 {{< note >}}
+
 The below scrape configuration is a [subset of the full `linkerd-prometheus`
 scrape
 configuration](https://github.com/linkerd/linkerd2/blob/main/viz/charts/linkerd-viz/templates/prometheus.yaml#L60-L139).
+
 {{< /note >}}
 
-Before applying, it is important to replace templated values (present in `{{}}`)
-with direct values for the below configuration to work.
+Before applying, it is important to replace templated values (present in
+`{{}}`) with direct values for the below configuration to work.
 
 ```yaml
     - job_name: 'linkerd-controller'
@@ -135,13 +138,13 @@ kubectl -n linkerd-viz  get configmap prometheus-config -o yaml
 
 ## Linkerd-Viz Extension Configuration
 
-Linkerd's viz extension components like `metrics-api`, etc depend
-on the Prometheus instance to power the dashboard and CLI.
+Linkerd's viz extension components like `metrics-api`, etc depend on the
+Prometheus instance to power the dashboard and CLI.
 
-The `prometheusUrl` field gives you a single place through
-which all these components can be configured to an external Prometheus URL.
-This is allowed both through Helm and the CLI. If the external Prometheus is
-secured with basic auth, you can include the credentials in the URL as well.
+The `prometheusUrl` field gives you a single place through which all these
+components can be configured to an external Prometheus URL. This is allowed
+both through Helm and the CLI. If the external Prometheus is secured with
+basic auth, you can include the credentials in the URL as well.
 
 ### Helm
 
@@ -159,18 +162,17 @@ credentials in the URL as well.
 prometheusUrl: http://username:password@existing-prometheus.namespace:9090
 ```
 
-When using an external Prometheus and configuring the `prometheusUrl`
-field, Linkerd's Prometheus will still be included in the installation.
-If you wish to disable it, be sure to include the
-following configuration as well:
+When using an external Prometheus and configuring the `prometheusUrl` field,
+Linkerd's Prometheus will still be included in the installation. If you wish
+to disable it, be sure to include the following configuration as well:
 
 ```yaml
 prometheus:
   enabled: false
 ```
 
-This configuration is **not** persistent across installs: you'll need to
-pass the same `values.yaml` for re-installs, upgrades, etc.
+This configuration is **not** persistent across installs: you'll need to pass
+the same `values.yaml` for re-installs, upgrades, etc.
 
 More information on installation through Helm can be found
 [here](../install-helm/)

--- a/linkerd.io/content/2.16/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.16/tasks/external-prometheus.md
@@ -160,7 +160,7 @@ prometheusUrl: http://username:password@existing-prometheus.namespace:9090
 ```
 
 When using an external Prometheus and configuring the `prometheusUrl`
-field, Linkerd's Prometheus will still be included in installation.
+field, Linkerd's Prometheus will still be included in the installation.
 If you wish to disable it, be sure to include the
 following configuration as well:
 

--- a/linkerd.io/content/2.16/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.16/tasks/external-prometheus.md
@@ -140,19 +140,24 @@ on the Prometheus instance to power the dashboard and CLI.
 
 The `prometheusUrl` field gives you a single place through
 which all these components can be configured to an external Prometheus URL.
-This is allowed both through the CLI and Helm.
+This is allowed both through Helm and the CLI. If the external Prometheus is
+secured with basic auth, you can include the credentials in the URL as well.
 
-### CLI
+### Helm
 
-This can be done by passing a file with the above field to the `values` flag,
-which is available through `linkerd viz install` command.
+To configure an external Prometheus instance through Helm, you'll set
+`prometheusUrl` in your `values.yaml` file:
 
 ```yaml
-prometheusUrl: existing-prometheus.xyz:9090
+prometheusUrl: http://existing-prometheus.namespace:9090
 ```
 
-Once applied, this configuration is not persistent across installs.
-The same has to be passed again by the user during re-installs, upgrades, etc.
+If the external Prometheus is secured with basic auth, you can include the
+credentials in the URL as well.
+
+```yaml
+prometheusUrl: http://username:password@existing-prometheus.namespace:9090
+```
 
 When using an external Prometheus and configuring the `prometheusUrl`
 field, Linkerd's Prometheus will still be included in installation.
@@ -164,11 +169,20 @@ prometheus:
   enabled: false
 ```
 
-### Helm
-
-The same configuration can be applied through `values.yaml` when using Helm.
-Once applied, Helm makes sure that the configuration is
-persistent across upgrades.
+This configuration is **not** persistent across installs: you'll need to
+pass the same `values.yaml` for re-installs, upgrades, etc.
 
 More information on installation through Helm can be found
 [here](../install-helm/)
+
+### CLI
+
+When installing using the CLI, you can use the `--values` switch to use the
+same `values.yaml` that you would with Helm, or you can set the
+`prometheusUrl` directly, for example:
+
+```bash
+linkerd viz install \
+    --set prometheus.enabled=false \
+    --set prometheusUrl=http://existing-prometheus.namespace:9090
+```

--- a/linkerd.io/content/2.17/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.17/tasks/external-prometheus.md
@@ -142,7 +142,7 @@ The `prometheusUrl` field gives you a single place through which all these
 components can be configured to an external Prometheus URL. This is allowed
 both through Helm and the CLI. Additionally, if the external Prometheus is
 secured with basic auth, you can retrieve those credentials from a Secret or
-include them credentials in the URL.
+include the credentials in the URL.
 
 ### Helm
 

--- a/linkerd.io/content/2.17/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.17/tasks/external-prometheus.md
@@ -26,7 +26,7 @@ Prometheus instance.
 {{< note >}}
 The below scrape configuration is a [subset of the full `linkerd-prometheus`
 scrape
-configuration](https://github.com/linkerd/linkerd2/blob/main/viz/charts/linkerd-viz/templates/prometheus.yaml#L47-L151).
+configuration](https://github.com/linkerd/linkerd2/blob/main/viz/charts/linkerd-viz/templates/prometheus.yaml#L60-L139).
 {{< /note >}}
 
 Before applying, it is important to replace templated values (present in `{{}}`)
@@ -54,7 +54,7 @@ with direct values for the below configuration to work.
       - role: pod
       relabel_configs:
       - source_labels:
-        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_label_component
         - __meta_kubernetes_pod_container_port_name
         action: keep
         regex: linkerd-service-mirror;admin-http$

--- a/linkerd.io/content/2.17/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.17/tasks/external-prometheus.md
@@ -181,7 +181,7 @@ prometheusUrl: http://username:password@existing-prometheus.namespace:9090
 ```
 
 Finally, when using an external Prometheus and configuring the `prometheusUrl`
-field, Linkerd's Prometheus will still be included in installation unless you
+field, Linkerd's Prometheus will still be included in the installation unless you
 disable it:
 
 ```yaml

--- a/linkerd.io/content/2.17/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.17/tasks/external-prometheus.md
@@ -138,37 +138,80 @@ kubectl -n linkerd-viz  get configmap prometheus-config -o yaml
 Linkerd's viz extension components like `metrics-api`, etc depend
 on the Prometheus instance to power the dashboard and CLI.
 
-The `prometheusUrl` field gives you a single place through
-which all these components can be configured to an external Prometheus URL.
-This is allowed both through the CLI and Helm.
+The `prometheusUrl` field gives you a single place through which all these
+components can be configured to an external Prometheus URL. This is allowed
+both through Helm and the CLI. Additionally, if the external Prometheus is
+secured with basic auth, you can retrieve those credentials from a Secret or
+include them credentials in the URL.
 
-### CLI
+### Helm
 
-This can be done by passing a file with the above field to the `values` flag,
-which is available through `linkerd viz install` command.
+To configure an external Prometheus instance through Helm, you'll set
+`prometheusUrl` in your `values.yaml` file:
 
 ```yaml
-prometheusUrl: existing-prometheus.xyz:9090
+prometheusUrl: http://existing-prometheus.namespace:9090
 ```
 
-Once applied, this configuration is not persistent across installs.
-The same has to be passed again by the user during re-installs, upgrades, etc.
+If the external Prometheus is secured with basic auth, you can either store
+the credentials in a Secret or you can put them directly into the URL.
 
-When using an external Prometheus and configuring the `prometheusUrl`
-field, Linkerd's Prometheus will still be included in installation.
-If you wish to disable it, be sure to include the
-following configuration as well:
+We recommend using a Secret -- first, create the Secret, which must be in the
+same namespace as Linkerd Viz itself:
+
+```yaml
+kubectl create secret generic \
+  prometheus-credentials -n linkerd-viz \
+  --from-literal=user=your-username
+  --from-literal=password=your-password
+```
+
+Then reference the Secret in your `values.yaml`:
+
+```yaml
+prometheusUrl: http://existing-prometheus.namespace:9090
+prometheusCredsSecret: prometheus-credentials
+```
+
+If you can't use a Secret, you can include the credentials directly in the URL
+instead:
+
+```yaml
+prometheusUrl: http://username:password@existing-prometheus.namespace:9090
+```
+
+Finally, when using an external Prometheus and configuring the `prometheusUrl`
+field, Linkerd's Prometheus will still be included in installation unless you
+disable it:
 
 ```yaml
 prometheus:
   enabled: false
 ```
 
-### Helm
-
-The same configuration can be applied through `values.yaml` when using Helm.
-Once applied, Helm makes sure that the configuration is
-persistent across upgrades.
+This configuration is **not** persistent across installs: you'll need to
+pass the same `values.yaml` for re-installs, upgrades, etc.
 
 More information on installation through Helm can be found
 [here](../install-helm/)
+
+### CLI
+
+When installing using the CLI, you can use the `--values` switch to use the
+same `values.yaml` that you would with Helm, or you can set the
+`prometheusUrl` directly, for example:
+
+```bash
+linkerd viz install \
+    --set prometheus.enabled=false \
+    --set prometheusUrl=http://existing-prometheus.namespace:9090
+```
+
+You can also set the `prometheusCredsSecret` directly:
+
+```bash
+linkerd viz install \
+    --set prometheus.enabled=false \
+    --set prometheusUrl=http://existing-prometheus.namespace:9090 \
+    --set prometheusCredsSecret=prometheus-credentials
+```

--- a/linkerd.io/content/2.17/tasks/external-prometheus.md
+++ b/linkerd.io/content/2.17/tasks/external-prometheus.md
@@ -7,9 +7,10 @@ Even though [the linkerd-viz extension](../../features/dashboard/) comes with
 its own Prometheus instance, there can be cases where using an external
 instance makes more sense for various reasons.
 
-This tutorial shows how to configure an external Prometheus instance to scrape both
-the control plane as well as the proxy's metrics in a format that is consumable
-both by a user as well as Linkerd control plane components like web, etc.
+This tutorial shows how to configure an external Prometheus instance to scrape
+both the control plane as well as the proxy's metrics in a format that is
+consumable both by a user as well as Linkerd control plane components like
+web, etc.
 
 {{< docs/production-note >}}
 
@@ -24,13 +25,15 @@ The following scrape configuration has to be applied to the external
 Prometheus instance.
 
 {{< note >}}
+
 The below scrape configuration is a [subset of the full `linkerd-prometheus`
 scrape
 configuration](https://github.com/linkerd/linkerd2/blob/main/viz/charts/linkerd-viz/templates/prometheus.yaml#L60-L139).
+
 {{< /note >}}
 
-Before applying, it is important to replace templated values (present in `{{}}`)
-with direct values for the below configuration to work.
+Before applying, it is important to replace templated values (present in
+`{{}}`) with direct values for the below configuration to work.
 
 ```yaml
     - job_name: 'linkerd-controller'
@@ -135,8 +138,8 @@ kubectl -n linkerd-viz  get configmap prometheus-config -o yaml
 
 ## Linkerd-Viz Extension Configuration
 
-Linkerd's viz extension components like `metrics-api`, etc depend
-on the Prometheus instance to power the dashboard and CLI.
+Linkerd's viz extension components like `metrics-api`, etc depend on the
+Prometheus instance to power the dashboard and CLI.
 
 The `prometheusUrl` field gives you a single place through which all these
 components can be configured to an external Prometheus URL. This is allowed
@@ -181,16 +184,16 @@ prometheusUrl: http://username:password@existing-prometheus.namespace:9090
 ```
 
 Finally, when using an external Prometheus and configuring the `prometheusUrl`
-field, Linkerd's Prometheus will still be included in the installation unless you
-disable it:
+field, Linkerd's Prometheus will still be included in the installation unless
+you disable it:
 
 ```yaml
 prometheus:
   enabled: false
 ```
 
-This configuration is **not** persistent across installs: you'll need to
-pass the same `values.yaml` for re-installs, upgrades, etc.
+This configuration is **not** persistent across installs: you'll need to pass
+the same `values.yaml` for re-installs, upgrades, etc.
 
 More information on installation through Helm can be found
 [here](../install-helm/)


### PR DESCRIPTION
Originally by @JadKHaddad in #1659, thanks!

- **Subject: Communication Issue Between Viz and External Prometheus**
- **Example without basic auth added. Same changes in 2.14 done**
- **Update for 2.14+, and talk about basic-auth Secrets for 2.17 & 2-edge.**
