### PR TITLE
Update multicluster-using-statefulsets

### DIFF
--- a/linkerd.io/content/2-edge/tasks/multicluster-using-statefulsets.md
+++ b/linkerd.io/content/2-edge/tasks/multicluster-using-statefulsets.md
@@ -31,7 +31,7 @@ on how multi-cluster support for headless services work, check out
 - [`smallstep/CLI`](https://github.com/smallstep/cli/releases) to generate
   certificates for Linkerd installation.
 - [`A recent linkerd release`](https://github.com/linkerd/linkerd2/releases)
-  (2.11 or older).
+  (2.18 or older).
 
 To help with cluster creation and installation, there is a demo repository
 available. Throughout the guide, we will be using the scripts from the
@@ -48,7 +48,7 @@ repository on your local machine.
 
 ```sh
 # clone example repository
-$ git clone git@github.com:mateiidavid/l2d-k3d-statefulset.git
+$ git clone git@github.com:linkerd/l2d-k3d-statefulset.git
 $ cd l2d-k3d-statefulset
 ```
 
@@ -71,10 +71,9 @@ west   1/1       0/0      true
 
 Once our clusters are created, we will install Linkerd and the multi-cluster
 extension. Finally, once both are installed, we need to link the two clusters
-together so their services may be mirrored. To enable support for headless
-services, we will pass an additional `--set "enableHeadlessServices=true` flag
-to `linkerd multicluster link`. As before, these steps are automated through
-the provided scripts, but feel free to have a look!
+together so their services may be mirrored. As before, these steps are automated
+through the provided scripts; please give them a look and see how the
+controllers and links are generated for both clusters.
 
 ```sh
 # Install Linkerd and multicluster, output to check should be a success
@@ -178,7 +177,7 @@ nginx-set-1             2/2     Running           0          4m58s
 nginx-set-2             2/2     Running           0          4m51s
 curl-56dc7d945d-s4n8j   0/2     PodInitializing   0          4s
 
-$ kubectl --context=k3d-west exec -it curl-56dc7d945d-s4n8j -c curl -- bin/sh
+$ kubectl --context=k3d-west exec -it curl-56dc7d945d-s4n8j -c curl -- sh
 /$ # prompt for curl pod
 ```
 
@@ -235,7 +234,7 @@ endpoints for `nginx-svc-west` will have the same hostnames, but each hostname
 will point to one of the services we see above:
 
 ```sh
-$ kubectl --context=k3d-east get endpoints nginx-svc-west -o yaml
+$ kubectl --context=k3d-east get endpoints nginx-svc-k3d-west -o yaml
 subsets:
 - addresses:
   - hostname: nginx-set-0
@@ -256,12 +255,12 @@ NAME                    READY   STATUS    RESTARTS   AGE
 curl-56dc7d945d-96r6p   2/2     Running   0          23m
 
 # exec and curl
-$ kubectl --context=k3d-east exec pod curl-56dc7d945d-96r6p -it -c curl -- bin/sh
+$ kubectl --context=k3d-east exec curl-56dc7d945d-96r6p -it -c curl -- sh
 # we want to curl the same hostname we see in the endpoints object above.
 # however, the service and cluster domain will now be different, since we
 # are in a different cluster.
 #
-/ $ curl nginx-set-0.nginx-svc-west.default.svc.east.cluster.local
+/ $ curl nginx-set-0.nginx-svc-k3d-west.default.svc.east.cluster.local
 <!DOCTYPE html>
 <html>
 <head>


### PR DESCRIPTION
Changed demo repo to https://github.com/linkerd/l2d-k3d-statefulset, which has been updated (linkerdll2d-k3d-statefulset#1) to fit the new multicluster link management in 2.18.

Also fixed a couple other errors.