### PR TITLE
Fix incorrect value in Configuring Proxy Concurrency task page

### DIFF
--- a/linkerd.io/content/2-edge/tasks/configuring-proxy-concurrency.md
+++ b/linkerd.io/content/2-edge/tasks/configuring-proxy-concurrency.md
@@ -65,7 +65,7 @@ spec:
   template:
     metadata:
       annotations:
-        config.linkerd.io/proxy-cpu-limit: '1'
+        config.linkerd.io/proxy-cpu-limit: '2'
   # ...
 ```
 

--- a/linkerd.io/content/2.10/tasks/configuring-proxy-concurrency.md
+++ b/linkerd.io/content/2.10/tasks/configuring-proxy-concurrency.md
@@ -61,7 +61,7 @@ spec:
   template:
     metadata:
       annotations:
-        config.linkerd.io/proxy-cpu-limit: '1'
+        config.linkerd.io/proxy-cpu-limit: '2'
   # ...
 ```
 

--- a/linkerd.io/content/2.11/tasks/configuring-proxy-concurrency.md
+++ b/linkerd.io/content/2.11/tasks/configuring-proxy-concurrency.md
@@ -61,7 +61,7 @@ spec:
   template:
     metadata:
       annotations:
-        config.linkerd.io/proxy-cpu-limit: '1'
+        config.linkerd.io/proxy-cpu-limit: '2'
   # ...
 ```
 

--- a/linkerd.io/content/2.12/tasks/configuring-proxy-concurrency.md
+++ b/linkerd.io/content/2.12/tasks/configuring-proxy-concurrency.md
@@ -65,7 +65,7 @@ spec:
   template:
     metadata:
       annotations:
-        config.linkerd.io/proxy-cpu-limit: '1'
+        config.linkerd.io/proxy-cpu-limit: '2'
   # ...
 ```
 

--- a/linkerd.io/content/2.13/tasks/configuring-proxy-concurrency.md
+++ b/linkerd.io/content/2.13/tasks/configuring-proxy-concurrency.md
@@ -65,7 +65,7 @@ spec:
   template:
     metadata:
       annotations:
-        config.linkerd.io/proxy-cpu-limit: '1'
+        config.linkerd.io/proxy-cpu-limit: '2'
   # ...
 ```
 

--- a/linkerd.io/content/2.14/tasks/configuring-proxy-concurrency.md
+++ b/linkerd.io/content/2.14/tasks/configuring-proxy-concurrency.md
@@ -65,7 +65,7 @@ spec:
   template:
     metadata:
       annotations:
-        config.linkerd.io/proxy-cpu-limit: '1'
+        config.linkerd.io/proxy-cpu-limit: '2'
   # ...
 ```
 

--- a/linkerd.io/content/2.15/tasks/configuring-proxy-concurrency.md
+++ b/linkerd.io/content/2.15/tasks/configuring-proxy-concurrency.md
@@ -65,7 +65,7 @@ spec:
   template:
     metadata:
       annotations:
-        config.linkerd.io/proxy-cpu-limit: '1'
+        config.linkerd.io/proxy-cpu-limit: '2'
   # ...
 ```
 

--- a/linkerd.io/content/2.16/tasks/configuring-proxy-concurrency.md
+++ b/linkerd.io/content/2.16/tasks/configuring-proxy-concurrency.md
@@ -65,7 +65,7 @@ spec:
   template:
     metadata:
       annotations:
-        config.linkerd.io/proxy-cpu-limit: '1'
+        config.linkerd.io/proxy-cpu-limit: '2'
   # ...
 ```
 

--- a/linkerd.io/content/2.17/tasks/configuring-proxy-concurrency.md
+++ b/linkerd.io/content/2.17/tasks/configuring-proxy-concurrency.md
@@ -65,7 +65,7 @@ spec:
   template:
     metadata:
       annotations:
-        config.linkerd.io/proxy-cpu-limit: '1'
+        config.linkerd.io/proxy-cpu-limit: '2'
   # ...
 ```
 


### PR DESCRIPTION
Fixed incorrect value in the deployment manifest example on the Configuring Proxy Concurrency task page.

Fixes [#1808](https://github.com/linkerd/website/issues/1808)
