### PR TITLE
Remove .metadata.namespace from Bundle

### DIFF
--- a/linkerd.io/content/2-edge/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2-edge/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -467,7 +467,6 @@ metadata:
   # This is the name of the Bundle and _also_ the name of the
   # ConfigMap in which we'll write the trust bundle.
   name: linkerd-identity-trust-roots
-  namespace: linkerd
 spec:
   # This tells trust-manager where to find the public keys to copy into
   # the trust bundle.

--- a/linkerd.io/content/2.14/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.14/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -467,7 +467,6 @@ metadata:
   # This is the name of the Bundle and _also_ the name of the
   # ConfigMap in which we'll write the trust bundle.
   name: linkerd-identity-trust-roots
-  namespace: linkerd
 spec:
   # This tells trust-manager where to find the public keys to copy into
   # the trust bundle.

--- a/linkerd.io/content/2.15/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.15/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -467,7 +467,6 @@ metadata:
   # This is the name of the Bundle and _also_ the name of the
   # ConfigMap in which we'll write the trust bundle.
   name: linkerd-identity-trust-roots
-  namespace: linkerd
 spec:
   # This tells trust-manager where to find the public keys to copy into
   # the trust bundle.

--- a/linkerd.io/content/2.16/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.16/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -467,7 +467,6 @@ metadata:
   # This is the name of the Bundle and _also_ the name of the
   # ConfigMap in which we'll write the trust bundle.
   name: linkerd-identity-trust-roots
-  namespace: linkerd
 spec:
   # This tells trust-manager where to find the public keys to copy into
   # the trust bundle.

--- a/linkerd.io/content/2.17/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.17/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -467,7 +467,6 @@ metadata:
   # This is the name of the Bundle and _also_ the name of the
   # ConfigMap in which we'll write the trust bundle.
   name: linkerd-identity-trust-roots
-  namespace: linkerd
 spec:
   # This tells trust-manager where to find the public keys to copy into
   # the trust bundle.

--- a/linkerd.io/content/2.18/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.18/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -467,7 +467,6 @@ metadata:
   # This is the name of the Bundle and _also_ the name of the
   # ConfigMap in which we'll write the trust bundle.
   name: linkerd-identity-trust-roots
-  namespace: linkerd
 spec:
   # This tells trust-manager where to find the public keys to copy into
   # the trust bundle.


### PR DESCRIPTION
Bundle is a cluster-level resource, hence .metadata.namespace was removed.

```
$ kubectl api-resources
NAME                                SHORTNAMES   APIVERSION                                NAMESPACED   KIND
bundles                                          trust.cert-manager.io/v1alpha1            false        Bundle
```