### PR TITLE
Fix typo in the "Distributed tracing with Linkerd" page

### DIFF
--- a/linkerd.io/content/2.11/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.11/tasks/distributed-tracing.md
@@ -158,9 +158,8 @@ and specifies the OpenCensus collector's config.
 cat <<EOF > jaeger-linkerd.yaml
 jaeger:
   enabled: false
-
 collector:
-  config: |
+  config:
     receivers:
       otlp:
         protocols:

--- a/linkerd.io/content/2.12/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.12/tasks/distributed-tracing.md
@@ -158,9 +158,8 @@ and specifies the OpenCensus collector's config.
 cat <<EOF > jaeger-linkerd.yaml
 jaeger:
   enabled: false
-
 collector:
-  config: |
+  config:
     receivers:
       otlp:
         protocols:

--- a/linkerd.io/content/2.13/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.13/tasks/distributed-tracing.md
@@ -159,9 +159,8 @@ and specifies the OpenCensus collector's config.
 cat <<EOF > jaeger-linkerd.yaml
 jaeger:
   enabled: false
-
 collector:
-  config: |
+  config:
     receivers:
       otlp:
         protocols:

--- a/linkerd.io/content/2.14/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.14/tasks/distributed-tracing.md
@@ -159,9 +159,8 @@ and specifies the OpenCensus collector's config.
 cat <<EOF > jaeger-linkerd.yaml
 jaeger:
   enabled: false
-
 collector:
-  config: |
+  config:
     receivers:
       otlp:
         protocols:

--- a/linkerd.io/content/2.15/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.15/tasks/distributed-tracing.md
@@ -159,9 +159,8 @@ and specifies the OpenCensus collector's config.
 cat <<EOF > jaeger-linkerd.yaml
 jaeger:
   enabled: false
-
 collector:
-  config: |
+  config:
     receivers:
       otlp:
         protocols:

--- a/linkerd.io/content/2.16/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.16/tasks/distributed-tracing.md
@@ -159,9 +159,8 @@ and specifies the OpenCensus collector's config.
 cat <<EOF > jaeger-linkerd.yaml
 jaeger:
   enabled: false
-
 collector:
-  config: |
+  config:
     receivers:
       otlp:
         protocols:

--- a/linkerd.io/content/2.17/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.17/tasks/distributed-tracing.md
@@ -175,9 +175,8 @@ and specifies the OpenCensus collector's config.
 cat <<EOF > jaeger-linkerd.yaml
 jaeger:
   enabled: false
-
 collector:
-  config: |
+  config:
     receivers:
       otlp:
         protocols:


### PR DESCRIPTION
It's treating the config as a string rather than as an object.