### PR TITLE
Maintain consistent image ratio on blog post feature images

### DIFF
--- a/linkerd.io/README.md
+++ b/linkerd.io/README.md
@@ -100,7 +100,7 @@ params:
 **Note:** If an author only has a single blog post, but there's a chance they
 will have more in the future, please not use the inline method.
 
-#### Cover, thumbnail, and feature images
+#### Naming images
 
 To associate a cover, thumbnail, or feature image to a blog post, you do not
 have to specify them in the frontmatter. You can simply name them `cover`,
@@ -116,10 +116,39 @@ blog/
         └── thumbnail.jpg
 ```
 
+If you need to name your images another way, you can reference the image names
+in the frontmatter of the blog post. For example:
+
+```yaml
+params:
+  thumbnail: square.png
+  cover: hero.png
+  feature: hero-cropped.png
+```
+
+#### Feature a blog post
+
+A blog post can be featured on the blog listing page by adding a reference to
+the blog post in the frontmatter params. For example:
+
+```yaml
+# /content/blog/_index.md
+params:
+  feature:
+    - /blog/2024/0102-my-blog-post
+```
+
+**Note:** Only the first 2 items in the list will be featured.
+
 If a blog post is featured, by default, the cover image will be used on the blog
 list page. If a cover image is not present, or you would like to use a different
 image than the cover image, you can name it `feature` and place it in the blog
 post folder.
+
+**Note:** When a blog post is featured on the blog listing it will be
+cropped into a 4x1 ratio.
+
+#### Thumbnail images
 
 If a thumbnail image is not present in the blog post folder, then the cover
 image will be used. By default, the thumbnail image will be cropped into a
@@ -137,16 +166,6 @@ adding the `showCover` frontmatter param. For example:
 ```yaml
 params:
   showCover: true
-```
-
-If you need to name your images another way, you can reference the image names
-in the frontmatter:
-
-```yaml
-params:
-  thumbnail: square.png
-  cover: hero.png
-  feature: hero-cropped.png
 ```
 
 #### Open graph images

--- a/linkerd.io/assets/scss/components/_img-ratio.scss
+++ b/linkerd.io/assets/scss/components/_img-ratio.scss
@@ -1,0 +1,37 @@
+/*
+@markup
+<figure class="img-ratio img-ratio--16x9">
+  <img>
+</figure>
+*/
+
+.img-ratio {
+  position: relative;
+  width: 100%;
+  height: 0;
+  padding-bottom: 56.25%; // Default to 16x9
+  overflow: hidden;
+
+  img,
+  .img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center center;
+  }
+
+  // @options
+  
+  &.img-ratio--4x3 {
+    padding-bottom: 75%;
+  }
+  &.img-ratio--16x9 {
+    padding-bottom: 56.25%;
+  }
+  &.img-ratio--4x1 {
+    padding-bottom: 25%;
+  }
+}

--- a/linkerd.io/assets/scss/main.scss
+++ b/linkerd.io/assets/scss/main.scss
@@ -28,6 +28,7 @@
 @import "components/highlight";
 @import "components/icon-button";
 @import "components/icon";
+@import "components/img-ratio";
 @import "components/img";
 @import "components/keyval";
 @import "components/loader";

--- a/linkerd.io/content/tests/components.html
+++ b/linkerd.io/content/tests/components.html
@@ -245,6 +245,9 @@ title: Components
     <img src="../image.png" class="img img--w128">
     <img src="../image.png" class="img img--h128">
   </div>
+  <figure class="img-ratio img-ratio--4x1">
+    <img src="../image.png" class="img img--rounded">
+  </figure>
 
   <h2>Loader</h2>
 

--- a/linkerd.io/layouts/blog/_feature.html
+++ b/linkerd.io/layouts/blog/_feature.html
@@ -1,7 +1,9 @@
 <div class="card">
   <div class="card__media">
     {{ with .Render "_feature-relref" }}
-      <img src="{{ . }}" alt="{{ path.BaseName . | humanize }}" class="img img--fill img--cover img--rounded">
+      <figure class="img-ratio img-ratio--4x1">
+        <img src="{{ . }}" alt="{{ path.BaseName . | humanize }}" class="img img--rounded">
+      </figure>
     {{ end }}
   </div>
   <div class="card__body">


### PR DESCRIPTION
With this PR, the featured images on the blog post listing page maintain a 4x1 aspect ratio on all screen sizes.

**Preview**
https://deploy-preview-2008--linkerdio.netlify.app/blog/

To test this change locally, you can feature a blog post with a cover image that is not in 4x1 ratio, such as `/blog/2024/1205-announcing-linkerd-2.17`.
