### PR TITLE
chore(install-ege): remove checksum validation from install script

### DIFF
--- a/run.linkerd.io/public/install-edge
+++ b/run.linkerd.io/public/install-edge
@@ -32,29 +32,6 @@ happyexit() {
   exit 0
 }
 
-validate_checksum() {
-  filename=$1
-  SHA=$(curl --proto '=https' --tlsv1.2 -sSfL "${url}.sha256")
-  echo ""
-  echo "Validating checksum..."
-
-  case $checksumbin in
-    *openssl)
-      checksum=$($checksumbin dgst -sha256 "${filename}" | sed -e 's/^.* //')
-      ;;
-    *shasum)
-      checksum=$($checksumbin -a256 "${filename}" | sed -e 's/ .*$//')
-      ;;
-  esac
-
-  if [ "$checksum" != "$SHA" ]; then
-    echo "Checksum validation failed." >&2
-    return 1
-  fi
-  echo "Checksum valid."
-  return 0
-}
-
 OS=$(uname -s)
 arch=$(uname -m)
 cli_arch=""
@@ -106,12 +83,6 @@ case $OS in
 esac
 OS=$(echo "$OS" | tr '[:upper:]' '[:lower:]')
 
-checksumbin=$(command -v openssl) || checksumbin=$(command -v shasum) || {
-  echo "Failed to find checksum binary. Please install openssl or shasum."
-  exit 1
-}
-
-
 tmpdir=$(mktemp -d /tmp/linkerd2.XXXXXX)
 srcfile="linkerd2-cli-${LINKERD2_VERSION}-${OS}"
 if [ -n "${cli_arch}" ]; then
@@ -121,17 +92,15 @@ dstfile="${INSTALLROOT}/bin/linkerd-${LINKERD2_VERSION}"
 url="https://github.com/linkerd/linkerd2/releases/download/${LINKERD2_VERSION}/${srcfile}"
 
 if [ -e "${dstfile}" ]; then
-  if validate_checksum "${dstfile}"; then
-    echo ""
-    echo "Linkerd ${LINKERD2_VERSION} was already downloaded; making it the default 🎉"
-    echo ""
-    echo "To force re-downloading, delete '${dstfile}' then run me again."
-    (
-      rm -f "${INSTALLROOT}/bin/linkerd"
-      ln -s "${dstfile}" "${INSTALLROOT}/bin/linkerd"
-    )
-    happyexit
-  fi
+  echo ""
+  echo "Linkerd ${LINKERD2_VERSION} was already downloaded; making it the default 🎉"
+  echo ""
+  echo "To force re-downloading, delete '${dstfile}' then run me again."
+  (
+    rm -f "${INSTALLROOT}/bin/linkerd"
+    ln -s "${dstfile}" "${INSTALLROOT}/bin/linkerd"
+  )
+  happyexit
 fi
 
 (
@@ -140,10 +109,6 @@ fi
   echo "Downloading ${srcfile}..."
   curl --proto '=https' --tlsv1.2 -fLO "${url}"
   echo "Download complete!"
-
-  if ! validate_checksum "${srcfile}"; then
-    exit 1
-  fi
   echo ""
 )
 


### PR DESCRIPTION
https://github.com/linkerd/linkerd2/pull/14511 removed sha256 digests from cli builds. This updates the install script to skip sha validation