### PR TITLE
document control plane port names

### DIFF
--- a/linkerd.io/content/2-edge/reference/controlplane-port-names.md
+++ b/linkerd.io/content/2-edge/reference/controlplane-port-names.md
@@ -1,0 +1,26 @@
+---
+title: Control Plane Port Names
+description: Reference guide to Linkerd control plane port names.
+---
+
+Linkerd's control plane components expose various ports for communication and
+administration. Each container port is assigned a unique name to enable precise
+references from Services, probes, and monitoring configurations.
+
+## Control Plane Port Names
+
+The following table lists control plane container port names:
+
+{{< keyval >}}
+| Component | Port Name | Protocol |
+|-----------|-----------|----------|
+| destination | `dest-grpc` | gRPC |
+| destination | `dest-admin` | HTTP |
+| sp-validator | `spval-admin` | HTTP |
+| policy-controller | `policy-grpc` | gRPC |
+| policy-controller | `policy-admin` | HTTP |
+| identity | `ident-grpc` | gRPC |
+| identity | `ident-admin` | HTTP |
+| proxy-injector | `injector-admin` | HTTP |
+| linkerd2-cni | `repair-admin` | HTTP |
+{{< /keyval >}}


### PR DESCRIPTION
provides a reference document of control plane port names for users that need to reference them.