### PR TITLE
Fix broken tap-rbac redirect

### DIFF
--- a/linkerd.io/static/tap-rbac/index.html
+++ b/linkerd.io/static/tap-rbac/index.html
@@ -5,12 +5,12 @@
     <title>Linkerd Redirection</title>
     <!-- This redirect is referenced in the linkerd2 CLI -->
     <meta name="robots" content="noindex">
-    <meta http-equiv="refresh" content="0; url=https://linkerd.io/2/tasks/securing-your-cluster/#tap">
+    <meta http-equiv="refresh" content="0; url=https://linkerd.io/2/tasks/securing-linkerd-tap/">
     <script>
-      window.location.href = window.location.origin + "/2/tasks/securing-your-cluster/#tap";
+      window.location.href = window.location.origin + "/2/tasks/securing-linkerd-tap/";
     </script>
   </head>
   <body>
-    If you are not redirected automatically, follow this <a href="https://linkerd.io/2/tasks/securing-your-cluster/#tap">link</a>.
+    If you are not redirected automatically, follow this <a href="https://linkerd.io/2/tasks/securing-linkerd-tap/">link</a>.
   </body>
 </html>


### PR DESCRIPTION
Fix broken redirect for linkerd.io/tap-rbac.

Fixes: #2083

## Note to reviewers

The redirect on this branch preview will not work, as the `/2/` redirect only works on prod.

When visiting the redirect:
https://deploy-preview-2084--linkerdio.netlify.app/tap-rbac

It should redirect to:
https://deploy-preview-2084--linkerdio.netlify.app/2/tasks/securing-linkerd-tap/

To test, just manually change the `/2/` to `/2.19/`.