### PR TITLE
fix(ci): Fix bindir in validate scripts

### DIFF
--- a/bin/export-channel-versions
+++ b/bin/export-channel-versions
@@ -2,8 +2,6 @@
 
 set -eu
 
-bindir=$( cd "${0%/*}" && pwd )
-
 github_token=${GITHUB_TOKEN:-}
 if [ -z "$github_token" ] && [ -n "${GITHUB_TOKEN_FILE:-}" ] && [ -f "$GITHUB_TOKEN_FILE" ]; then
   github_token=$(cat "$GITHUB_TOKEN_FILE")
@@ -11,9 +9,9 @@ fi
 
 ghcurl() {
   if [ -n "${github_token:-}" ]; then
-    "$bindir"/scurl -H "Authorization: Bearer ${github_token:-}" "$@"
+    ./bin/scurl -H "Authorization: Bearer ${github_token:-}" "$@"
   else
-    "$bindir"/scurl "$@"
+    ./bin/scurl "$@"
   fi
 }
 


### PR DESCRIPTION
Previously, the scripts would try to infer the bin directory from the script arguments, which isn't consistent. This updates it to simply reference the bin directory directly.