### PR TITLE
Remove whitespace below footer

### DIFF
--- a/linkerd.io/layouts/partials/body-close.html
+++ b/linkerd.io/layouts/partials/body-close.html
@@ -6,5 +6,5 @@
 {{ end }}
 
 {{ if hugo.IsProduction }}
-  <img alt="scarf" referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=134c11a9-d08b-45e0-8cc9-d1ed96a92343">
+  <img alt="scarf" referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=134c11a9-d08b-45e0-8cc9-d1ed96a92343" style="position:absolute;top:0;left:0;width:1px;height:1px;">
 {{ end }}


### PR DESCRIPTION
There is whitespace showing below the footer caused by the scarf tracking pixel.

With this PR, the tracking pixel is absolute positioned, to remove it from the normal document flow.

Fixes #2002