### PR TITLE
Fix AuthorizationPolicy docs to indicate that targetRef cannot include a namespace

### DIFF
--- a/linkerd.io/content/2-edge/reference/authorization-policy.md
+++ b/linkerd.io/content/2-edge/reference/authorization-policy.md
@@ -209,14 +209,13 @@ applies. The API objects supported are:
   matching the HTTPRoute.
 - A namespace (`kind: Namespace`), indicating that the AuthorizationPolicy
   applies to all traffic to all [Servers] and [HTTPRoutes] defined in the
-  namespace.
+  namespace. This may only be the namespace of the AuthorizationPolicy.
 
 {{< keyval >}}
 | field| value |
 |------|-------|
 | `group`| Group is the group of the target resource. For namespace kinds, this should be omitted.|
 | `kind`| Kind is kind of the target resource.|
-| `namespace`| The namespace of the target resource. When unspecified (or empty string), this refers to the local namespace of the policy.|
 | `name`| Name is the name of the target resource.|
 {{< /keyval >}}
 

--- a/linkerd.io/content/2.12/reference/authorization-policy.md
+++ b/linkerd.io/content/2.12/reference/authorization-policy.md
@@ -356,14 +356,13 @@ applies. The API objects supported are:
   matching the HTTPRoute.
 - A namespace (`kind: Namespace`), indicating that the AuthorizationPolicy
   applies to all traffic to all [Servers] and [HTTPRoutes] defined in the
-  namespace.
+  namespace. This may only be the namespace of the AuthorizationPolicy.
 
 {{< keyval >}}
 | field| value |
 |------|-------|
 | `group`| Group is the group of the target resource. For namespace kinds, this should be omitted.|
 | `kind`| Kind is kind of the target resource.|
-| `namespace`| The namespace of the target resource. When unspecified (or empty string), this refers to the local namespace of the policy.|
 | `name`| Name is the name of the target resource.|
 {{< /keyval >}}
 

--- a/linkerd.io/content/2.13/reference/authorization-policy.md
+++ b/linkerd.io/content/2.13/reference/authorization-policy.md
@@ -181,14 +181,13 @@ applies. The API objects supported are:
   matching the HTTPRoute.
 - A namespace (`kind: Namespace`), indicating that the AuthorizationPolicy
   applies to all traffic to all [Servers] and [HTTPRoutes] defined in the
-  namespace.
+  namespace. This may only be the namespace of the AuthorizationPolicy.
 
 {{< keyval >}}
 | field| value |
 |------|-------|
 | `group`| Group is the group of the target resource. For namespace kinds, this should be omitted.|
 | `kind`| Kind is kind of the target resource.|
-| `namespace`| The namespace of the target resource. When unspecified (or empty string), this refers to the local namespace of the policy.|
 | `name`| Name is the name of the target resource.|
 {{< /keyval >}}
 

--- a/linkerd.io/content/2.14/reference/authorization-policy.md
+++ b/linkerd.io/content/2.14/reference/authorization-policy.md
@@ -196,14 +196,13 @@ applies. The API objects supported are:
   matching the HTTPRoute.
 - A namespace (`kind: Namespace`), indicating that the AuthorizationPolicy
   applies to all traffic to all [Servers] and [HTTPRoutes] defined in the
-  namespace.
+  namespace. This may only be the namespace of the AuthorizationPolicy.
 
 {{< keyval >}}
 | field| value |
 |------|-------|
 | `group`| Group is the group of the target resource. For namespace kinds, this should be omitted.|
 | `kind`| Kind is kind of the target resource.|
-| `namespace`| The namespace of the target resource. When unspecified (or empty string), this refers to the local namespace of the policy.|
 | `name`| Name is the name of the target resource.|
 {{< /keyval >}}
 

--- a/linkerd.io/content/2.15/reference/authorization-policy.md
+++ b/linkerd.io/content/2.15/reference/authorization-policy.md
@@ -196,14 +196,13 @@ applies. The API objects supported are:
   matching the HTTPRoute.
 - A namespace (`kind: Namespace`), indicating that the AuthorizationPolicy
   applies to all traffic to all [Servers] and [HTTPRoutes] defined in the
-  namespace.
+  namespace. This may only be the namespace of the AuthorizationPolicy.
 
 {{< keyval >}}
 | field| value |
 |------|-------|
 | `group`| Group is the group of the target resource. For namespace kinds, this should be omitted.|
 | `kind`| Kind is kind of the target resource.|
-| `namespace`| The namespace of the target resource. When unspecified (or empty string), this refers to the local namespace of the policy.|
 | `name`| Name is the name of the target resource.|
 {{< /keyval >}}
 

--- a/linkerd.io/content/2.16/reference/authorization-policy.md
+++ b/linkerd.io/content/2.16/reference/authorization-policy.md
@@ -209,14 +209,13 @@ applies. The API objects supported are:
   matching the HTTPRoute.
 - A namespace (`kind: Namespace`), indicating that the AuthorizationPolicy
   applies to all traffic to all [Servers] and [HTTPRoutes] defined in the
-  namespace.
+  namespace. This may only be the namespace of the AuthorizationPolicy.
 
 {{< keyval >}}
 | field| value |
 |------|-------|
 | `group`| Group is the group of the target resource. For namespace kinds, this should be omitted.|
 | `kind`| Kind is kind of the target resource.|
-| `namespace`| The namespace of the target resource. When unspecified (or empty string), this refers to the local namespace of the policy.|
 | `name`| Name is the name of the target resource.|
 {{< /keyval >}}
 

--- a/linkerd.io/content/2.17/reference/authorization-policy.md
+++ b/linkerd.io/content/2.17/reference/authorization-policy.md
@@ -209,14 +209,13 @@ applies. The API objects supported are:
   matching the HTTPRoute.
 - A namespace (`kind: Namespace`), indicating that the AuthorizationPolicy
   applies to all traffic to all [Servers] and [HTTPRoutes] defined in the
-  namespace.
+  namespace. This may only be the namespace of the AuthorizationPolicy.
 
 {{< keyval >}}
 | field| value |
 |------|-------|
 | `group`| Group is the group of the target resource. For namespace kinds, this should be omitted.|
 | `kind`| Kind is kind of the target resource.|
-| `namespace`| The namespace of the target resource. When unspecified (or empty string), this refers to the local namespace of the policy.|
 | `name`| Name is the name of the target resource.|
 {{< /keyval >}}
 


### PR DESCRIPTION
An AuthorizationPolicy cannot target a resource in another namespace, as this would allow one namespace to grant access to another's resources.  This is codified in the CRD as the `targetRef` does not have a `namespace` field.  However, our docs incorrect claim that it does have a `namespace` field.

We correct this error by removing references to the non-existent field and clarifying that only the namespace which can be targeted is the local one.