### PR TITLE
fix spiffe link url typo

### DIFF
--- a/linkerd.io/content/2-edge/tasks/adding-non-kubernetes-workloads.md
+++ b/linkerd.io/content/2-edge/tasks/adding-non-kubernetes-workloads.md
@@ -49,7 +49,7 @@ Kubernetes Service Account token that is provided to each Pod.
 
 Since our external workload lives outside of Kubernetes, the concept of Service
 Account tokens does not exist. Instead, we turn to the [SPIFFE
-framework](https://spiffee.io) and its SPIRE implementation to create identities
+framework](https://spiffe.io) and its SPIRE implementation to create identities
 for off-cluster resources. Thus, for mesh expansion, we configure the Linkerd
 proxy to obtain its certificates directly from SPIRE instead of the Linkerd's
 identity service. The magic of SPIFFE is that these certificates are compatible

--- a/linkerd.io/content/2.15/tasks/adding-non-kubernetes-workloads.md
+++ b/linkerd.io/content/2.15/tasks/adding-non-kubernetes-workloads.md
@@ -49,7 +49,7 @@ Kubernetes Service Account token that is provided to each Pod.
 
 Since our external workload lives outside of Kubernetes, the concept of Service
 Account tokens does not exist. Instead, we turn to the [SPIFFE
-framework](https://spiffee.io) and its SPIRE implementation to create identities
+framework](https://spiffe.io) and its SPIRE implementation to create identities
 for off-cluster resources. Thus, for mesh expansion, we configure the Linkerd
 proxy to obtain its certificates directly from SPIRE instead of the Linkerd's
 identity service. The magic of SPIFFE is that these certificates are compatible

--- a/linkerd.io/content/2.16/tasks/adding-non-kubernetes-workloads.md
+++ b/linkerd.io/content/2.16/tasks/adding-non-kubernetes-workloads.md
@@ -49,7 +49,7 @@ Kubernetes Service Account token that is provided to each Pod.
 
 Since our external workload lives outside of Kubernetes, the concept of Service
 Account tokens does not exist. Instead, we turn to the [SPIFFE
-framework](https://spiffee.io) and its SPIRE implementation to create identities
+framework](https://spiffe.io) and its SPIRE implementation to create identities
 for off-cluster resources. Thus, for mesh expansion, we configure the Linkerd
 proxy to obtain its certificates directly from SPIRE instead of the Linkerd's
 identity service. The magic of SPIFFE is that these certificates are compatible

--- a/linkerd.io/content/2.17/tasks/adding-non-kubernetes-workloads.md
+++ b/linkerd.io/content/2.17/tasks/adding-non-kubernetes-workloads.md
@@ -49,7 +49,7 @@ Kubernetes Service Account token that is provided to each Pod.
 
 Since our external workload lives outside of Kubernetes, the concept of Service
 Account tokens does not exist. Instead, we turn to the [SPIFFE
-framework](https://spiffee.io) and its SPIRE implementation to create identities
+framework](https://spiffe.io) and its SPIRE implementation to create identities
 for off-cluster resources. Thus, for mesh expansion, we configure the Linkerd
 proxy to obtain its certificates directly from SPIRE instead of the Linkerd's
 identity service. The magic of SPIFFE is that these certificates are compatible


### PR DESCRIPTION
SPIFFE link in docs points to `spiffee.io` which is a non-existent domain and is likely a typo.  corrected the url to point to `spiffe.io`.