### PR TITLE
Update link to authzpolicy-grafana.yaml

### DIFF
--- a/linkerd.io/content/2-edge/tasks/grafana.md
+++ b/linkerd.io/content/2-edge/tasks/grafana.md
@@ -41,7 +41,7 @@ The access to Linkerd Viz' Prometheus instance is restricted through the
 `prometheus-admin` AuthorizationPolicy, granting access only to the
 `metrics-api` ServiceAccount. In order to also grant access to Grafana, you need
 to add an AuthorizationPolicy pointing to its ServiceAccount. You can apply
-[authzpolicy-grafana.yaml](https://github.com/linkerd/linkerd2/blob/release/stable-2.13/grafana/authzpolicy-grafana.yaml)
+[authzpolicy-grafana.yaml](https://github.com/linkerd/linkerd2/blob/main/grafana/authzpolicy-grafana.yaml)
 which grants permission for the `grafana` ServiceAccount.
 {{< /note >}}
 

--- a/linkerd.io/content/2.13/tasks/grafana.md
+++ b/linkerd.io/content/2.13/tasks/grafana.md
@@ -41,7 +41,7 @@ The access to Linkerd Viz' Prometheus instance is restricted through the
 `prometheus-admin` AuthorizationPolicy, granting access only to the
 `metrics-api` ServiceAccount. In order to also grant access to Grafana, you need
 to add an AuthorizationPolicy pointing to its ServiceAccount. You can apply
-[authzpolicy-grafana.yaml](https://github.com/linkerd/linkerd2/blob/release/stable-2.13/grafana/authzpolicy-grafana.yaml)
+[authzpolicy-grafana.yaml](https://github.com/linkerd/linkerd2/blob/main/grafana/authzpolicy-grafana.yaml)
 which grants permission for the `grafana` ServiceAccount.
 {{< /note >}}
 

--- a/linkerd.io/content/2.14/tasks/grafana.md
+++ b/linkerd.io/content/2.14/tasks/grafana.md
@@ -41,7 +41,7 @@ The access to Linkerd Viz' Prometheus instance is restricted through the
 `prometheus-admin` AuthorizationPolicy, granting access only to the
 `metrics-api` ServiceAccount. In order to also grant access to Grafana, you need
 to add an AuthorizationPolicy pointing to its ServiceAccount. You can apply
-[authzpolicy-grafana.yaml](https://github.com/linkerd/linkerd2/blob/release/stable-2.13/grafana/authzpolicy-grafana.yaml)
+[authzpolicy-grafana.yaml](https://github.com/linkerd/linkerd2/blob/main/grafana/authzpolicy-grafana.yaml)
 which grants permission for the `grafana` ServiceAccount.
 {{< /note >}}
 

--- a/linkerd.io/content/2.15/tasks/grafana.md
+++ b/linkerd.io/content/2.15/tasks/grafana.md
@@ -41,7 +41,7 @@ The access to Linkerd Viz' Prometheus instance is restricted through the
 `prometheus-admin` AuthorizationPolicy, granting access only to the
 `metrics-api` ServiceAccount. In order to also grant access to Grafana, you need
 to add an AuthorizationPolicy pointing to its ServiceAccount. You can apply
-[authzpolicy-grafana.yaml](https://github.com/linkerd/linkerd2/blob/release/stable-2.13/grafana/authzpolicy-grafana.yaml)
+[authzpolicy-grafana.yaml](https://github.com/linkerd/linkerd2/blob/main/grafana/authzpolicy-grafana.yaml)
 which grants permission for the `grafana` ServiceAccount.
 {{< /note >}}
 

--- a/linkerd.io/content/2.16/tasks/grafana.md
+++ b/linkerd.io/content/2.16/tasks/grafana.md
@@ -41,7 +41,7 @@ The access to Linkerd Viz' Prometheus instance is restricted through the
 `prometheus-admin` AuthorizationPolicy, granting access only to the
 `metrics-api` ServiceAccount. In order to also grant access to Grafana, you need
 to add an AuthorizationPolicy pointing to its ServiceAccount. You can apply
-[authzpolicy-grafana.yaml](https://github.com/linkerd/linkerd2/blob/release/stable-2.13/grafana/authzpolicy-grafana.yaml)
+[authzpolicy-grafana.yaml](https://github.com/linkerd/linkerd2/blob/main/grafana/authzpolicy-grafana.yaml)
 which grants permission for the `grafana` ServiceAccount.
 {{< /note >}}
 

--- a/linkerd.io/content/2.17/tasks/grafana.md
+++ b/linkerd.io/content/2.17/tasks/grafana.md
@@ -41,7 +41,7 @@ The access to Linkerd Viz' Prometheus instance is restricted through the
 `prometheus-admin` AuthorizationPolicy, granting access only to the
 `metrics-api` ServiceAccount. In order to also grant access to Grafana, you need
 to add an AuthorizationPolicy pointing to its ServiceAccount. You can apply
-[authzpolicy-grafana.yaml](https://github.com/linkerd/linkerd2/blob/release/stable-2.13/grafana/authzpolicy-grafana.yaml)
+[authzpolicy-grafana.yaml](https://github.com/linkerd/linkerd2/blob/main/grafana/authzpolicy-grafana.yaml)
 which grants permission for the `grafana` ServiceAccount.
 {{< /note >}}
 

--- a/linkerd.io/content/2.18/tasks/grafana.md
+++ b/linkerd.io/content/2.18/tasks/grafana.md
@@ -41,7 +41,7 @@ The access to Linkerd Viz' Prometheus instance is restricted through the
 `prometheus-admin` AuthorizationPolicy, granting access only to the
 `metrics-api` ServiceAccount. In order to also grant access to Grafana, you need
 to add an AuthorizationPolicy pointing to its ServiceAccount. You can apply
-[authzpolicy-grafana.yaml](https://github.com/linkerd/linkerd2/blob/release/stable-2.13/grafana/authzpolicy-grafana.yaml)
+[authzpolicy-grafana.yaml](https://github.com/linkerd/linkerd2/blob/main/grafana/authzpolicy-grafana.yaml)
 which grants permission for the `grafana` ServiceAccount.
 {{< /note >}}
 


### PR DESCRIPTION
Currently on the [Grafana](https://linkerd.io/2.18/tasks/grafana/#install-grafana) page, we link to the `2.13` release when referencing the `authzpolicy-grafana.yaml` file. With this PR, the link now points to `main`.

**Preview:**
https://deploy-preview-2033--linkerdio.netlify.app/2.18/tasks/grafana/#install-grafana
