### PR TITLE
nit(features): address typo in `linkerd.io/tcp` note

### DIFF
--- a/linkerd.io/content/2-edge/features/protocol-detection.md
+++ b/linkerd.io/content/2-edge/features/protocol-detection.md
@@ -98,7 +98,7 @@ and skip automatic protocol detection entirely.
 | `appProtocol`     | Protocol   | Notes |
 |-------------------|------------|-------|
 | linkerd.io/opaque | opaque     |       |
-| linkerd.io/tcp    | opaque     | This is an alias of `linkerd.io/opaque`, as it istreated exactly the same. |
+| linkerd.io/tcp    | opaque     | This is an alias of `linkerd.io/opaque`. It is treated exactly the same. |
 | http              | HTTP/1     | The source proxy may upgrade the connection to the destination proxy to HTTP/2, though the destination workload will still see HTTP/1 |
 | kubernetes.io/h2c | HTTP/2     |       |
 


### PR DESCRIPTION
this commit makes a small patch to the documentation of the `linkerd.io/tcp` directive, fixing a typo in the note's text.