### PR TITLE
Truncate summary when used as page description

### DIFF
--- a/linkerd.io/layouts/partials/page-description.html
+++ b/linkerd.io/layouts/partials/page-description.html
@@ -1,3 +1,3 @@
-{{- with or .Description .Summary site.Params.description | plainify | htmlUnescape }}
-  {{- trim . "\n\r\t " }}
+{{- with or .Description (.Summary | truncate 160) site.Params.description | plainify | htmlUnescape }}
+  {{- trim . "\n\r\t " | replaceRE "[\n\r\t]+" " " }}
 {{- end -}}


### PR DESCRIPTION
Currently, when the `.Summary` is use for the meta description because the `.Description` value is empty, the summary content is not truncated. Because of this, the length of the summary can be longer than the recommended length of a page description.

With this PR, when the summary is used as the page description, it is truncated to 160 characters.
