### PR TITLE
docs(getting-started): add LINKERD2_VERSION to install examples

### DIFF
--- a/linkerd.io/content/2.10/getting-started/_index.md
+++ b/linkerd.io/content/2.10/getting-started/_index.md
@@ -57,7 +57,7 @@ allow you to interact with your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
-LINKERD2_VERSION=stable-2.10.2
+export LINKERD2_VERSION=stable-2.10.2
 curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 

--- a/linkerd.io/content/2.10/getting-started/_index.md
+++ b/linkerd.io/content/2.10/getting-started/_index.md
@@ -57,6 +57,7 @@ allow you to interact with your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
+LINKERD2_VERSION=stable-2.10.2
 curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 

--- a/linkerd.io/content/2.11/getting-started/_index.md
+++ b/linkerd.io/content/2.11/getting-started/_index.md
@@ -59,7 +59,7 @@ your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
-LINKERD2_VERSION=stable-2.11.5
+export LINKERD2_VERSION=stable-2.11.5
 curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 

--- a/linkerd.io/content/2.11/getting-started/_index.md
+++ b/linkerd.io/content/2.11/getting-started/_index.md
@@ -59,6 +59,7 @@ your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
+LINKERD2_VERSION=stable-2.11.5
 curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 

--- a/linkerd.io/content/2.12/getting-started/_index.md
+++ b/linkerd.io/content/2.12/getting-started/_index.md
@@ -59,7 +59,7 @@ your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
-LINKERD2_VERSION=stable-2.12.6
+export LINKERD2_VERSION=stable-2.12.6
 curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 

--- a/linkerd.io/content/2.12/getting-started/_index.md
+++ b/linkerd.io/content/2.12/getting-started/_index.md
@@ -59,6 +59,7 @@ your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
+LINKERD2_VERSION=stable-2.12.6
 curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 

--- a/linkerd.io/content/2.13/getting-started/_index.md
+++ b/linkerd.io/content/2.13/getting-started/_index.md
@@ -59,7 +59,7 @@ your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
-LINKERD2_VERSION=stable-2.13.5
+export LINKERD2_VERSION=stable-2.13.5
 curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 

--- a/linkerd.io/content/2.13/getting-started/_index.md
+++ b/linkerd.io/content/2.13/getting-started/_index.md
@@ -59,6 +59,7 @@ your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
+LINKERD2_VERSION=stable-2.13.5
 curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 

--- a/linkerd.io/content/2.14/getting-started/_index.md
+++ b/linkerd.io/content/2.14/getting-started/_index.md
@@ -59,6 +59,7 @@ your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
+LINKERD2_VERSION=stable-2.14.10
 curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 

--- a/linkerd.io/content/2.14/getting-started/_index.md
+++ b/linkerd.io/content/2.14/getting-started/_index.md
@@ -59,7 +59,7 @@ your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
-LINKERD2_VERSION=stable-2.14.10
+export LINKERD2_VERSION=stable-2.14.10
 curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 ```
 

--- a/linkerd.io/content/2.15/getting-started/_index.md
+++ b/linkerd.io/content/2.15/getting-started/_index.md
@@ -56,6 +56,7 @@ your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
+LINKERD2_VERSION=edge-24.2.4
 curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install-edge | sh
 ```
 

--- a/linkerd.io/content/2.15/getting-started/_index.md
+++ b/linkerd.io/content/2.15/getting-started/_index.md
@@ -56,7 +56,7 @@ your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
-LINKERD2_VERSION=edge-24.2.4
+export LINKERD2_VERSION=edge-24.2.4
 curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install-edge | sh
 ```
 

--- a/linkerd.io/content/2.16/getting-started/_index.md
+++ b/linkerd.io/content/2.16/getting-started/_index.md
@@ -56,7 +56,7 @@ your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
-LINKERD2_VERSION=edge-24.8.2
+export LINKERD2_VERSION=edge-24.8.2
 curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install-edge | sh
 ```
 

--- a/linkerd.io/content/2.16/getting-started/_index.md
+++ b/linkerd.io/content/2.16/getting-started/_index.md
@@ -56,6 +56,7 @@ your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
+LINKERD2_VERSION=edge-24.8.2
 curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install-edge | sh
 ```
 

--- a/linkerd.io/content/2.17/getting-started/_index.md
+++ b/linkerd.io/content/2.17/getting-started/_index.md
@@ -56,7 +56,7 @@ your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
-LINKERD2_VERSION=edge-24.11.8
+export LINKERD2_VERSION=edge-24.11.8
 curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install-edge | sh
 ```
 

--- a/linkerd.io/content/2.17/getting-started/_index.md
+++ b/linkerd.io/content/2.17/getting-started/_index.md
@@ -56,6 +56,7 @@ your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
+LINKERD2_VERSION=edge-24.11.8
 curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install-edge | sh
 ```
 

--- a/linkerd.io/content/2.18/getting-started/_index.md
+++ b/linkerd.io/content/2.18/getting-started/_index.md
@@ -56,7 +56,7 @@ your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
-LINKERD2_VERSION=edge-25.4.4
+export LINKERD2_VERSION=edge-25.4.4
 curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install-edge | sh
 ```
 

--- a/linkerd.io/content/2.18/getting-started/_index.md
+++ b/linkerd.io/content/2.18/getting-started/_index.md
@@ -56,6 +56,7 @@ your Linkerd deployment.
 To install the CLI manually, run:
 
 ```bash
+LINKERD2_VERSION=edge-25.4.4
 curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install-edge | sh
 ```
 


### PR DESCRIPTION
### Problem
The getting-started installation snippets for versions 2.10 through 2.18
did not explicitly define the `LINKERD2_VERSION` variable.  
Without this, users might run the install script and end up pulling a
different CLI version than expected, which could cause inconsistencies
with the control plane.

### Solution
- Added `LINKERD2_VERSION` to each install snippet with the correct
  stable or edge version:
  - 2.10 → stable-2.10.2  
  - 2.11 → stable-2.11.5  
  - 2.12 → stable-2.12.6  
  - 2.13 → stable-2.13.5  
  - 2.14 → stable-2.14.10  
  - 2.15 → edge-24.2.4  
  - 2.16 → edge-24.8.2  
  - 2.17 → edge-24.11.8  
  - 2.18 → edge-25.4.4

### Validation
- Verified that the CLI install script (`install` and `install-edge`)
- Built the docs locally with `hugo server` to ensure pages compile.

#### Validation stable-*
```bash

export LINKERD2_VERSION=stable-2.14.10
curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh

Validating checksum...
Checksum valid.

Linkerd stable-2.14.10 was already downloaded; making it the default 🎉
```
#### Validation edge-*
```bash

 export LINKERD2_VERSION=edge-25.4.4
curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install-edge | sh

Validating checksum...
Checksum valid.

Linkerd edge-25.4.4 was already downloaded; making it the default 🎉
```



