### PR TITLE
Update warning regarding certificate private key rotation

### DIFF
--- a/linkerd.io/content/2-edge/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2-edge/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -243,12 +243,19 @@ EOF
 
 {{< warning >}}
 
-If you do not set `rotationPolicy: Always` in the Certificate's `privateKey`
-section, cert-manager **will not** actually rotate the trust anchor: instead, it
-will update the validity timestamps but **not** generate a new private key.
-**This is definitely not as secure as rotating the private key**; we recommend
-always setting `rotationPolicy: Always` for any certificate that cert-manager is
-managing.
+The default value of the `rotationPolicy` in the Certificate's `privateKey`
+section is dependent on your version of cert-manager. In version 1.17 and
+below, the default value was `Never`. With this configuration, cert-manager
+**will not** actually rotate the trust anchor: instead, it will update the
+validity timestamps but **not** generate a new private key.
+**This is definitely not as secure as rotating the private key**.
+
+If you are upgrading cert-manager from version 1.17 or below to version 1.18 or
+above, be aware that this new default will change the `rotationPolicy` if you
+are not explicitly setting it in your Certificate resource manifest.
+
+To avoid ambiguity, we recommend always setting `rotationPolicy: Always` for
+any certificate that cert-manager is managing.
 
 {{< /warning >}}
 
@@ -353,12 +360,19 @@ EOF
 
 {{< warning >}}
 
-If you do not set `rotationPolicy: Always` in the Certificate's `privateKey`
-section, cert-manager **will not** actually rotate the trust anchor: instead, it
-will update the validity timestamps but **not** generate a new private key.
-**This is definitely not as secure as rotating the private key**; we recommend
-always setting `rotationPolicy: Always` for any certificate that cert-manager is
-managing.
+The default value of the `rotationPolicy` in the Certificate's `privateKey`
+section is dependent on your version of cert-manager. In version 1.17 and
+below, the default value was `Never`. With this configuration, cert-manager
+**will not** actually rotate the trust anchor: instead, it will update the
+validity timestamps but **not** generate a new private key.
+**This is definitely not as secure as rotating the private key**.
+
+If you are upgrading cert-manager from version 1.17 or below to version 1.18 or
+above, be aware that this new default will change the `rotationPolicy` if you
+are not explicitly setting it in your Certificate resource manifest.
+
+To avoid ambiguity, we recommend always setting `rotationPolicy: Always` for
+any certificate that cert-manager is managing.
 
 {{< /warning >}}
 

--- a/linkerd.io/content/2.14/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.14/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -243,12 +243,19 @@ EOF
 
 {{< warning >}}
 
-If you do not set `rotationPolicy: Always` in the Certificate's `privateKey`
-section, cert-manager **will not** actually rotate the trust anchor: instead, it
-will update the validity timestamps but **not** generate a new private key.
-**This is definitely not as secure as rotating the private key**; we recommend
-always setting `rotationPolicy: Always` for any certificate that cert-manager is
-managing.
+The default value of the `rotationPolicy` in the Certificate's `privateKey`
+section is dependent on your version of cert-manager. In version 1.17 and
+below, the default value was `Never`. With this configuration, cert-manager
+**will not** actually rotate the trust anchor: instead, it will update the
+validity timestamps but **not** generate a new private key.
+**This is definitely not as secure as rotating the private key**.
+
+If you are upgrading cert-manager from version 1.17 or below to version 1.18 or
+above, be aware that this new default will change the `rotationPolicy` if you
+are not explicitly setting it in your Certificate resource manifest.
+
+To avoid ambiguity, we recommend always setting `rotationPolicy: Always` for
+any certificate that cert-manager is managing.
 
 {{< /warning >}}
 
@@ -353,12 +360,19 @@ EOF
 
 {{< warning >}}
 
-If you do not set `rotationPolicy: Always` in the Certificate's `privateKey`
-section, cert-manager **will not** actually rotate the trust anchor: instead, it
-will update the validity timestamps but **not** generate a new private key.
-**This is definitely not as secure as rotating the private key**; we recommend
-always setting `rotationPolicy: Always` for any certificate that cert-manager is
-managing.
+The default value of the `rotationPolicy` in the Certificate's `privateKey`
+section is dependent on your version of cert-manager. In version 1.17 and
+below, the default value was `Never`. With this configuration, cert-manager
+**will not** actually rotate the trust anchor: instead, it will update the
+validity timestamps but **not** generate a new private key.
+**This is definitely not as secure as rotating the private key**.
+
+If you are upgrading cert-manager from version 1.17 or below to version 1.18 or
+above, be aware that this new default will change the `rotationPolicy` if you
+are not explicitly setting it in your Certificate resource manifest.
+
+To avoid ambiguity, we recommend always setting `rotationPolicy: Always` for
+any certificate that cert-manager is managing.
 
 {{< /warning >}}
 

--- a/linkerd.io/content/2.15/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.15/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -243,12 +243,19 @@ EOF
 
 {{< warning >}}
 
-If you do not set `rotationPolicy: Always` in the Certificate's `privateKey`
-section, cert-manager **will not** actually rotate the trust anchor: instead, it
-will update the validity timestamps but **not** generate a new private key.
-**This is definitely not as secure as rotating the private key**; we recommend
-always setting `rotationPolicy: Always` for any certificate that cert-manager is
-managing.
+The default value of the `rotationPolicy` in the Certificate's `privateKey`
+section is dependent on your version of cert-manager. In version 1.17 and
+below, the default value was `Never`. With this configuration, cert-manager
+**will not** actually rotate the trust anchor: instead, it will update the
+validity timestamps but **not** generate a new private key.
+**This is definitely not as secure as rotating the private key**.
+
+If you are upgrading cert-manager from version 1.17 or below to version 1.18 or
+above, be aware that this new default will change the `rotationPolicy` if you
+are not explicitly setting it in your Certificate resource manifest.
+
+To avoid ambiguity, we recommend always setting `rotationPolicy: Always` for
+any certificate that cert-manager is managing.
 
 {{< /warning >}}
 
@@ -353,12 +360,19 @@ EOF
 
 {{< warning >}}
 
-If you do not set `rotationPolicy: Always` in the Certificate's `privateKey`
-section, cert-manager **will not** actually rotate the trust anchor: instead, it
-will update the validity timestamps but **not** generate a new private key.
-**This is definitely not as secure as rotating the private key**; we recommend
-always setting `rotationPolicy: Always` for any certificate that cert-manager is
-managing.
+The default value of the `rotationPolicy` in the Certificate's `privateKey`
+section is dependent on your version of cert-manager. In version 1.17 and
+below, the default value was `Never`. With this configuration, cert-manager
+**will not** actually rotate the trust anchor: instead, it will update the
+validity timestamps but **not** generate a new private key.
+**This is definitely not as secure as rotating the private key**.
+
+If you are upgrading cert-manager from version 1.17 or below to version 1.18 or
+above, be aware that this new default will change the `rotationPolicy` if you
+are not explicitly setting it in your Certificate resource manifest.
+
+To avoid ambiguity, we recommend always setting `rotationPolicy: Always` for
+any certificate that cert-manager is managing.
 
 {{< /warning >}}
 

--- a/linkerd.io/content/2.16/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.16/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -243,12 +243,19 @@ EOF
 
 {{< warning >}}
 
-If you do not set `rotationPolicy: Always` in the Certificate's `privateKey`
-section, cert-manager **will not** actually rotate the trust anchor: instead, it
-will update the validity timestamps but **not** generate a new private key.
-**This is definitely not as secure as rotating the private key**; we recommend
-always setting `rotationPolicy: Always` for any certificate that cert-manager is
-managing.
+The default value of the `rotationPolicy` in the Certificate's `privateKey`
+section is dependent on your version of cert-manager. In version 1.17 and
+below, the default value was `Never`. With this configuration, cert-manager
+**will not** actually rotate the trust anchor: instead, it will update the
+validity timestamps but **not** generate a new private key.
+**This is definitely not as secure as rotating the private key**.
+
+If you are upgrading cert-manager from version 1.17 or below to version 1.18 or
+above, be aware that this new default will change the `rotationPolicy` if you
+are not explicitly setting it in your Certificate resource manifest.
+
+To avoid ambiguity, we recommend always setting `rotationPolicy: Always` for
+any certificate that cert-manager is managing.
 
 {{< /warning >}}
 
@@ -353,12 +360,19 @@ EOF
 
 {{< warning >}}
 
-If you do not set `rotationPolicy: Always` in the Certificate's `privateKey`
-section, cert-manager **will not** actually rotate the trust anchor: instead, it
-will update the validity timestamps but **not** generate a new private key.
-**This is definitely not as secure as rotating the private key**; we recommend
-always setting `rotationPolicy: Always` for any certificate that cert-manager is
-managing.
+The default value of the `rotationPolicy` in the Certificate's `privateKey`
+section is dependent on your version of cert-manager. In version 1.17 and
+below, the default value was `Never`. With this configuration, cert-manager
+**will not** actually rotate the trust anchor: instead, it will update the
+validity timestamps but **not** generate a new private key.
+**This is definitely not as secure as rotating the private key**.
+
+If you are upgrading cert-manager from version 1.17 or below to version 1.18 or
+above, be aware that this new default will change the `rotationPolicy` if you
+are not explicitly setting it in your Certificate resource manifest.
+
+To avoid ambiguity, we recommend always setting `rotationPolicy: Always` for
+any certificate that cert-manager is managing.
 
 {{< /warning >}}
 

--- a/linkerd.io/content/2.17/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.17/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -243,12 +243,19 @@ EOF
 
 {{< warning >}}
 
-If you do not set `rotationPolicy: Always` in the Certificate's `privateKey`
-section, cert-manager **will not** actually rotate the trust anchor: instead, it
-will update the validity timestamps but **not** generate a new private key.
-**This is definitely not as secure as rotating the private key**; we recommend
-always setting `rotationPolicy: Always` for any certificate that cert-manager is
-managing.
+The default value of the `rotationPolicy` in the Certificate's `privateKey`
+section is dependent on your version of cert-manager. In version 1.17 and
+below, the default value was `Never`. With this configuration, cert-manager
+**will not** actually rotate the trust anchor: instead, it will update the
+validity timestamps but **not** generate a new private key.
+**This is definitely not as secure as rotating the private key**.
+
+If you are upgrading cert-manager from version 1.17 or below to version 1.18 or
+above, be aware that this new default will change the `rotationPolicy` if you
+are not explicitly setting it in your Certificate resource manifest.
+
+To avoid ambiguity, we recommend always setting `rotationPolicy: Always` for
+any certificate that cert-manager is managing.
 
 {{< /warning >}}
 
@@ -353,12 +360,19 @@ EOF
 
 {{< warning >}}
 
-If you do not set `rotationPolicy: Always` in the Certificate's `privateKey`
-section, cert-manager **will not** actually rotate the trust anchor: instead, it
-will update the validity timestamps but **not** generate a new private key.
-**This is definitely not as secure as rotating the private key**; we recommend
-always setting `rotationPolicy: Always` for any certificate that cert-manager is
-managing.
+The default value of the `rotationPolicy` in the Certificate's `privateKey`
+section is dependent on your version of cert-manager. In version 1.17 and
+below, the default value was `Never`. With this configuration, cert-manager
+**will not** actually rotate the trust anchor: instead, it will update the
+validity timestamps but **not** generate a new private key.
+**This is definitely not as secure as rotating the private key**.
+
+If you are upgrading cert-manager from version 1.17 or below to version 1.18 or
+above, be aware that this new default will change the `rotationPolicy` if you
+are not explicitly setting it in your Certificate resource manifest.
+
+To avoid ambiguity, we recommend always setting `rotationPolicy: Always` for
+any certificate that cert-manager is managing.
 
 {{< /warning >}}
 

--- a/linkerd.io/content/2.18/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.18/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -243,12 +243,19 @@ EOF
 
 {{< warning >}}
 
-If you do not set `rotationPolicy: Always` in the Certificate's `privateKey`
-section, cert-manager **will not** actually rotate the trust anchor: instead, it
-will update the validity timestamps but **not** generate a new private key.
-**This is definitely not as secure as rotating the private key**; we recommend
-always setting `rotationPolicy: Always` for any certificate that cert-manager is
-managing.
+The default value of the `rotationPolicy` in the Certificate's `privateKey`
+section is dependent on your version of cert-manager. In version 1.17 and
+below, the default value was `Never`. With this configuration, cert-manager
+**will not** actually rotate the trust anchor: instead, it will update the
+validity timestamps but **not** generate a new private key.
+**This is definitely not as secure as rotating the private key**.
+
+If you are upgrading cert-manager from version 1.17 or below to version 1.18 or
+above, be aware that this new default will change the `rotationPolicy` if you
+are not explicitly setting it in your Certificate resource manifest.
+
+To avoid ambiguity, we recommend always setting `rotationPolicy: Always` for
+any certificate that cert-manager is managing.
 
 {{< /warning >}}
 
@@ -353,12 +360,19 @@ EOF
 
 {{< warning >}}
 
-If you do not set `rotationPolicy: Always` in the Certificate's `privateKey`
-section, cert-manager **will not** actually rotate the trust anchor: instead, it
-will update the validity timestamps but **not** generate a new private key.
-**This is definitely not as secure as rotating the private key**; we recommend
-always setting `rotationPolicy: Always` for any certificate that cert-manager is
-managing.
+The default value of the `rotationPolicy` in the Certificate's `privateKey`
+section is dependent on your version of cert-manager. In version 1.17 and
+below, the default value was `Never`. With this configuration, cert-manager
+**will not** actually rotate the trust anchor: instead, it will update the
+validity timestamps but **not** generate a new private key.
+**This is definitely not as secure as rotating the private key**.
+
+If you are upgrading cert-manager from version 1.17 or below to version 1.18 or
+above, be aware that this new default will change the `rotationPolicy` if you
+are not explicitly setting it in your Certificate resource manifest.
+
+To avoid ambiguity, we recommend always setting `rotationPolicy: Always` for
+any certificate that cert-manager is managing.
 
 {{< /warning >}}
 

--- a/linkerd.io/content/2.19/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.19/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -243,12 +243,19 @@ EOF
 
 {{< warning >}}
 
-If you do not set `rotationPolicy: Always` in the Certificate's `privateKey`
-section, cert-manager **will not** actually rotate the trust anchor: instead, it
-will update the validity timestamps but **not** generate a new private key.
-**This is definitely not as secure as rotating the private key**; we recommend
-always setting `rotationPolicy: Always` for any certificate that cert-manager is
-managing.
+The default value of the `rotationPolicy` in the Certificate's `privateKey`
+section is dependent on your version of cert-manager. In version 1.17 and
+below, the default value was `Never`. With this configuration, cert-manager
+**will not** actually rotate the trust anchor: instead, it will update the
+validity timestamps but **not** generate a new private key.
+**This is definitely not as secure as rotating the private key**.
+
+If you are upgrading cert-manager from version 1.17 or below to version 1.18 or
+above, be aware that this new default will change the `rotationPolicy` if you
+are not explicitly setting it in your Certificate resource manifest.
+
+To avoid ambiguity, we recommend always setting `rotationPolicy: Always` for
+any certificate that cert-manager is managing.
 
 {{< /warning >}}
 
@@ -353,12 +360,19 @@ EOF
 
 {{< warning >}}
 
-If you do not set `rotationPolicy: Always` in the Certificate's `privateKey`
-section, cert-manager **will not** actually rotate the trust anchor: instead, it
-will update the validity timestamps but **not** generate a new private key.
-**This is definitely not as secure as rotating the private key**; we recommend
-always setting `rotationPolicy: Always` for any certificate that cert-manager is
-managing.
+The default value of the `rotationPolicy` in the Certificate's `privateKey`
+section is dependent on your version of cert-manager. In version 1.17 and
+below, the default value was `Never`. With this configuration, cert-manager
+**will not** actually rotate the trust anchor: instead, it will update the
+validity timestamps but **not** generate a new private key.
+**This is definitely not as secure as rotating the private key**.
+
+If you are upgrading cert-manager from version 1.17 or below to version 1.18 or
+above, be aware that this new default will change the `rotationPolicy` if you
+are not explicitly setting it in your Certificate resource manifest.
+
+To avoid ambiguity, we recommend always setting `rotationPolicy: Always` for
+any certificate that cert-manager is managing.
 
 {{< /warning >}}
 


### PR DESCRIPTION
This PR updates the warning regarding the `rotationPolicy` of the trust anchor's private key to reflect the fact that the default was changed in `cert-manager` version 1.18 and above.