### PR TITLE
Fix broken links in httproute and grpcroute docs

### DIFF
--- a/linkerd.io/content/2.16/reference/grpcroute.md
+++ b/linkerd.io/content/2.16/reference/grpcroute.md
@@ -83,3 +83,6 @@ spec:
 [ns-boundaries]: https://gateway-api.sigs.k8s.io/geps/gep-1426/#namespace-boundaries
 [Server]: authorization-policy/#server
 [Service]: https://kubernetes.io/docs/concepts/services-networking/service/
+[auth-policy]: ../tasks/configuring-per-route-policy/
+[dyn-routing]: ../tasks/configuring-dynamic-request-routing/
+[timeouts]: timeouts/#configuring-timeouts

--- a/linkerd.io/content/2.16/reference/grpcroute.md
+++ b/linkerd.io/content/2.16/reference/grpcroute.md
@@ -33,7 +33,7 @@ authorization and authentication policies][auth-policy].
 configure policies for _outbound_ proxies in pods which are clients of that
 [Service]. Outbound policy includes [dynamic request routing][dyn-routing],
 adding request headers, modifying a request's path, and reliability features
-such as [timeouts].
+such as timeouts.
 
 {{< warning >}}
 **Outbound GRPCRoutes and [ServiceProfiles](service-profiles/) provide
@@ -85,4 +85,3 @@ spec:
 [Service]: https://kubernetes.io/docs/concepts/services-networking/service/
 [auth-policy]: ../tasks/configuring-per-route-policy/
 [dyn-routing]: ../tasks/configuring-dynamic-request-routing/
-[timeouts]: timeouts/#configuring-timeouts

--- a/linkerd.io/content/2.16/reference/httproute.md
+++ b/linkerd.io/content/2.16/reference/httproute.md
@@ -33,7 +33,7 @@ authorization and authentication policies][auth-policy].
 configure policies for _outbound_ proxies in pods which are clients of that
 [Service]. Outbound policy includes [dynamic request routing][dyn-routing],
 adding request headers, modifying a request's path, and reliability features
-such as [timeouts].
+such as [timeouts](#httproutetimeouts).
 
 {{< warning >}}
 **Outbound HTTPRoutes and [ServiceProfiles](service-profiles/) provide
@@ -335,3 +335,5 @@ spec:
 [ns-boundaries]: https://gateway-api.sigs.k8s.io/geps/gep-1426/#namespace-boundaries
 [Server]: authorization-policy/#server
 [Service]: https://kubernetes.io/docs/concepts/services-networking/service/
+[auth-policy]: ../tasks/configuring-per-route-policy/
+[dyn-routing]: ../tasks/configuring-dynamic-request-routing/

--- a/linkerd.io/content/2.17/reference/grpcroute.md
+++ b/linkerd.io/content/2.17/reference/grpcroute.md
@@ -83,3 +83,6 @@ spec:
 [ns-boundaries]: https://gateway-api.sigs.k8s.io/geps/gep-1426/#namespace-boundaries
 [Server]: authorization-policy/#server
 [Service]: https://kubernetes.io/docs/concepts/services-networking/service/
+[auth-policy]: ../tasks/configuring-per-route-policy/
+[dyn-routing]: ../tasks/configuring-dynamic-request-routing/
+[timeouts]: timeouts/#configuring-timeouts

--- a/linkerd.io/content/2.17/reference/grpcroute.md
+++ b/linkerd.io/content/2.17/reference/grpcroute.md
@@ -33,7 +33,7 @@ authorization and authentication policies][auth-policy].
 configure policies for _outbound_ proxies in pods which are clients of that
 [Service]. Outbound policy includes [dynamic request routing][dyn-routing],
 adding request headers, modifying a request's path, and reliability features
-such as [timeouts].
+such as timeouts.
 
 {{< warning >}}
 **Outbound GRPCRoutes and [ServiceProfiles](service-profiles/) provide
@@ -85,4 +85,3 @@ spec:
 [Service]: https://kubernetes.io/docs/concepts/services-networking/service/
 [auth-policy]: ../tasks/configuring-per-route-policy/
 [dyn-routing]: ../tasks/configuring-dynamic-request-routing/
-[timeouts]: timeouts/#configuring-timeouts

--- a/linkerd.io/content/2.17/reference/httproute.md
+++ b/linkerd.io/content/2.17/reference/httproute.md
@@ -33,7 +33,7 @@ authorization and authentication policies][auth-policy].
 configure policies for _outbound_ proxies in pods which are clients of that
 [Service]. Outbound policy includes [dynamic request routing][dyn-routing],
 adding request headers, modifying a request's path, and reliability features
-such as [timeouts].
+such as [timeouts](#httproutetimeouts).
 
 {{< warning >}}
 **Outbound HTTPRoutes and [ServiceProfiles](service-profiles/) provide
@@ -335,3 +335,5 @@ spec:
 [ns-boundaries]: https://gateway-api.sigs.k8s.io/geps/gep-1426/#namespace-boundaries
 [Server]: authorization-policy/#server
 [Service]: https://kubernetes.io/docs/concepts/services-networking/service/
+[auth-policy]: ../tasks/configuring-per-route-policy/
+[dyn-routing]: ../tasks/configuring-dynamic-request-routing/

--- a/linkerd.io/content/2.18/reference/grpcroute.md
+++ b/linkerd.io/content/2.18/reference/grpcroute.md
@@ -83,3 +83,6 @@ spec:
 [ns-boundaries]: https://gateway-api.sigs.k8s.io/geps/gep-1426/#namespace-boundaries
 [Server]: authorization-policy/#server
 [Service]: https://kubernetes.io/docs/concepts/services-networking/service/
+[auth-policy]: ../tasks/configuring-per-route-policy/
+[dyn-routing]: ../tasks/configuring-dynamic-request-routing/
+[timeouts]: timeouts/#configuring-timeouts

--- a/linkerd.io/content/2.18/reference/grpcroute.md
+++ b/linkerd.io/content/2.18/reference/grpcroute.md
@@ -33,7 +33,7 @@ authorization and authentication policies][auth-policy].
 configure policies for _outbound_ proxies in pods which are clients of that
 [Service]. Outbound policy includes [dynamic request routing][dyn-routing],
 adding request headers, modifying a request's path, and reliability features
-such as [timeouts].
+such as timeouts.
 
 {{< warning >}}
 **Outbound GRPCRoutes and [ServiceProfiles](service-profiles/) provide
@@ -85,4 +85,3 @@ spec:
 [Service]: https://kubernetes.io/docs/concepts/services-networking/service/
 [auth-policy]: ../tasks/configuring-per-route-policy/
 [dyn-routing]: ../tasks/configuring-dynamic-request-routing/
-[timeouts]: timeouts/#configuring-timeouts

--- a/linkerd.io/content/2.18/reference/httproute.md
+++ b/linkerd.io/content/2.18/reference/httproute.md
@@ -33,7 +33,7 @@ authorization and authentication policies][auth-policy].
 configure policies for _outbound_ proxies in pods which are clients of that
 [Service]. Outbound policy includes [dynamic request routing][dyn-routing],
 adding request headers, modifying a request's path, and reliability features
-such as [timeouts].
+such as [timeouts](#httproutetimeouts).
 
 {{< warning >}}
 **Outbound HTTPRoutes and [ServiceProfiles](service-profiles/) provide
@@ -335,3 +335,5 @@ spec:
 [ns-boundaries]: https://gateway-api.sigs.k8s.io/geps/gep-1426/#namespace-boundaries
 [Server]: authorization-policy/#server
 [Service]: https://kubernetes.io/docs/concepts/services-networking/service/
+[auth-policy]: ../tasks/configuring-per-route-policy/
+[dyn-routing]: ../tasks/configuring-dynamic-request-routing/


### PR DESCRIPTION
It appears that a few link references got orphaned when the Gateway API docs were [reworked](https://github.com/linkerd/website/pull/1909). 

@wmorgan Specifically in the GRPCRoute reference doc, is the timeout link going to the right place? I wasn't sure if it should go to the feature page or the reference page.

https://deploy-preview-1973--linkerdio.netlify.app/2.18/reference/httproute/
https://deploy-preview-1973--linkerdio.netlify.app/2.18/reference/grpcroute/

https://deploy-preview-1973--linkerdio.netlify.app/2.17/reference/httproute/
https://deploy-preview-1973--linkerdio.netlify.app/2.17/reference/grpcroute/

https://deploy-preview-1973--linkerdio.netlify.app/2.16/reference/httproute/
https://deploy-preview-1973--linkerdio.netlify.app/2.16/reference/grpcroute/