### PR TITLE
Fix enterprise training link/redirect

### DIFF
--- a/linkerd.io/content/enterprise/_index.md
+++ b/linkerd.io/content/enterprise/_index.md
@@ -69,6 +69,6 @@ params:
             this self-paced course.
           image: images/linux-foundation.png
           button:
-            href: https://www.edx.org/course/introduction-to-service-mesh-with-linkerd
+            href: https://training.linuxfoundation.org/training/service-mesh-fundamentals-lfs243/
             text: Learn more
 ---


### PR DESCRIPTION
Subject
Fix enterprise training link/redirect

Problem
Users navigating from /enterprise end up at an archived/outdated LF course page, causing confusion.

Solution
- Remove stale Netlify redirect for /enterprise (if present) and point to the actual Enterprise page.
- Update the training link on the Enterprise page to a currently maintained edX listing.


Fixes #2025