### PR TITLE
docs(edge/multicluster): use edge Helm repo & chart; avoid mixing stable on edge page

### DIFF
--- a/linkerd.io/content/2-edge/tasks/installing-multicluster.md
+++ b/linkerd.io/content/2-edge/tasks/installing-multicluster.md
@@ -221,7 +221,7 @@ pipeline.
 First, let's add the Linkerd's Helm repository by running
 
 ```bash
-# To add the repo for Linkerd stable releases:
+# To add the repo for Linkerd edge releases:
 helm repo add linkerd https://helm.linkerd.io/edge
 ```
 


### PR DESCRIPTION
**Problem**  
The 2-edge “Installing Multi-cluster Components” guide referenced the **stable** Helm repo and chart, which is confusing on an **edge** page.

**Solution**  
- Add the **edge** Helm repo (`helm repo add linkerd-edge https://helm.linkerd.io/edge && helm repo update`).  
- Install from `linkerd-edge/linkerd-multicluster`.  
- Align the “additional access credentials” example to use the edge chart.

**Why**  
Keeps channel semantics consistent and avoids users pulling the wrong chart.
