### PR TITLE
chore(tasks): update configuring-proxy-concurrency

### DIFF
--- a/linkerd.io/content/2-edge/tasks/configuring-proxy-concurrency.md
+++ b/linkerd.io/content/2-edge/tasks/configuring-proxy-concurrency.md
@@ -148,7 +148,9 @@ while a value of `0.2` configures the proxy to allocate 1 proxy worker for every
 
 ## Configuring Rational Proxy CPU Limits Using Helm
 
-Global defaults can be configured in the control-plane helm chart: ```yaml proxy:
+Global defaults can be configured in the control-plane helm chart:
+
+```yaml proxy:
   runtime:
     workers:
       maximumCPURatio: 0.2

--- a/linkerd.io/content/2-edge/tasks/configuring-proxy-concurrency.md
+++ b/linkerd.io/content/2-edge/tasks/configuring-proxy-concurrency.md
@@ -142,9 +142,11 @@ workload (for example, because the workload does not use CPU limits and runs on
 variably sized nodes). In this case, the proxy can be configured with a maximum
 ratio of the host's total available CPUs.
 
-For example, a value of `1.0` configures the proxy to use all available CPUs,
-while a value of `0.2` configures the proxy to allocate 1 proxy worker for every
-5 available cores (rounded).
+A `runtime.workers.maximumCPURatio` value of `1.0` configures the proxy to
+allocate a worker for each CPU, while a value of `0.2` configures the proxy to
+allocate 1 proxy worker for every 5 available cores (rounded up or down as
+appropriate). The `runtime.workers.minimum` value sets a lower bound on the
+number of workers per proxy.
 
 ## Configuring Rational Proxy CPU Limits Using Helm
 

--- a/linkerd.io/content/2-edge/tasks/configuring-proxy-concurrency.md
+++ b/linkerd.io/content/2-edge/tasks/configuring-proxy-concurrency.md
@@ -13,6 +13,24 @@ pod’s CPU limits and resource quotas to ensure that both the proxy and the
 application containers operate efficiently without degrading overall
 performance.
 
+## Default Behavior
+
+Linkerd's default Helm configuration runs sidecar proxies to use a single
+runtime worker. No requests or limits are configured for the proxy.
+
+```yaml
+proxy:
+  resources:
+    cpu:
+      request:
+      limit:
+  runtime:
+    workers:
+      minimum: 1
+```
+
+This document describes how to run proxies with additional runtime workers.
+
 ## Configuring Proxy CPU Requests and Limits
 
 Kubernetes provides
@@ -53,8 +71,8 @@ criteria must be met:
   for memory and CPU, and the limit for each must have the same value as the
   request.
 - The CPU limit and CPU request must be an integer greater than or equal to 1.
- 
-###  Configuring Default Proxy CPU Requests and Limits Using Helm
+
+### Configuring Default Proxy CPU Requests and Limits Using Helm
 
 A global default CPU request can be configured in the control-plane helm chart
 to influence the scheduler:
@@ -79,8 +97,8 @@ proxy:
       limit: 2000m
 ```
 
-Similarly, this value controls the proxy's runtime configuration (by rounding up to
-the next whole number).
+Similarly, this value controls the proxy's runtime configuration (by rounding up
+to the next whole number).
 
 When both values are specified, the request is used to influence the scheduler
 and the limit is used to configure the proxy's runtime:
@@ -125,19 +143,17 @@ variably sized nodes). In this case, the proxy can be configured with a maximum
 ratio of the host's total available CPUs.
 
 For example, a value of `1.0` configures the proxy to use all available CPUs,
-while a value of `0.2` configures the proxy to allocate 1 proxy thread for every
-5 available cores.
+while a value of `0.2` configures the proxy to allocate 1 proxy worker for every
+5 available cores (rounded).
 
 ## Configuring Rational Proxy CPU Limits Using Helm
 
-Global defaults can be configured in the control-plane helm chart:
-
-```yaml
-proxy:
+Global defaults can be configured in the control-plane helm chart: ```yaml proxy:
   runtime:
     workers:
       maximumCPURatio: 0.2
       minimum: 1
+
 ```
 
 ## Overriding Rational Proxy CPU Limits Using Annotations

--- a/linkerd.io/content/2-edge/tasks/configuring-proxy-concurrency.md
+++ b/linkerd.io/content/2-edge/tasks/configuring-proxy-concurrency.md
@@ -160,6 +160,10 @@ proxy:
       minimum: 1
 ```
 
+{{< note >}} CPU limits takes precedence over the maximum CPU ratio, so it is
+suitable to set a global default maximumCPURatio while setting limits on
+specific workloads. {{< /note >}}
+
 ## Overriding Rational Proxy CPU Limits Using Annotations
 
 To override the default maximum CPU ratio, use the
@@ -174,25 +178,6 @@ spec:
   template:
     metadata:
       annotations:
-        config.linkerd.io/proxy-cpu-ratio-limit: '0.3'
-  # ...
-```
-
-Note that this may be combined with the `config.linkerd.io/proxy-cpu-request`
-annotation (i.e. to influence scheduling). However, the
-`config.linkerd.io/proxy-cpu-limit` annotation takes precedence over the ratio
-configuration.
-
-```yaml
-kind: Deployment
-apiVersion: apps/v1
-metadata:
-  # ...
-spec:
-  template:
-    metadata:
-      annotations:
-        config.linkerd.io/proxy-cpu-request: '100m'
         config.linkerd.io/proxy-cpu-ratio-limit: '0.3'
   # ...
 ```

--- a/linkerd.io/content/2-edge/tasks/configuring-proxy-concurrency.md
+++ b/linkerd.io/content/2-edge/tasks/configuring-proxy-concurrency.md
@@ -40,13 +40,18 @@ Linkerd proxy. However, the effect of these settings depends on how the kubelet
 enforces CPU limits.
 
 The kubelet enforces pod CPU limits using one of two approaches, determined by
-its `--cpu-manager-policy` flag:
+its
+[`--cpu-manager-policy`](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#configuration)
+flag:
 
-### No CPU Manager Policy (Default)
+### Default CPU Manager Policy
 
-When using the default none policy, the kubelet relies on Completely Fair
-Scheduler (CFS) quotas. In this mode, the Linux kernel limits the percentage of
-CPU time that processes (including the Linkerd proxy) can use.
+When using the default
+[`none`](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#none-policy)
+policy, the kubelet relies on [Completely Fair Scheduler
+(CFS)](https://en.wikipedia.org/wiki/Completely_Fair_Scheduler) quotas. In this
+mode, the Linux kernel limits the percentage of CPU time that processes
+(including the Linkerd proxy) can use.
 
 ### Static CPU Manager Policy
 
@@ -55,7 +60,8 @@ whole CPU cores to containers by leveraging Linux [cgroup
 cpusets](https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html#cpuset).
 To successfully use this mechanism, the following conditions must be met:
 
-- The kubelet must run with the `static` CPU manager policy.
+- The kubelet must run with the [`static` CPU manager
+  policy](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy).
 - The pod must belong to the [Guaranteed QoS
   class](https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed).
   This requires that every container in the pod has matching CPU (and memory)

--- a/linkerd.io/content/2-edge/tasks/configuring-proxy-concurrency.md
+++ b/linkerd.io/content/2-edge/tasks/configuring-proxy-concurrency.md
@@ -6,7 +6,7 @@ description: Limit the Linkerd proxy's CPU usage.
 Linkerd data plane proxies allocate a fixed number of worker threads at startup,
 and this thread count directly determines the maximum CPU consumption of the
 proxy. In Kubernetes environments, where proxies run as sidecars alongside other
-containers in the same pod—-and coexist with pods on the same node—-this static
+containers in the same pod and coexist with pods on the same node, this static
 allocation means that choosing too many threads can lead to CPU
 oversubscription. Operators must balance the proxy’s fixed thread count with the
 pod’s CPU limits and resource quotas to ensure that both the proxy and the
@@ -15,8 +15,8 @@ performance.
 
 ## Default Behavior
 
-Linkerd's default Helm configuration runs sidecar proxies to use a single
-runtime worker. No requests or limits are configured for the proxy.
+Linkerd's default Helm configuration runs sidecar proxies with a single runtime
+worker. No requests or limits are configured for the proxy.
 
 ```yaml
 proxy:
@@ -65,7 +65,7 @@ However, it's worth noting that in order for this mechanism to be used, certain
 criteria must be met:
 
 - The kubelet must be configured with the `static` CPU manager policy
-- The pod must be in the
+- The pod must belong to the
   [Guaranteed QoS class](https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed).
   This means that all containers in the pod must have both a limit and a request
   for memory and CPU, and the limit for each must have the same value as the
@@ -137,10 +137,10 @@ the proxy's runtime. {{< /note >}}
 
 ## Configuring _Rational Proxy CPU Limits_
 
-In some environments, it may not be practical to use a fixed CPU limit for a
-workload (for example, because the workload does not use CPU limits and runs on
-variably sized nodes). In this case, the proxy can be configured with a maximum
-ratio of the host's total available CPUs.
+In some environments, it might not be practical to use a fixed CPU limit for a
+workload (for example, when the workload does not specify CPU limits and runs on
+nodes of varying sizes). In this case, the proxy can be configured with a
+maximum ratio of the host's total available CPUs.
 
 A `runtime.workers.maximumCPURatio` value of `1.0` configures the proxy to
 allocate a worker for each CPU, while a value of `0.2` configures the proxy to
@@ -152,12 +152,12 @@ number of workers per proxy.
 
 Global defaults can be configured in the control-plane helm chart:
 
-```yaml proxy:
+```yaml
+proxy:
   runtime:
     workers:
       maximumCPURatio: 0.2
       minimum: 1
-
 ```
 
 ## Overriding Rational Proxy CPU Limits Using Annotations


### PR DESCRIPTION
The proxy's configuration has been updated to support "rational" CPU limits. This change reorganizes the Proxy configuration guide to describe the new configuration.