### PR TITLE
Fix deprecated alert

### DIFF
--- a/linkerd.io/layouts/docs/_docs-deprecated-alert.html
+++ b/linkerd.io/layouts/docs/_docs-deprecated-alert.html
@@ -4,8 +4,8 @@
     <div class="alert__content">
       You are viewing docs for an older version of Linkerd.
       {{ $latestFilePath := replace .RelPermalink (printf "/%s/" .Section) (printf "/%s/" $latestVersion) }}
-      {{ if fileExists $latestFilePath }}
-        You may want the <a href="{{ $latestFilePath }}">latest documentation</a> for this page instead.
+      {{ with site.GetPage $latestFilePath }}
+        You may want the <a href="{{ .RelPermalink }}">latest documentation</a> for this page instead.
       {{ else }}
         <a href="/{{ $latestVersion }}/">View the latest docs</a>.
       {{ end }}


### PR DESCRIPTION
At some point the deprecated alert in the older docs stopped working. This PR fixes the logic so an old doc will once again link to the latest version of the doc.

To test, verify that the link in the deprecated alert...

https://deploy-preview-1970--linkerdio.netlify.app/2.15/tasks/automatic-failover/

goes to this page...

https://deploy-preview-1970--linkerdio.netlify.app/2.18/tasks/automatic-failover/