### PR TITLE
docs(non-k8s): update proxy binary instructions

### DIFF
--- a/linkerd.io/content/2-edge/tasks/adding-non-kubernetes-workloads.md
+++ b/linkerd.io/content/2-edge/tasks/adding-non-kubernetes-workloads.md
@@ -234,7 +234,7 @@ When in a foreign environment, we do not need this functionality, so we can
 simply get the proxy binary:
 
 ```bash
-LINKERD_VERSION={{< latest-edge-version >}}
+LINKERD_VERSION={{< edge-version >}}
 mkdir /opt/linkerd-proxy && cd /opt/linkerd-proxy
 id=$(docker create cr.l5d.io/linkerd/proxy:$LINKERD_VERSION)
 docker cp $id:/usr/lib/linkerd/linkerd2-proxy ./linkerd-proxy

--- a/linkerd.io/content/2.15/tasks/adding-non-kubernetes-workloads.md
+++ b/linkerd.io/content/2.15/tasks/adding-non-kubernetes-workloads.md
@@ -234,7 +234,7 @@ When in a foreign environment, we do not need this functionality, so we can
 simply get the proxy binary:
 
 ```bash
-LINKERD_VERSION={{< edge-version "2.15" >}}
+LINKERD_VERSION={{< edge-version >}}
 mkdir /opt/linkerd-proxy && cd /opt/linkerd-proxy
 id=$(docker create cr.l5d.io/linkerd/proxy:$LINKERD_VERSION)
 docker cp $id:/usr/lib/linkerd/linkerd2-proxy ./linkerd-proxy

--- a/linkerd.io/content/2.16/tasks/adding-non-kubernetes-workloads.md
+++ b/linkerd.io/content/2.16/tasks/adding-non-kubernetes-workloads.md
@@ -234,7 +234,7 @@ When in a foreign environment, we do not need this functionality, so we can
 simply get the proxy binary:
 
 ```bash
-LINKERD_VERSION={{< edge-version "2.16" >}}
+LINKERD_VERSION={{< edge-version >}}
 mkdir /opt/linkerd-proxy && cd /opt/linkerd-proxy
 id=$(docker create cr.l5d.io/linkerd/proxy:$LINKERD_VERSION)
 docker cp $id:/usr/lib/linkerd/linkerd2-proxy ./linkerd-proxy

--- a/linkerd.io/content/2.17/tasks/adding-non-kubernetes-workloads.md
+++ b/linkerd.io/content/2.17/tasks/adding-non-kubernetes-workloads.md
@@ -234,7 +234,7 @@ When in a foreign environment, we do not need this functionality, so we can
 simply get the proxy binary:
 
 ```bash
-LINKERD_VERSION={{< edge-version "2.17" >}}
+LINKERD_VERSION={{< edge-version >}}
 mkdir /opt/linkerd-proxy && cd /opt/linkerd-proxy
 id=$(docker create cr.l5d.io/linkerd/proxy:$LINKERD_VERSION)
 docker cp $id:/usr/lib/linkerd/linkerd2-proxy ./linkerd-proxy

--- a/linkerd.io/content/2.18/tasks/adding-non-kubernetes-workloads.md
+++ b/linkerd.io/content/2.18/tasks/adding-non-kubernetes-workloads.md
@@ -234,7 +234,7 @@ When in a foreign environment, we do not need this functionality, so we can
 simply get the proxy binary:
 
 ```bash
-LINKERD_VERSION={{< edge-version  "2.18" >}}
+LINKERD_VERSION={{< edge-version >}}
 mkdir /opt/linkerd-proxy && cd /opt/linkerd-proxy
 id=$(docker create cr.l5d.io/linkerd/proxy:$LINKERD_VERSION)
 docker cp $id:/usr/lib/linkerd/linkerd2-proxy ./linkerd-proxy


### PR DESCRIPTION
### Problem
The documentation for adding non-Kubernetes workloads had outdated and incorrect examples:
- The `LINKERD_VERSION` variable was set to `enterprise-2.15.0`, which is no longer valid in OSS docs.
- The command to change into the created directory used `cs` instead of `cd`.

### Solution
- Updated `LINKERD_VERSION` values:
  - 2.15 ... ` 2-edge → `` `{{< edge-version >}}` ``
- Corrected the typo: `cs` → `cd` in the `mkdir` command.

### Validation
- Verified the referenced edge proxy versions exist on Artifact Hub.  
- Checked that the `cd` command works correctly in the snippet.  
- Built the site locally with `hugo server` to ensure docs compile successfully.

### Fixes
Fixes #2037
