### PR TITLE
CSS fixes

### DIFF
--- a/linkerd.io/README.md
+++ b/linkerd.io/README.md
@@ -196,13 +196,6 @@ To display a caption below the image, provide an image title. For example:
 ![Alt text](my-image.jpg 'My image caption')
 ```
 
-To center the image, use a Markdown attribute:
-
-```markdown
-![Alt text](my-image.jpg)
-{.center}
-```
-
 #### Image dimensions
 
 Here are the recommended image dimensions for each image type:

--- a/linkerd.io/assets/scss/_base.scss
+++ b/linkerd.io/assets/scss/_base.scss
@@ -108,9 +108,11 @@ figure img {
 blockquote {
   margin: 0;
   margin-bottom: spacer(3);
-  padding: spacer(3);
-  border-left: solid 2px $border-color;
-
+  padding: spacer(4);
+  border-left: solid 4px $blue;
+  background-color: $light-blue;
+  border-radius: $border-radius;
+  
   & > :last-child {
     margin-bottom: 0;
   }

--- a/linkerd.io/assets/scss/app/_adopters.scss
+++ b/linkerd.io/assets/scss/app/_adopters.scss
@@ -11,6 +11,12 @@
     gap: spacer(4);
     grid-template-columns: 1fr;
 
+    blockquote {
+      // Remove base styling
+      padding: 0;
+      border: none;
+      background-color: $white;
+    }
     @media (min-width: breakpoint-min-width("lg")) {
       grid-template-columns: repeat(2, 1fr);
     }

--- a/linkerd.io/assets/scss/components/_alert.scss
+++ b/linkerd.io/assets/scss/components/_alert.scss
@@ -34,7 +34,7 @@
   // @options
 
   &.alert--callout {
-    border-width: 3px;
+    border-width: 4px;
     border-top: none;
     border-right: none;
     border-bottom: none;

--- a/linkerd.io/assets/scss/components/_prose.scss
+++ b/linkerd.io/assets/scss/components/_prose.scss
@@ -36,7 +36,7 @@ Apply to containers that contain rendered markdown.
 
   // Add bottom margin to html inserted by Hugo's youtube shortcode
   // Hugo does not add a class name on the div, so target the title attribute
-  div:has(iframe[title='YouTube video']) {
+  div:has(> iframe[title='YouTube video']) {
     margin-bottom: spacer(3);
   }
 

--- a/linkerd.io/assets/scss/components/_prose.scss
+++ b/linkerd.io/assets/scss/components/_prose.scss
@@ -34,10 +34,10 @@ Apply to containers that contain rendered markdown.
     margin-bottom: spacer(3);
   }
 
-  // Add bottom margin to iframes inserted by Hugo's youtube shortcode
-  // Hugo does not add a class name, so target the title attribute
-  iframe[title='YouTube video'] {
-    padding-bottom: spacer(3);
+  // Add bottom margin to html inserted by Hugo's youtube shortcode
+  // Hugo does not add a class name on the div, so target the title attribute
+  div:has(iframe[title='YouTube video']) {
+    margin-bottom: spacer(3);
   }
 
 }

--- a/linkerd.io/assets/scss/components/_prose.scss
+++ b/linkerd.io/assets/scss/components/_prose.scss
@@ -17,6 +17,13 @@ Apply to containers that contain rendered markdown.
     }
   }
 
+  // Center standalone images within content
+  figure {
+    img {
+      margin: 0 auto;
+    }
+  }
+
   // Add bottom margin to alerts
   .alert {
     margin-bottom: spacer(3);
@@ -27,9 +34,10 @@ Apply to containers that contain rendered markdown.
     margin-bottom: spacer(3);
   }
 
-  // Markdown attribute classes
-  img.center {
-    margin: 0 auto;
+  // Add bottom margin to iframes inserted by Hugo's youtube shortcode
+  // Hugo does not add a class name, so target the title attribute
+  iframe[title='YouTube video'] {
+    padding-bottom: spacer(3);
   }
 
 }

--- a/linkerd.io/config/_default/menu.yaml
+++ b/linkerd.io/config/_default/menu.yaml
@@ -9,7 +9,7 @@ main:
     pageRef: /community/get-involved/
     weight: 1
     parent: Community
-  - name: Adopters
+  - name: Adopters & Case Studies
     pageRef: /community/adopters/
     weight: 2
     parent: Community

--- a/linkerd.io/content/2-edge/tasks/books.md
+++ b/linkerd.io/content/2-edge/tasks/books.md
@@ -21,7 +21,6 @@ For demo purposes, the app comes with a simple traffic generator. The overall
 topology looks like this:
 
 ![Topology](/docs/images/books/topology.png "Topology")
-{.center}
 
 ## Prerequisites
 
@@ -83,7 +82,6 @@ perspective, it looks like everything's fine, but you know the application is
 returning errors.
 
 ![Failure](/docs/images/books/failure.png "Failure")
-{.center}
 
 ## Add Linkerd to the service
 

--- a/linkerd.io/content/2-edge/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2-edge/tasks/distributed-tracing.md
@@ -21,7 +21,6 @@ In the case of emojivoto, once all these steps are complete there will be a
 topology that looks like:
 
 ![Topology](/docs/images/tracing/tracing-topology.svg "Topology")
-{.center}
 
 ## Prerequisites
 

--- a/linkerd.io/content/2-edge/tasks/fault-injection.md
+++ b/linkerd.io/content/2-edge/tasks/fault-injection.md
@@ -12,7 +12,6 @@ The [books demo](books/) is a great way to show off this behavior. The
 overall topology looks like:
 
 ![Topology](/docs/images/books/topology.png "Topology")
-{.center}
 
 In this guide, you will split some of the requests from `webapp` to `books`.
 Most requests will end up at the correct `books` destination, however some of

--- a/linkerd.io/content/2-edge/tasks/flagger.md
+++ b/linkerd.io/content/2-edge/tasks/flagger.md
@@ -70,7 +70,6 @@ as there needs to be some kind of active traffic to complete the operation.
 Together, these components have a topology that looks like:
 
 ![Topology](/docs/images/canary/simple-topology.svg "Topology")
-{.center}
 
 To add these components to your cluster and include them in the Linkerd
 [data plane](../reference/architecture/#data-plane), run:
@@ -213,7 +212,6 @@ podinfo-primary      ClusterIP   10.7.249.63   <none>        9898/TCP   23m
 At this point, the topology looks a little like:
 
 ![Initialized](/docs/images/canary/initialized.svg "Initialized")
-{.center}
 
 {{< note >}}
 This guide barely touches all the functionality provided by Flagger. Make sure
@@ -258,7 +256,6 @@ While an update is occurring, the resources and traffic will look like this at a
 high level:
 
 ![Ongoing](/docs/images/canary/ongoing.svg "Ongoing")
-{.center}
 
 After the update is complete, this picture will go back to looking just like the
 figure from the previous section.

--- a/linkerd.io/content/2.10/tasks/books.md
+++ b/linkerd.io/content/2.10/tasks/books.md
@@ -21,7 +21,6 @@ For demo purposes, the app comes with a simple traffic generator. The overall
 topology looks like this:
 
 ![Topology](/docs/images/books/topology.png "Topology")
-{.center}
 
 ## Prerequisites
 
@@ -80,7 +79,6 @@ perspective, it looks like everything's fine, but you know the application is
 returning errors.
 
 ![Failure](/docs/images/books/failure.png "Failure")
-{.center}
 
 ## Add Linkerd to the service
 

--- a/linkerd.io/content/2.10/tasks/canary-release.md
+++ b/linkerd.io/content/2.10/tasks/canary-release.md
@@ -68,7 +68,6 @@ as there needs to be some kind of active traffic to complete the operation.
 Together, these components have a topology that looks like:
 
 ![Topology](/docs/images/canary/simple-topology.svg "Topology")
-{.center}
 
 To add these components to your cluster and include them in the Linkerd
 [data plane](../reference/architecture/#data-plane), run:
@@ -170,7 +169,6 @@ podinfo-primary      ClusterIP   10.7.249.63   <none>        9898/TCP   23m
 At this point, the topology looks a little like:
 
 ![Initialized](/docs/images/canary/initialized.svg "Initialized")
-{.center}
 
 {{< note >}}
 This guide barely touches all the functionality provided by Flagger. Make sure
@@ -215,7 +213,6 @@ While an update is occurring, the resources and traffic will look like this at a
 high level:
 
 ![Ongoing](/docs/images/canary/ongoing.svg "Ongoing")
-{.center}
 
 After the update is complete, this picture will go back to looking just like the
 figure from the previous section.
@@ -264,7 +261,6 @@ running `linkerd viz dashboard` and then look at the detail page for the
 split](http://localhost:50750/namespaces/test/trafficsplits/podinfo).
 
 ![Dashboard](/docs/images/canary/traffic-split.png "Dashboard")
-{.center}
 
 ### Browser
 

--- a/linkerd.io/content/2.10/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.10/tasks/distributed-tracing.md
@@ -21,7 +21,6 @@ In the case of emojivoto, once all these steps are complete there will be a
 topology that looks like:
 
 ![Topology](/docs/images/tracing/tracing-topology.svg "Topology")
-{.center}
 
 ## Prerequisites
 

--- a/linkerd.io/content/2.10/tasks/fault-injection.md
+++ b/linkerd.io/content/2.10/tasks/fault-injection.md
@@ -14,7 +14,6 @@ The [books demo](books/) is a great way to show off this behavior. The
 overall topology looks like:
 
 ![Topology](/docs/images/books/topology.png "Topology")
-{.center}
 
 In this guide, you will split some of the requests from `webapp` to `books`.
 Most requests will end up at the correct `books` destination, however some of

--- a/linkerd.io/content/2.11/tasks/books.md
+++ b/linkerd.io/content/2.11/tasks/books.md
@@ -21,7 +21,6 @@ For demo purposes, the app comes with a simple traffic generator. The overall
 topology looks like this:
 
 ![Topology](/docs/images/books/topology.png "Topology")
-{.center}
 
 ## Prerequisites
 
@@ -80,7 +79,6 @@ perspective, it looks like everything's fine, but you know the application is
 returning errors.
 
 ![Failure](/docs/images/books/failure.png "Failure")
-{.center}
 
 ## Add Linkerd to the service
 

--- a/linkerd.io/content/2.11/tasks/canary-release.md
+++ b/linkerd.io/content/2.11/tasks/canary-release.md
@@ -69,7 +69,6 @@ as there needs to be some kind of active traffic to complete the operation.
 Together, these components have a topology that looks like:
 
 ![Topology](/docs/images/canary/simple-topology.svg "Topology")
-{.center}
 
 To add these components to your cluster and include them in the Linkerd
 [data plane](../reference/architecture/#data-plane), run:
@@ -171,7 +170,6 @@ podinfo-primary      ClusterIP   10.7.249.63   <none>        9898/TCP   23m
 At this point, the topology looks a little like:
 
 ![Initialized](/docs/images/canary/initialized.svg "Initialized")
-{.center}
 
 {{< note >}}
 This guide barely touches all the functionality provided by Flagger. Make sure
@@ -216,7 +214,6 @@ While an update is occurring, the resources and traffic will look like this at a
 high level:
 
 ![Ongoing](/docs/images/canary/ongoing.svg "Ongoing")
-{.center}
 
 After the update is complete, this picture will go back to looking just like the
 figure from the previous section.
@@ -265,7 +262,6 @@ running `linkerd viz dashboard` and then look at the detail page for the
 split](http://localhost:50750/namespaces/test/trafficsplits/podinfo).
 
 ![Dashboard](/docs/images/canary/traffic-split.png "Dashboard")
-{.center}
 
 ### Browser
 

--- a/linkerd.io/content/2.11/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.11/tasks/distributed-tracing.md
@@ -21,7 +21,6 @@ In the case of emojivoto, once all these steps are complete there will be a
 topology that looks like:
 
 ![Topology](/docs/images/tracing/tracing-topology.svg "Topology")
-{.center}
 
 ## Prerequisites
 

--- a/linkerd.io/content/2.11/tasks/fault-injection.md
+++ b/linkerd.io/content/2.11/tasks/fault-injection.md
@@ -14,7 +14,6 @@ The [books demo](books/) is a great way to show off this behavior. The
 overall topology looks like:
 
 ![Topology](/docs/images/books/topology.png "Topology")
-{.center}
 
 In this guide, you will split some of the requests from `webapp` to `books`.
 Most requests will end up at the correct `books` destination, however some of

--- a/linkerd.io/content/2.12/tasks/books.md
+++ b/linkerd.io/content/2.12/tasks/books.md
@@ -21,7 +21,6 @@ For demo purposes, the app comes with a simple traffic generator. The overall
 topology looks like this:
 
 ![Topology](/docs/images/books/topology.png "Topology")
-{.center}
 
 ## Prerequisites
 
@@ -80,7 +79,6 @@ perspective, it looks like everything's fine, but you know the application is
 returning errors.
 
 ![Failure](/docs/images/books/failure.png "Failure")
-{.center}
 
 ## Add Linkerd to the service
 

--- a/linkerd.io/content/2.12/tasks/canary-release.md
+++ b/linkerd.io/content/2.12/tasks/canary-release.md
@@ -70,7 +70,6 @@ as there needs to be some kind of active traffic to complete the operation.
 Together, these components have a topology that looks like:
 
 ![Topology](/docs/images/canary/simple-topology.svg "Topology")
-{.center}
 
 To add these components to your cluster and include them in the Linkerd
 [data plane](../reference/architecture/#data-plane), run:
@@ -172,7 +171,6 @@ podinfo-primary      ClusterIP   10.7.249.63   <none>        9898/TCP   23m
 At this point, the topology looks a little like:
 
 ![Initialized](/docs/images/canary/initialized.svg "Initialized")
-{.center}
 
 {{< note >}}
 This guide barely touches all the functionality provided by Flagger. Make sure
@@ -217,7 +215,6 @@ While an update is occurring, the resources and traffic will look like this at a
 high level:
 
 ![Ongoing](/docs/images/canary/ongoing.svg "Ongoing")
-{.center}
 
 After the update is complete, this picture will go back to looking just like the
 figure from the previous section.
@@ -266,7 +263,6 @@ running `linkerd viz dashboard` and then look at the detail page for the
 split](http://localhost:50750/namespaces/test/trafficsplits/podinfo).
 
 ![Dashboard](/docs/images/canary/traffic-split.png "Dashboard")
-{.center}
 
 ### Browser
 

--- a/linkerd.io/content/2.12/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.12/tasks/distributed-tracing.md
@@ -21,7 +21,6 @@ In the case of emojivoto, once all these steps are complete there will be a
 topology that looks like:
 
 ![Topology](/docs/images/tracing/tracing-topology.svg "Topology")
-{.center}
 
 ## Prerequisites
 

--- a/linkerd.io/content/2.12/tasks/fault-injection.md
+++ b/linkerd.io/content/2.12/tasks/fault-injection.md
@@ -14,7 +14,6 @@ The [books demo](books/) is a great way to show off this behavior. The
 overall topology looks like:
 
 ![Topology](/docs/images/books/topology.png "Topology")
-{.center}
 
 In this guide, you will split some of the requests from `webapp` to `books`.
 Most requests will end up at the correct `books` destination, however some of

--- a/linkerd.io/content/2.13/tasks/books.md
+++ b/linkerd.io/content/2.13/tasks/books.md
@@ -21,7 +21,6 @@ For demo purposes, the app comes with a simple traffic generator. The overall
 topology looks like this:
 
 ![Topology](/docs/images/books/topology.png "Topology")
-{.center}
 
 ## Prerequisites
 
@@ -80,7 +79,6 @@ perspective, it looks like everything's fine, but you know the application is
 returning errors.
 
 ![Failure](/docs/images/books/failure.png "Failure")
-{.center}
 
 ## Add Linkerd to the service
 

--- a/linkerd.io/content/2.13/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.13/tasks/distributed-tracing.md
@@ -21,7 +21,6 @@ In the case of emojivoto, once all these steps are complete there will be a
 topology that looks like:
 
 ![Topology](/docs/images/tracing/tracing-topology.svg "Topology")
-{.center}
 
 ## Prerequisites
 

--- a/linkerd.io/content/2.13/tasks/fault-injection.md
+++ b/linkerd.io/content/2.13/tasks/fault-injection.md
@@ -12,7 +12,6 @@ The [books demo](books/) is a great way to show off this behavior. The
 overall topology looks like:
 
 ![Topology](/docs/images/books/topology.png "Topology")
-{.center}
 
 In this guide, you will split some of the requests from `webapp` to `books`.
 Most requests will end up at the correct `books` destination, however some of

--- a/linkerd.io/content/2.13/tasks/flagger.md
+++ b/linkerd.io/content/2.13/tasks/flagger.md
@@ -70,7 +70,6 @@ as there needs to be some kind of active traffic to complete the operation.
 Together, these components have a topology that looks like:
 
 ![Topology](/docs/images/canary/simple-topology.svg "Topology")
-{.center}
 
 To add these components to your cluster and include them in the Linkerd
 [data plane](../reference/architecture/#data-plane), run:
@@ -172,7 +171,6 @@ podinfo-primary      ClusterIP   10.7.249.63   <none>        9898/TCP   23m
 At this point, the topology looks a little like:
 
 ![Initialized](/docs/images/canary/initialized.svg "Initialized")
-{.center}
 
 {{< note >}}
 This guide barely touches all the functionality provided by Flagger. Make sure
@@ -217,7 +215,6 @@ While an update is occurring, the resources and traffic will look like this at a
 high level:
 
 ![Ongoing](/docs/images/canary/ongoing.svg "Ongoing")
-{.center}
 
 After the update is complete, this picture will go back to looking just like the
 figure from the previous section.
@@ -266,7 +263,6 @@ running `linkerd viz dashboard` and then look at the detail page for the
 split](http://localhost:50750/namespaces/test/trafficsplits/podinfo).
 
 ![Dashboard](/docs/images/canary/traffic-split.png "Dashboard")
-{.center}
 
 ### Browser
 

--- a/linkerd.io/content/2.14/tasks/books.md
+++ b/linkerd.io/content/2.14/tasks/books.md
@@ -21,7 +21,6 @@ For demo purposes, the app comes with a simple traffic generator. The overall
 topology looks like this:
 
 ![Topology](/docs/images/books/topology.png "Topology")
-{.center}
 
 ## Prerequisites
 
@@ -83,7 +82,6 @@ perspective, it looks like everything's fine, but you know the application is
 returning errors.
 
 ![Failure](/docs/images/books/failure.png "Failure")
-{.center}
 
 ## Add Linkerd to the service
 

--- a/linkerd.io/content/2.14/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.14/tasks/distributed-tracing.md
@@ -21,7 +21,6 @@ In the case of emojivoto, once all these steps are complete there will be a
 topology that looks like:
 
 ![Topology](/docs/images/tracing/tracing-topology.svg "Topology")
-{.center}
 
 ## Prerequisites
 

--- a/linkerd.io/content/2.14/tasks/fault-injection.md
+++ b/linkerd.io/content/2.14/tasks/fault-injection.md
@@ -12,7 +12,6 @@ The [books demo](books/) is a great way to show off this behavior. The
 overall topology looks like:
 
 ![Topology](/docs/images/books/topology.png "Topology")
-{.center}
 
 In this guide, you will split some of the requests from `webapp` to `books`.
 Most requests will end up at the correct `books` destination, however some of

--- a/linkerd.io/content/2.14/tasks/flagger.md
+++ b/linkerd.io/content/2.14/tasks/flagger.md
@@ -70,7 +70,6 @@ as there needs to be some kind of active traffic to complete the operation.
 Together, these components have a topology that looks like:
 
 ![Topology](/docs/images/canary/simple-topology.svg "Topology")
-{.center}
 
 To add these components to your cluster and include them in the Linkerd
 [data plane](../reference/architecture/#data-plane), run:
@@ -254,7 +253,6 @@ podinfo-primary      ClusterIP   10.7.249.63   <none>        9898/TCP   23m
 At this point, the topology looks a little like:
 
 ![Initialized](/docs/images/canary/initialized.svg "Initialized")
-{.center}
 
 {{< note >}}
 This guide barely touches all the functionality provided by Flagger. Make sure
@@ -299,7 +297,6 @@ While an update is occurring, the resources and traffic will look like this at a
 high level:
 
 ![Ongoing](/docs/images/canary/ongoing.svg "Ongoing")
-{.center}
 
 After the update is complete, this picture will go back to looking just like the
 figure from the previous section.

--- a/linkerd.io/content/2.15/tasks/books.md
+++ b/linkerd.io/content/2.15/tasks/books.md
@@ -21,7 +21,6 @@ For demo purposes, the app comes with a simple traffic generator. The overall
 topology looks like this:
 
 ![Topology](/docs/images/books/topology.png "Topology")
-{.center}
 
 ## Prerequisites
 
@@ -83,7 +82,6 @@ perspective, it looks like everything's fine, but you know the application is
 returning errors.
 
 ![Failure](/docs/images/books/failure.png "Failure")
-{.center}
 
 ## Add Linkerd to the service
 

--- a/linkerd.io/content/2.15/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.15/tasks/distributed-tracing.md
@@ -21,7 +21,6 @@ In the case of emojivoto, once all these steps are complete there will be a
 topology that looks like:
 
 ![Topology](/docs/images/tracing/tracing-topology.svg "Topology")
-{.center}
 
 ## Prerequisites
 

--- a/linkerd.io/content/2.15/tasks/fault-injection.md
+++ b/linkerd.io/content/2.15/tasks/fault-injection.md
@@ -12,7 +12,6 @@ The [books demo](books/) is a great way to show off this behavior. The
 overall topology looks like:
 
 ![Topology](/docs/images/books/topology.png "Topology")
-{.center}
 
 In this guide, you will split some of the requests from `webapp` to `books`.
 Most requests will end up at the correct `books` destination, however some of

--- a/linkerd.io/content/2.15/tasks/flagger.md
+++ b/linkerd.io/content/2.15/tasks/flagger.md
@@ -70,7 +70,6 @@ as there needs to be some kind of active traffic to complete the operation.
 Together, these components have a topology that looks like:
 
 ![Topology](/docs/images/canary/simple-topology.svg "Topology")
-{.center}
 
 To add these components to your cluster and include them in the Linkerd
 [data plane](../reference/architecture/#data-plane), run:
@@ -213,7 +212,6 @@ podinfo-primary      ClusterIP   10.7.249.63   <none>        9898/TCP   23m
 At this point, the topology looks a little like:
 
 ![Initialized](/docs/images/canary/initialized.svg "Initialized")
-{.center}
 
 {{< note >}}
 This guide barely touches all the functionality provided by Flagger. Make sure
@@ -258,7 +256,6 @@ While an update is occurring, the resources and traffic will look like this at a
 high level:
 
 ![Ongoing](/docs/images/canary/ongoing.svg "Ongoing")
-{.center}
 
 After the update is complete, this picture will go back to looking just like the
 figure from the previous section.

--- a/linkerd.io/content/2.16/tasks/books.md
+++ b/linkerd.io/content/2.16/tasks/books.md
@@ -21,7 +21,6 @@ For demo purposes, the app comes with a simple traffic generator. The overall
 topology looks like this:
 
 ![Topology](/docs/images/books/topology.png "Topology")
-{.center}
 
 ## Prerequisites
 
@@ -83,7 +82,6 @@ perspective, it looks like everything's fine, but you know the application is
 returning errors.
 
 ![Failure](/docs/images/books/failure.png "Failure")
-{.center}
 
 ## Add Linkerd to the service
 

--- a/linkerd.io/content/2.16/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.16/tasks/distributed-tracing.md
@@ -21,7 +21,6 @@ In the case of emojivoto, once all these steps are complete there will be a
 topology that looks like:
 
 ![Topology](/docs/images/tracing/tracing-topology.svg "Topology")
-{.center}
 
 ## Prerequisites
 

--- a/linkerd.io/content/2.16/tasks/fault-injection.md
+++ b/linkerd.io/content/2.16/tasks/fault-injection.md
@@ -12,7 +12,6 @@ The [books demo](books/) is a great way to show off this behavior. The
 overall topology looks like:
 
 ![Topology](/docs/images/books/topology.png "Topology")
-{.center}
 
 In this guide, you will split some of the requests from `webapp` to `books`.
 Most requests will end up at the correct `books` destination, however some of

--- a/linkerd.io/content/2.16/tasks/flagger.md
+++ b/linkerd.io/content/2.16/tasks/flagger.md
@@ -70,7 +70,6 @@ as there needs to be some kind of active traffic to complete the operation.
 Together, these components have a topology that looks like:
 
 ![Topology](/docs/images/canary/simple-topology.svg "Topology")
-{.center}
 
 To add these components to your cluster and include them in the Linkerd
 [data plane](../reference/architecture/#data-plane), run:
@@ -213,7 +212,6 @@ podinfo-primary      ClusterIP   10.7.249.63   <none>        9898/TCP   23m
 At this point, the topology looks a little like:
 
 ![Initialized](/docs/images/canary/initialized.svg "Initialized")
-{.center}
 
 {{< note >}}
 This guide barely touches all the functionality provided by Flagger. Make sure
@@ -258,7 +256,6 @@ While an update is occurring, the resources and traffic will look like this at a
 high level:
 
 ![Ongoing](/docs/images/canary/ongoing.svg "Ongoing")
-{.center}
 
 After the update is complete, this picture will go back to looking just like the
 figure from the previous section.

--- a/linkerd.io/content/2.17/tasks/books.md
+++ b/linkerd.io/content/2.17/tasks/books.md
@@ -21,7 +21,6 @@ For demo purposes, the app comes with a simple traffic generator. The overall
 topology looks like this:
 
 ![Topology](/docs/images/books/topology.png "Topology")
-{.center}
 
 ## Prerequisites
 
@@ -83,7 +82,6 @@ perspective, it looks like everything's fine, but you know the application is
 returning errors.
 
 ![Failure](/docs/images/books/failure.png "Failure")
-{.center}
 
 ## Add Linkerd to the service
 

--- a/linkerd.io/content/2.17/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.17/tasks/distributed-tracing.md
@@ -21,7 +21,6 @@ In the case of emojivoto, once all these steps are complete there will be a
 topology that looks like:
 
 ![Topology](/docs/images/tracing/tracing-topology.svg "Topology")
-{.center}
 
 ## Prerequisites
 

--- a/linkerd.io/content/2.17/tasks/fault-injection.md
+++ b/linkerd.io/content/2.17/tasks/fault-injection.md
@@ -12,7 +12,6 @@ The [books demo](books/) is a great way to show off this behavior. The
 overall topology looks like:
 
 ![Topology](/docs/images/books/topology.png "Topology")
-{.center}
 
 In this guide, you will split some of the requests from `webapp` to `books`.
 Most requests will end up at the correct `books` destination, however some of

--- a/linkerd.io/content/2.17/tasks/flagger.md
+++ b/linkerd.io/content/2.17/tasks/flagger.md
@@ -70,7 +70,6 @@ as there needs to be some kind of active traffic to complete the operation.
 Together, these components have a topology that looks like:
 
 ![Topology](/docs/images/canary/simple-topology.svg "Topology")
-{.center}
 
 To add these components to your cluster and include them in the Linkerd
 [data plane](../reference/architecture/#data-plane), run:
@@ -213,7 +212,6 @@ podinfo-primary      ClusterIP   10.7.249.63   <none>        9898/TCP   23m
 At this point, the topology looks a little like:
 
 ![Initialized](/docs/images/canary/initialized.svg "Initialized")
-{.center}
 
 {{< note >}}
 This guide barely touches all the functionality provided by Flagger. Make sure
@@ -258,7 +256,6 @@ While an update is occurring, the resources and traffic will look like this at a
 high level:
 
 ![Ongoing](/docs/images/canary/ongoing.svg "Ongoing")
-{.center}
 
 After the update is complete, this picture will go back to looking just like the
 figure from the previous section.

--- a/linkerd.io/content/2.18/tasks/books.md
+++ b/linkerd.io/content/2.18/tasks/books.md
@@ -21,7 +21,6 @@ For demo purposes, the app comes with a simple traffic generator. The overall
 topology looks like this:
 
 ![Topology](/docs/images/books/topology.png "Topology")
-{.center}
 
 ## Prerequisites
 
@@ -83,7 +82,6 @@ perspective, it looks like everything's fine, but you know the application is
 returning errors.
 
 ![Failure](/docs/images/books/failure.png "Failure")
-{.center}
 
 ## Add Linkerd to the service
 

--- a/linkerd.io/content/2.18/tasks/distributed-tracing.md
+++ b/linkerd.io/content/2.18/tasks/distributed-tracing.md
@@ -21,7 +21,6 @@ In the case of emojivoto, once all these steps are complete there will be a
 topology that looks like:
 
 ![Topology](/docs/images/tracing/tracing-topology.svg "Topology")
-{.center}
 
 ## Prerequisites
 

--- a/linkerd.io/content/2.18/tasks/fault-injection.md
+++ b/linkerd.io/content/2.18/tasks/fault-injection.md
@@ -12,7 +12,6 @@ The [books demo](books/) is a great way to show off this behavior. The
 overall topology looks like:
 
 ![Topology](/docs/images/books/topology.png "Topology")
-{.center}
 
 In this guide, you will split some of the requests from `webapp` to `books`.
 Most requests will end up at the correct `books` destination, however some of

--- a/linkerd.io/content/2.18/tasks/flagger.md
+++ b/linkerd.io/content/2.18/tasks/flagger.md
@@ -70,7 +70,6 @@ as there needs to be some kind of active traffic to complete the operation.
 Together, these components have a topology that looks like:
 
 ![Topology](/docs/images/canary/simple-topology.svg "Topology")
-{.center}
 
 To add these components to your cluster and include them in the Linkerd
 [data plane](../reference/architecture/#data-plane), run:
@@ -213,7 +212,6 @@ podinfo-primary      ClusterIP   10.7.249.63   <none>        9898/TCP   23m
 At this point, the topology looks a little like:
 
 ![Initialized](/docs/images/canary/initialized.svg "Initialized")
-{.center}
 
 {{< note >}}
 This guide barely touches all the functionality provided by Flagger. Make sure
@@ -258,7 +256,6 @@ While an update is occurring, the resources and traffic will look like this at a
 high level:
 
 ![Ongoing](/docs/images/canary/ongoing.svg "Ongoing")
-{.center}
 
 After the update is complete, this picture will go back to looking just like the
 figure from the previous section.

--- a/linkerd.io/content/community/adopters/_index.md
+++ b/linkerd.io/content/community/adopters/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Linkerd 2.x Adopters
+title: Linkerd 2.x Adopters & Case Studies
 description: |-
   Here are some of the organizations we know are using Linkerd 2.x. If you're
   using Linkerd 2.x and aren't on this list, please submit a pull request!


### PR DESCRIPTION
This PR includes a few CSS fixes
- Improve blockquote style to stand out more from the surrounding content
  - I also made the border width of Alerts consistent with blockquotes
- Add missing whitespace below youtube videos
- Center images within docs and blog post content by default (remove `.center` markdown attribute)
  - This should not have any visual change, since all images that were more narrow than the content width had the `.center` markdown attribute. All other images fill the content container, so centering them will not have any effect.

To verify the blockquote and youtube changes, see this page:
**Before:** https://linkerd.io/2018/10/23/a-linkerd-2-0-deep-dive-unboxing-debugging-and-monitoring-kubernetes-services-on-azure/
**After:** https://deploy-preview-2021--linkerdio.netlify.app/2018/10/23/a-linkerd-2-0-deep-dive-unboxing-debugging-and-monitoring-kubernetes-services-on-azure/