### PR TITLE
feat(proxy-metrics): document outbound policy routing metrics

### DIFF
--- a/linkerd.io/content/2-edge/reference/proxy-metrics.md
+++ b/linkerd.io/content/2-edge/reference/proxy-metrics.md
@@ -238,7 +238,9 @@ layer.
 * `inbound_tcp_authz_deny_total`: A counter of the total number of TCP
   connections that were denied
 
+<!-- markdownlint-disable MD024 -->
 ### Labels
+<!-- markdownlint-enable MD024 -->
 
 Each of these metrics has the following labels:
 
@@ -316,7 +318,9 @@ gRPC responses from a particular backend, labeled by the `grpc-status` code.
 measuring the sizes of `DATA` frames in gRPC response bodies from a particular
 backend.
 
+<!-- markdownlint-disable MD024 -->
 ### Labels
+<!-- markdownlint-enable MD024 -->
 
 Each of these metrics has the following common labels, which describe the
 Kubernetes resources to which traffic is routed by the proxy:


### PR DESCRIPTION
the documentation of our proxy metrics has not kept pace with all of the
exciting telemetry that has been introduced since
https://github.com/linkerd/website/pull/1599 documented the state of our
authorization policy metrics.

this commit reworks the documentation to exhaustively document the
families of metrics exported by the proxy. this commit does not
introduce mention of the _inbound_ metrics that have been added, but
does rename this section to "_Endpoint Metrics_" in order to be
compatible with the future addition of `inbound_http_route_*`,
`inbound_http_route_backend_*`, `inbound_grpc_route*`, and
`inbound_grpc_route_backend_*` metrics.

see:
* https://github.com/linkerd/linkerd2-proxy/pull/2377
* https://github.com/linkerd/linkerd2-proxy/pull/2380
* https://github.com/linkerd/linkerd2-proxy/pull/3086
* https://github.com/linkerd/linkerd2-proxy/pull/3308
* https://github.com/linkerd/linkerd2-proxy/pull/3334

Signed-off-by: katelyn martin <kate@buoyant.io>
