### PR TITLE
Update protocol detection doc

### DIFF
--- a/linkerd.io/content/2-edge/common-errors/network-policy.md
+++ b/linkerd.io/content/2-edge/common-errors/network-policy.md
@@ -1,0 +1,13 @@
+---
+title: Network Policy
+description: NetworkPolicy must not block the Linkerd inbound port.
+---
+
+Communication between two meshed pods will always have its original target port
+replaced with the proxy's inbound port (by default, `4143`). Once the inbound
+proxy receives the traffic, it will transparently forward it to the main
+application container on the original port.
+
+However, this means that any `NetworkPolicy` which blocks the Linkerd inbound
+port (`4143`) will block all meshed traffic. For compatibility with Linkerd,
+please ensure that any `NetworkPolicy` allows traffic to this port.


### PR DESCRIPTION
The protocol detection doc was out of date and included incorrect information.  I've updated the doc to reflect current best practices with Linkerd around `appProtocol` and opaque ports.