### PR TITLE
feat(docs): add new inbound proxy metrics

### DIFF
--- a/linkerd.io/content/2-edge/reference/proxy-metrics.md
+++ b/linkerd.io/content/2-edge/reference/proxy-metrics.md
@@ -307,6 +307,35 @@ The outbound proxy records the following metrics:
 - `outbound_grpc_route_backend_response_frame_size_bytes`: A histogram measuring
   the sizes of `DATA` frames in gRPC response bodies from a particular backend.
 
+The inbound proxy records the following metrics:
+
+- `inbound_http_requests_total`: A counter tracking the total number of inbound HTTP
+  requests received by a particular backend.
+- `inbound_grpc_requests_total`: A counter tracking the total number of inbound gRPC
+  requests received by a particular backend.
+- `inbound_http_statuses_total`: A counter tracking HTTP response status codes for
+  HTTP traffic received by a particular backend.
+- `inbound_grpc_statuses_total`: A counter tracking gRPC response status codes for
+  gRPC traffic received by a particular backend.
+- `inbound_http_request_duration_seconds`: A histogram measuring the time
+  between HTTP request initialization and HTTP response completion.
+- `inbound_http_response_duration_seconds`: A histogram measuring the time in
+  seconds between the HTTP request completing and HTTP response completing, for
+  a particular backend.
+- `inbound_grpc_request_duration_seconds`: A histogram measuring the time
+  between gRPC request initialization and gRPC response completion.
+- `inbound_grpc_response_duration_seconds`: A histogram measuring the time in
+  seconds between the gRPC request completing and gRPC response completing, for
+  a particular backend.
+- `inbound_http_request_frame_size_bytes`: A histogram measuring the
+  sizes of `DATA` frames in HTTP request bodies for a particular route.
+- `inbound_http_response_frame_size_bytes`: A histogram measuring the
+  sizes of `DATA` frames in HTTP response bodies for a particular route.
+- `inbound_grpc_request_frame_size_bytes`: A histogram measuring the
+  sizes of `DATA` frames in gRPC request bodies for a particular route.
+- `inbound_grpc_response_frame_size_bytes`: A histogram measuring the
+  sizes of `DATA` frames in gRPC response bodies for a particular route.
+
 ### Labels
 
 Each of these metrics has the following common labels, which describe the

--- a/linkerd.io/content/2-edge/reference/proxy-metrics.md
+++ b/linkerd.io/content/2-edge/reference/proxy-metrics.md
@@ -231,6 +231,7 @@ layer.
 - `inbound_tcp_authz_deny_total`: A counter of the total number of TCP
   connections that were denied
 
+<!-- markdownlint-disable-next-line no-duplicate-heading -->
 ### Labels
 
 Each of these metrics has the following labels:
@@ -336,6 +337,7 @@ The inbound proxy records the following metrics:
 - `inbound_grpc_response_frame_size_bytes`: A histogram measuring the
   sizes of `DATA` frames in gRPC response bodies for a particular route.
 
+<!-- markdownlint-disable-next-line no-duplicate-heading -->
 ### Labels
 
 Each of these metrics has the following common labels, which describe the


### PR DESCRIPTION
- **feat(docs): add new inbound proxy metrics**
  this commit introduces documentation for the inbound proxy metrics that
  have been added in recent edge releases.
  
  see these commits for more information:
  
  * https://github.com/linkerd/linkerd2-proxy/pull/4420
  * https://github.com/linkerd/linkerd2-proxy/pull/4313
  * https://github.com/linkerd/linkerd2-proxy/pull/4180
  * https://github.com/linkerd/linkerd2-proxy/pull/4165
  * https://github.com/linkerd/linkerd2-proxy/pull/4127
  
  Signed-off-by: katelyn martin <kate@buoyant.io>
  

- **chore(docs): add no-duplicate-heading linter directives**
  this commit adds some linter directives to silence warnings related to
  duplicate headers. in this case, it's valid to have duplicate labels,
  because different families of metrics, naturally, both have labels.
  
  Signed-off-by: katelyn martin <kate@buoyant.io>
  