### PR TITLE
fix(ci): Read releases json from file

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -28,6 +28,8 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Build scripts
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         make build-run.linkerd.io
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,5 +23,7 @@ jobs:
         make lint
 
     - name: Lint html and check for dead links
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         make check

--- a/bin/export-channel-versions
+++ b/bin/export-channel-versions
@@ -9,19 +9,21 @@ fi
 
 ghcurl() {
   if [ -n "${github_token:-}" ]; then
-    ./bin/scurl -H "Authorization: Bearer ${github_token:-}" "$@"
+    curl --proto '=https' --tlsv1.2 -sSfL -H "Authorization: Bearer ${github_token:-}" "$@"
   else
-    ./bin/scurl "$@"
+    curl --proto '=https' --tlsv1.2 -sSfL "$@"
   fi
 }
 
 releases_url="https://api.github.com/repos/linkerd/linkerd2/releases?per_page=100"
-releases_json=$(ghcurl "$releases_url")
+releases_json_file=$(mktemp)
+ghcurl "$releases_url" > "$releases_json_file"
 
 # Hardcode latest stable version
 export L5D2_STABLE_VERSION="stable-2.14.10"
 # Match examples: `"tag_name": "edge-25.7.4",`
-L5D2_EDGE_VERSION=$(echo "$releases_json" | jq -r '.[].tag_name' | grep -E 'edge-[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -n 1)
+L5D2_EDGE_VERSION=$(jq  -r '.[].tag_name' "$releases_json_file"  | grep -E 'edge-[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -n 1)
+rm "$releases_json_file"
 # separate export to avoid masking return values
 export L5D2_EDGE_VERSION="$L5D2_EDGE_VERSION"
 

--- a/bin/scurl
+++ b/bin/scurl
@@ -1,3 +1,0 @@
-#!/usr/bin/env sh
-
-exec curl --proto '=https' --tlsv1.2 -sSfL "$@"


### PR DESCRIPTION
Some shells can unescape newlines (\n) in script variables, this prevents that by dumping the json to a file and having jq read from that directly.