### PR TITLE
Add reference to the linkerd=debug directive in the Proxy Log Level page

### DIFF
--- a/linkerd.io/content/2.10/reference/proxy-log-level.md
+++ b/linkerd.io/content/2.10/reference/proxy-log-level.md
@@ -36,4 +36,4 @@ module names, separated by `::`.
 
 A module name starts with a letter, and consists of alphanumeric characters and `_`.
 
-The proxy's default log level is set to `warn,linkerd2_proxy=info`.
+The proxy's default log level is set to `warn,linkerd2_proxy=info`. To increase the verbosity of the Linkerd runtime, add `linkerd=debug` to your directives (for example: `debug,linkerd=debug`).

--- a/linkerd.io/content/2.11/reference/proxy-log-level.md
+++ b/linkerd.io/content/2.11/reference/proxy-log-level.md
@@ -36,4 +36,4 @@ module names, separated by `::`.
 
 A module name starts with a letter, and consists of alphanumeric characters and `_`.
 
-The proxy's default log level is set to `warn,linkerd2_proxy=info`.
+The proxy's default log level is set to `warn,linkerd2_proxy=info`. To increase the verbosity of the Linkerd runtime, add `linkerd=debug` to your directives (for example: `debug,linkerd=debug`).

--- a/linkerd.io/content/2.12/reference/proxy-log-level.md
+++ b/linkerd.io/content/2.12/reference/proxy-log-level.md
@@ -36,4 +36,4 @@ module names, separated by `::`.
 
 A module name starts with a letter, and consists of alphanumeric characters and `_`.
 
-The proxy's default log level is set to `warn,linkerd2_proxy=info`.
+The proxy's default log level is set to `warn,linkerd2_proxy=info`. To increase the verbosity of the Linkerd runtime, add `linkerd=debug` to your directives (for example: `debug,linkerd=debug`).

--- a/linkerd.io/content/2.13/reference/proxy-log-level.md
+++ b/linkerd.io/content/2.13/reference/proxy-log-level.md
@@ -36,4 +36,4 @@ module names, separated by `::`.
 
 A module name starts with a letter, and consists of alphanumeric characters and `_`.
 
-The proxy's default log level is set to `warn,linkerd2_proxy=info`.
+The proxy's default log level is set to `warn,linkerd2_proxy=info`. To increase the verbosity of the Linkerd runtime, add `linkerd=debug` to your directives (for example: `debug,linkerd=debug`).

--- a/linkerd.io/content/2.14/reference/proxy-log-level.md
+++ b/linkerd.io/content/2.14/reference/proxy-log-level.md
@@ -36,4 +36,4 @@ module names, separated by `::`.
 
 A module name starts with a letter, and consists of alphanumeric characters and `_`.
 
-The proxy's default log level is set to `warn,linkerd2_proxy=info`.
+The proxy's default log level is set to `warn,linkerd2_proxy=info`. To increase the verbosity of the Linkerd runtime, add `linkerd=debug` to your directives (for example: `debug,linkerd=debug`).

--- a/linkerd.io/content/2.15/reference/proxy-log-level.md
+++ b/linkerd.io/content/2.15/reference/proxy-log-level.md
@@ -36,4 +36,4 @@ module names, separated by `::`.
 
 A module name starts with a letter, and consists of alphanumeric characters and `_`.
 
-The proxy's default log level is set to `warn,linkerd2_proxy=info`.
+The proxy's default log level is set to `warn,linkerd2_proxy=info`. To increase the verbosity of the Linkerd runtime, add `linkerd=debug` to your directives (for example: `debug,linkerd=debug`).

--- a/linkerd.io/content/2.16/reference/proxy-log-level.md
+++ b/linkerd.io/content/2.16/reference/proxy-log-level.md
@@ -36,4 +36,4 @@ module names, separated by `::`.
 
 A module name starts with a letter, and consists of alphanumeric characters and `_`.
 
-The proxy's default log level is set to `warn,linkerd2_proxy=info`.
+The proxy's default log level is set to `warn,linkerd2_proxy=info`. To increase the verbosity of the Linkerd runtime, add `linkerd=debug` to your directives (for example: `debug,linkerd=debug`).

--- a/linkerd.io/content/2.17/reference/proxy-log-level.md
+++ b/linkerd.io/content/2.17/reference/proxy-log-level.md
@@ -36,4 +36,4 @@ module names, separated by `::`.
 
 A module name starts with a letter, and consists of alphanumeric characters and `_`.
 
-The proxy's default log level is set to `warn,linkerd2_proxy=info`.
+The proxy's default log level is set to `warn,linkerd2_proxy=info`. To increase the verbosity of the Linkerd runtime, add `linkerd=debug` to your directives (for example: `debug,linkerd=debug`).

--- a/linkerd.io/content/2.18/reference/proxy-log-level.md
+++ b/linkerd.io/content/2.18/reference/proxy-log-level.md
@@ -36,4 +36,4 @@ module names, separated by `::`.
 
 A module name starts with a letter, and consists of alphanumeric characters and `_`.
 
-The proxy's default log level is set to `warn,linkerd2_proxy=info`.
+The proxy's default log level is set to `warn,linkerd2_proxy=info`. To increase the verbosity of the Linkerd runtime, add `linkerd=debug` to your directives (for example: `debug,linkerd=debug`).


### PR DESCRIPTION
The Proxy Log Level page only references the `linkerd2_proxy` directive, but it is the `linkerd` directive that provides a lot of information about the overall behavior of the proxy.