### PR TITLE
Remove default image centering

### DIFF
--- a/linkerd.io/README.md
+++ b/linkerd.io/README.md
@@ -210,6 +210,13 @@ To display a caption below the image, provide an image title. For example:
 ![Alt text](my-image.jpg "My image caption")
 ```
 
+To center the image, use a Markdown attribute:
+
+```markdown
+![Alt text](my-image.jpg)
+{.center}
+```
+
 ### Hiding pages in the docs sidenav
 
 _(docs page only)_

--- a/linkerd.io/assets/scss/components/_prose.scss
+++ b/linkerd.io/assets/scss/components/_prose.scss
@@ -21,4 +21,10 @@ Apply to containers that contain rendered markdown.
   .alert {
     margin-bottom: spacer(3);
   }
+
+  // Markdown attribute classes
+  img.center {
+    margin: 0 auto;
+  }
+
 }

--- a/linkerd.io/content/2-edge/tasks/books.md
+++ b/linkerd.io/content/2-edge/tasks/books.md
@@ -21,6 +21,7 @@ For demo purposes, the app comes with a simple traffic generator. The overall
 topology looks like this:
 
 ![Topology](/docs/images/books/topology.png "Topology")
+{.center}
 
 ## Prerequisites
 
@@ -82,6 +83,7 @@ perspective, it looks like everything's fine, but you know the application is
 returning errors.
 
 ![Failure](/docs/images/books/failure.png "Failure")
+{.center}
 
 ## Add Linkerd to the service
 

--- a/linkerd.io/content/2-edge/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2-edge/tasks/distributed-tracing.md
@@ -21,6 +21,7 @@ In the case of emojivoto, once all these steps are complete there will be a
 topology that looks like:
 
 ![Topology](/docs/images/tracing/tracing-topology.svg "Topology")
+{.center}
 
 ## Prerequisites
 

--- a/linkerd.io/content/2-edge/tasks/fault-injection.md
+++ b/linkerd.io/content/2-edge/tasks/fault-injection.md
@@ -12,6 +12,7 @@ The [books demo](../books/) is a great way to show off this behavior. The
 overall topology looks like:
 
 ![Topology](/docs/images/books/topology.png "Topology")
+{.center}
 
 In this guide, you will split some of the requests from `webapp` to `books`.
 Most requests will end up at the correct `books` destination, however some of

--- a/linkerd.io/content/2-edge/tasks/flagger.md
+++ b/linkerd.io/content/2-edge/tasks/flagger.md
@@ -70,6 +70,7 @@ as there needs to be some kind of active traffic to complete the operation.
 Together, these components have a topology that looks like:
 
 ![Topology](/docs/images/canary/simple-topology.svg "Topology")
+{.center}
 
 To add these components to your cluster and include them in the Linkerd
 [data plane](../../reference/architecture/#data-plane), run:
@@ -212,6 +213,7 @@ podinfo-primary      ClusterIP   10.7.249.63   <none>        9898/TCP   23m
 At this point, the topology looks a little like:
 
 ![Initialized](/docs/images/canary/initialized.svg "Initialized")
+{.center}
 
 {{< note >}}
 This guide barely touches all the functionality provided by Flagger. Make sure
@@ -256,6 +258,7 @@ While an update is occurring, the resources and traffic will look like this at a
 high level:
 
 ![Ongoing](/docs/images/canary/ongoing.svg "Ongoing")
+{.center}
 
 After the update is complete, this picture will go back to looking just like the
 figure from the previous section.

--- a/linkerd.io/content/2.10/tasks/books.md
+++ b/linkerd.io/content/2.10/tasks/books.md
@@ -21,6 +21,7 @@ For demo purposes, the app comes with a simple traffic generator. The overall
 topology looks like this:
 
 ![Topology](/docs/images/books/topology.png "Topology")
+{.center}
 
 ## Prerequisites
 
@@ -79,6 +80,7 @@ perspective, it looks like everything's fine, but you know the application is
 returning errors.
 
 ![Failure](/docs/images/books/failure.png "Failure")
+{.center}
 
 ## Add Linkerd to the service
 

--- a/linkerd.io/content/2.10/tasks/canary-release.md
+++ b/linkerd.io/content/2.10/tasks/canary-release.md
@@ -68,6 +68,7 @@ as there needs to be some kind of active traffic to complete the operation.
 Together, these components have a topology that looks like:
 
 ![Topology](/docs/images/canary/simple-topology.svg "Topology")
+{.center}
 
 To add these components to your cluster and include them in the Linkerd
 [data plane](../../reference/architecture/#data-plane), run:
@@ -169,6 +170,7 @@ podinfo-primary      ClusterIP   10.7.249.63   <none>        9898/TCP   23m
 At this point, the topology looks a little like:
 
 ![Initialized](/docs/images/canary/initialized.svg "Initialized")
+{.center}
 
 {{< note >}}
 This guide barely touches all the functionality provided by Flagger. Make sure
@@ -213,6 +215,7 @@ While an update is occurring, the resources and traffic will look like this at a
 high level:
 
 ![Ongoing](/docs/images/canary/ongoing.svg "Ongoing")
+{.center}
 
 After the update is complete, this picture will go back to looking just like the
 figure from the previous section.
@@ -261,6 +264,7 @@ running `linkerd viz dashboard` and then look at the detail page for the
 split](http://localhost:50750/namespaces/test/trafficsplits/podinfo).
 
 ![Dashboard](/docs/images/canary/traffic-split.png "Dashboard")
+{.center}
 
 ### Browser
 

--- a/linkerd.io/content/2.10/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.10/tasks/distributed-tracing.md
@@ -21,6 +21,7 @@ In the case of emojivoto, once all these steps are complete there will be a
 topology that looks like:
 
 ![Topology](/docs/images/tracing/tracing-topology.svg "Topology")
+{.center}
 
 ## Prerequisites
 

--- a/linkerd.io/content/2.10/tasks/fault-injection.md
+++ b/linkerd.io/content/2.10/tasks/fault-injection.md
@@ -14,6 +14,7 @@ The [books demo](../books/) is a great way to show off this behavior. The
 overall topology looks like:
 
 ![Topology](/docs/images/books/topology.png "Topology")
+{.center}
 
 In this guide, you will split some of the requests from `webapp` to `books`.
 Most requests will end up at the correct `books` destination, however some of

--- a/linkerd.io/content/2.11/tasks/books.md
+++ b/linkerd.io/content/2.11/tasks/books.md
@@ -21,6 +21,7 @@ For demo purposes, the app comes with a simple traffic generator. The overall
 topology looks like this:
 
 ![Topology](/docs/images/books/topology.png "Topology")
+{.center}
 
 ## Prerequisites
 
@@ -79,6 +80,7 @@ perspective, it looks like everything's fine, but you know the application is
 returning errors.
 
 ![Failure](/docs/images/books/failure.png "Failure")
+{.center}
 
 ## Add Linkerd to the service
 

--- a/linkerd.io/content/2.11/tasks/canary-release.md
+++ b/linkerd.io/content/2.11/tasks/canary-release.md
@@ -69,6 +69,7 @@ as there needs to be some kind of active traffic to complete the operation.
 Together, these components have a topology that looks like:
 
 ![Topology](/docs/images/canary/simple-topology.svg "Topology")
+{.center}
 
 To add these components to your cluster and include them in the Linkerd
 [data plane](../../reference/architecture/#data-plane), run:
@@ -170,6 +171,7 @@ podinfo-primary      ClusterIP   10.7.249.63   <none>        9898/TCP   23m
 At this point, the topology looks a little like:
 
 ![Initialized](/docs/images/canary/initialized.svg "Initialized")
+{.center}
 
 {{< note >}}
 This guide barely touches all the functionality provided by Flagger. Make sure
@@ -214,6 +216,7 @@ While an update is occurring, the resources and traffic will look like this at a
 high level:
 
 ![Ongoing](/docs/images/canary/ongoing.svg "Ongoing")
+{.center}
 
 After the update is complete, this picture will go back to looking just like the
 figure from the previous section.
@@ -262,6 +265,7 @@ running `linkerd viz dashboard` and then look at the detail page for the
 split](http://localhost:50750/namespaces/test/trafficsplits/podinfo).
 
 ![Dashboard](/docs/images/canary/traffic-split.png "Dashboard")
+{.center}
 
 ### Browser
 

--- a/linkerd.io/content/2.11/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.11/tasks/distributed-tracing.md
@@ -21,6 +21,7 @@ In the case of emojivoto, once all these steps are complete there will be a
 topology that looks like:
 
 ![Topology](/docs/images/tracing/tracing-topology.svg "Topology")
+{.center}
 
 ## Prerequisites
 

--- a/linkerd.io/content/2.11/tasks/fault-injection.md
+++ b/linkerd.io/content/2.11/tasks/fault-injection.md
@@ -14,6 +14,7 @@ The [books demo](../books/) is a great way to show off this behavior. The
 overall topology looks like:
 
 ![Topology](/docs/images/books/topology.png "Topology")
+{.center}
 
 In this guide, you will split some of the requests from `webapp` to `books`.
 Most requests will end up at the correct `books` destination, however some of

--- a/linkerd.io/content/2.12/tasks/books.md
+++ b/linkerd.io/content/2.12/tasks/books.md
@@ -21,6 +21,7 @@ For demo purposes, the app comes with a simple traffic generator. The overall
 topology looks like this:
 
 ![Topology](/docs/images/books/topology.png "Topology")
+{.center}
 
 ## Prerequisites
 
@@ -79,6 +80,7 @@ perspective, it looks like everything's fine, but you know the application is
 returning errors.
 
 ![Failure](/docs/images/books/failure.png "Failure")
+{.center}
 
 ## Add Linkerd to the service
 

--- a/linkerd.io/content/2.12/tasks/canary-release.md
+++ b/linkerd.io/content/2.12/tasks/canary-release.md
@@ -70,6 +70,7 @@ as there needs to be some kind of active traffic to complete the operation.
 Together, these components have a topology that looks like:
 
 ![Topology](/docs/images/canary/simple-topology.svg "Topology")
+{.center}
 
 To add these components to your cluster and include them in the Linkerd
 [data plane](../../reference/architecture/#data-plane), run:
@@ -171,6 +172,7 @@ podinfo-primary      ClusterIP   10.7.249.63   <none>        9898/TCP   23m
 At this point, the topology looks a little like:
 
 ![Initialized](/docs/images/canary/initialized.svg "Initialized")
+{.center}
 
 {{< note >}}
 This guide barely touches all the functionality provided by Flagger. Make sure
@@ -215,6 +217,7 @@ While an update is occurring, the resources and traffic will look like this at a
 high level:
 
 ![Ongoing](/docs/images/canary/ongoing.svg "Ongoing")
+{.center}
 
 After the update is complete, this picture will go back to looking just like the
 figure from the previous section.
@@ -263,6 +266,7 @@ running `linkerd viz dashboard` and then look at the detail page for the
 split](http://localhost:50750/namespaces/test/trafficsplits/podinfo).
 
 ![Dashboard](/docs/images/canary/traffic-split.png "Dashboard")
+{.center}
 
 ### Browser
 

--- a/linkerd.io/content/2.12/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.12/tasks/distributed-tracing.md
@@ -21,6 +21,7 @@ In the case of emojivoto, once all these steps are complete there will be a
 topology that looks like:
 
 ![Topology](/docs/images/tracing/tracing-topology.svg "Topology")
+{.center}
 
 ## Prerequisites
 

--- a/linkerd.io/content/2.12/tasks/fault-injection.md
+++ b/linkerd.io/content/2.12/tasks/fault-injection.md
@@ -14,6 +14,7 @@ The [books demo](../books/) is a great way to show off this behavior. The
 overall topology looks like:
 
 ![Topology](/docs/images/books/topology.png "Topology")
+{.center}
 
 In this guide, you will split some of the requests from `webapp` to `books`.
 Most requests will end up at the correct `books` destination, however some of

--- a/linkerd.io/content/2.13/tasks/books.md
+++ b/linkerd.io/content/2.13/tasks/books.md
@@ -21,6 +21,7 @@ For demo purposes, the app comes with a simple traffic generator. The overall
 topology looks like this:
 
 ![Topology](/docs/images/books/topology.png "Topology")
+{.center}
 
 ## Prerequisites
 
@@ -79,6 +80,7 @@ perspective, it looks like everything's fine, but you know the application is
 returning errors.
 
 ![Failure](/docs/images/books/failure.png "Failure")
+{.center}
 
 ## Add Linkerd to the service
 

--- a/linkerd.io/content/2.13/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.13/tasks/distributed-tracing.md
@@ -21,6 +21,7 @@ In the case of emojivoto, once all these steps are complete there will be a
 topology that looks like:
 
 ![Topology](/docs/images/tracing/tracing-topology.svg "Topology")
+{.center}
 
 ## Prerequisites
 

--- a/linkerd.io/content/2.13/tasks/fault-injection.md
+++ b/linkerd.io/content/2.13/tasks/fault-injection.md
@@ -12,6 +12,7 @@ The [books demo](../books/) is a great way to show off this behavior. The
 overall topology looks like:
 
 ![Topology](/docs/images/books/topology.png "Topology")
+{.center}
 
 In this guide, you will split some of the requests from `webapp` to `books`.
 Most requests will end up at the correct `books` destination, however some of

--- a/linkerd.io/content/2.13/tasks/flagger.md
+++ b/linkerd.io/content/2.13/tasks/flagger.md
@@ -70,6 +70,7 @@ as there needs to be some kind of active traffic to complete the operation.
 Together, these components have a topology that looks like:
 
 ![Topology](/docs/images/canary/simple-topology.svg "Topology")
+{.center}
 
 To add these components to your cluster and include them in the Linkerd
 [data plane](../../reference/architecture/#data-plane), run:
@@ -171,6 +172,7 @@ podinfo-primary      ClusterIP   10.7.249.63   <none>        9898/TCP   23m
 At this point, the topology looks a little like:
 
 ![Initialized](/docs/images/canary/initialized.svg "Initialized")
+{.center}
 
 {{< note >}}
 This guide barely touches all the functionality provided by Flagger. Make sure
@@ -215,6 +217,7 @@ While an update is occurring, the resources and traffic will look like this at a
 high level:
 
 ![Ongoing](/docs/images/canary/ongoing.svg "Ongoing")
+{.center}
 
 After the update is complete, this picture will go back to looking just like the
 figure from the previous section.
@@ -263,6 +266,7 @@ running `linkerd viz dashboard` and then look at the detail page for the
 split](http://localhost:50750/namespaces/test/trafficsplits/podinfo).
 
 ![Dashboard](/docs/images/canary/traffic-split.png "Dashboard")
+{.center}
 
 ### Browser
 

--- a/linkerd.io/content/2.14/tasks/books.md
+++ b/linkerd.io/content/2.14/tasks/books.md
@@ -21,6 +21,7 @@ For demo purposes, the app comes with a simple traffic generator. The overall
 topology looks like this:
 
 ![Topology](/docs/images/books/topology.png "Topology")
+{.center}
 
 ## Prerequisites
 
@@ -82,6 +83,7 @@ perspective, it looks like everything's fine, but you know the application is
 returning errors.
 
 ![Failure](/docs/images/books/failure.png "Failure")
+{.center}
 
 ## Add Linkerd to the service
 

--- a/linkerd.io/content/2.14/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.14/tasks/distributed-tracing.md
@@ -21,6 +21,7 @@ In the case of emojivoto, once all these steps are complete there will be a
 topology that looks like:
 
 ![Topology](/docs/images/tracing/tracing-topology.svg "Topology")
+{.center}
 
 ## Prerequisites
 

--- a/linkerd.io/content/2.14/tasks/fault-injection.md
+++ b/linkerd.io/content/2.14/tasks/fault-injection.md
@@ -12,6 +12,7 @@ The [books demo](../books/) is a great way to show off this behavior. The
 overall topology looks like:
 
 ![Topology](/docs/images/books/topology.png "Topology")
+{.center}
 
 In this guide, you will split some of the requests from `webapp` to `books`.
 Most requests will end up at the correct `books` destination, however some of

--- a/linkerd.io/content/2.14/tasks/flagger.md
+++ b/linkerd.io/content/2.14/tasks/flagger.md
@@ -70,6 +70,7 @@ as there needs to be some kind of active traffic to complete the operation.
 Together, these components have a topology that looks like:
 
 ![Topology](/docs/images/canary/simple-topology.svg "Topology")
+{.center}
 
 To add these components to your cluster and include them in the Linkerd
 [data plane](../../reference/architecture/#data-plane), run:
@@ -253,6 +254,7 @@ podinfo-primary      ClusterIP   10.7.249.63   <none>        9898/TCP   23m
 At this point, the topology looks a little like:
 
 ![Initialized](/docs/images/canary/initialized.svg "Initialized")
+{.center}
 
 {{< note >}}
 This guide barely touches all the functionality provided by Flagger. Make sure
@@ -297,6 +299,7 @@ While an update is occurring, the resources and traffic will look like this at a
 high level:
 
 ![Ongoing](/docs/images/canary/ongoing.svg "Ongoing")
+{.center}
 
 After the update is complete, this picture will go back to looking just like the
 figure from the previous section.

--- a/linkerd.io/content/2.15/tasks/books.md
+++ b/linkerd.io/content/2.15/tasks/books.md
@@ -21,6 +21,7 @@ For demo purposes, the app comes with a simple traffic generator. The overall
 topology looks like this:
 
 ![Topology](/docs/images/books/topology.png "Topology")
+{.center}
 
 ## Prerequisites
 
@@ -82,6 +83,7 @@ perspective, it looks like everything's fine, but you know the application is
 returning errors.
 
 ![Failure](/docs/images/books/failure.png "Failure")
+{.center}
 
 ## Add Linkerd to the service
 

--- a/linkerd.io/content/2.15/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.15/tasks/distributed-tracing.md
@@ -21,6 +21,7 @@ In the case of emojivoto, once all these steps are complete there will be a
 topology that looks like:
 
 ![Topology](/docs/images/tracing/tracing-topology.svg "Topology")
+{.center}
 
 ## Prerequisites
 

--- a/linkerd.io/content/2.15/tasks/fault-injection.md
+++ b/linkerd.io/content/2.15/tasks/fault-injection.md
@@ -12,6 +12,7 @@ The [books demo](../books/) is a great way to show off this behavior. The
 overall topology looks like:
 
 ![Topology](/docs/images/books/topology.png "Topology")
+{.center}
 
 In this guide, you will split some of the requests from `webapp` to `books`.
 Most requests will end up at the correct `books` destination, however some of

--- a/linkerd.io/content/2.15/tasks/flagger.md
+++ b/linkerd.io/content/2.15/tasks/flagger.md
@@ -70,6 +70,7 @@ as there needs to be some kind of active traffic to complete the operation.
 Together, these components have a topology that looks like:
 
 ![Topology](/docs/images/canary/simple-topology.svg "Topology")
+{.center}
 
 To add these components to your cluster and include them in the Linkerd
 [data plane](../../reference/architecture/#data-plane), run:
@@ -212,6 +213,7 @@ podinfo-primary      ClusterIP   10.7.249.63   <none>        9898/TCP   23m
 At this point, the topology looks a little like:
 
 ![Initialized](/docs/images/canary/initialized.svg "Initialized")
+{.center}
 
 {{< note >}}
 This guide barely touches all the functionality provided by Flagger. Make sure
@@ -256,6 +258,7 @@ While an update is occurring, the resources and traffic will look like this at a
 high level:
 
 ![Ongoing](/docs/images/canary/ongoing.svg "Ongoing")
+{.center}
 
 After the update is complete, this picture will go back to looking just like the
 figure from the previous section.

--- a/linkerd.io/content/2.16/tasks/books.md
+++ b/linkerd.io/content/2.16/tasks/books.md
@@ -21,6 +21,7 @@ For demo purposes, the app comes with a simple traffic generator. The overall
 topology looks like this:
 
 ![Topology](/docs/images/books/topology.png "Topology")
+{.center}
 
 ## Prerequisites
 
@@ -82,6 +83,7 @@ perspective, it looks like everything's fine, but you know the application is
 returning errors.
 
 ![Failure](/docs/images/books/failure.png "Failure")
+{.center}
 
 ## Add Linkerd to the service
 

--- a/linkerd.io/content/2.16/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.16/tasks/distributed-tracing.md
@@ -21,6 +21,7 @@ In the case of emojivoto, once all these steps are complete there will be a
 topology that looks like:
 
 ![Topology](/docs/images/tracing/tracing-topology.svg "Topology")
+{.center}
 
 ## Prerequisites
 

--- a/linkerd.io/content/2.16/tasks/fault-injection.md
+++ b/linkerd.io/content/2.16/tasks/fault-injection.md
@@ -12,6 +12,7 @@ The [books demo](../books/) is a great way to show off this behavior. The
 overall topology looks like:
 
 ![Topology](/docs/images/books/topology.png "Topology")
+{.center}
 
 In this guide, you will split some of the requests from `webapp` to `books`.
 Most requests will end up at the correct `books` destination, however some of

--- a/linkerd.io/content/2.16/tasks/flagger.md
+++ b/linkerd.io/content/2.16/tasks/flagger.md
@@ -70,6 +70,7 @@ as there needs to be some kind of active traffic to complete the operation.
 Together, these components have a topology that looks like:
 
 ![Topology](/docs/images/canary/simple-topology.svg "Topology")
+{.center}
 
 To add these components to your cluster and include them in the Linkerd
 [data plane](../../reference/architecture/#data-plane), run:
@@ -212,6 +213,7 @@ podinfo-primary      ClusterIP   10.7.249.63   <none>        9898/TCP   23m
 At this point, the topology looks a little like:
 
 ![Initialized](/docs/images/canary/initialized.svg "Initialized")
+{.center}
 
 {{< note >}}
 This guide barely touches all the functionality provided by Flagger. Make sure
@@ -256,6 +258,7 @@ While an update is occurring, the resources and traffic will look like this at a
 high level:
 
 ![Ongoing](/docs/images/canary/ongoing.svg "Ongoing")
+{.center}
 
 After the update is complete, this picture will go back to looking just like the
 figure from the previous section.

--- a/linkerd.io/content/2.17/tasks/books.md
+++ b/linkerd.io/content/2.17/tasks/books.md
@@ -21,6 +21,7 @@ For demo purposes, the app comes with a simple traffic generator. The overall
 topology looks like this:
 
 ![Topology](/docs/images/books/topology.png "Topology")
+{.center}
 
 ## Prerequisites
 
@@ -82,6 +83,7 @@ perspective, it looks like everything's fine, but you know the application is
 returning errors.
 
 ![Failure](/docs/images/books/failure.png "Failure")
+{.center}
 
 ## Add Linkerd to the service
 

--- a/linkerd.io/content/2.17/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.17/tasks/distributed-tracing.md
@@ -21,6 +21,7 @@ In the case of emojivoto, once all these steps are complete there will be a
 topology that looks like:
 
 ![Topology](/docs/images/tracing/tracing-topology.svg "Topology")
+{.center}
 
 ## Prerequisites
 

--- a/linkerd.io/content/2.17/tasks/fault-injection.md
+++ b/linkerd.io/content/2.17/tasks/fault-injection.md
@@ -12,6 +12,7 @@ The [books demo](../books/) is a great way to show off this behavior. The
 overall topology looks like:
 
 ![Topology](/docs/images/books/topology.png "Topology")
+{.center}
 
 In this guide, you will split some of the requests from `webapp` to `books`.
 Most requests will end up at the correct `books` destination, however some of

--- a/linkerd.io/content/2.17/tasks/flagger.md
+++ b/linkerd.io/content/2.17/tasks/flagger.md
@@ -70,6 +70,7 @@ as there needs to be some kind of active traffic to complete the operation.
 Together, these components have a topology that looks like:
 
 ![Topology](/docs/images/canary/simple-topology.svg "Topology")
+{.center}
 
 To add these components to your cluster and include them in the Linkerd
 [data plane](../../reference/architecture/#data-plane), run:
@@ -212,6 +213,7 @@ podinfo-primary      ClusterIP   10.7.249.63   <none>        9898/TCP   23m
 At this point, the topology looks a little like:
 
 ![Initialized](/docs/images/canary/initialized.svg "Initialized")
+{.center}
 
 {{< note >}}
 This guide barely touches all the functionality provided by Flagger. Make sure
@@ -256,6 +258,7 @@ While an update is occurring, the resources and traffic will look like this at a
 high level:
 
 ![Ongoing](/docs/images/canary/ongoing.svg "Ongoing")
+{.center}
 
 After the update is complete, this picture will go back to looking just like the
 figure from the previous section.

--- a/linkerd.io/layouts/_default/_markup/render-image.html
+++ b/linkerd.io/layouts/_default/_markup/render-image.html
@@ -15,9 +15,14 @@
   {{- end }}
 {{- end }}
 {{- /* Process attributes */}}
-{{- $a := merge .Attributes (dict "alt" .Text "src" $src "class" "img img--max-fill img--center img--rounded") }}
+{{- /* Allow the class name that may be passed as a Markdown attribute to be merged first, before adding the default class names */}}
+{{- $a := merge (dict "alt" .Text "src" $src "class" "") .Attributes }}
+{{- $class := "img img--max-fill img--rounded" }}
 {{- $attributes := "" }}
 {{- range $k, $v := $a }}
+  {{- if eq $k "class" }}
+    {{- $v = printf "%s %s" $class $v }}
+  {{- end }}
   {{- if $v }}
     {{- $attributes = printf "%s %s=%q" $attributes $k $v }}
   {{- end }}


### PR DESCRIPTION
Removed default centering on images used in Markdown content.

To center the image, use a Markdown attribute:

```markdown
![alt](image.jpg)
{.center}
```