### PR TITLE
Fix renewBefore spec value so they match with the inline documentation

### DIFF
--- a/linkerd.io/content/2-edge/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2-edge/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -234,7 +234,7 @@ spec:
   # Feel free to reduce this, but remember that there is a manual
   # process for rotating the trust anchor!
   duration: 8760h0m0s
-  renewBefore: 7320h0m0s
+  renewBefore: 1440h0m0s
   privateKey:
     rotationPolicy: Always
     algorithm: ECDSA
@@ -351,7 +351,7 @@ spec:
   # This is a two-day duration, rotating slightly over a day before
   # expiry. Feel free to set this as you like.
   duration: 48h0m0s
-  renewBefore: 25h0m0s
+  renewBefore: 23h0m0s
   privateKey:
     rotationPolicy: Always
     algorithm: ECDSA

--- a/linkerd.io/content/2.14/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.14/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -234,7 +234,7 @@ spec:
   # Feel free to reduce this, but remember that there is a manual
   # process for rotating the trust anchor!
   duration: 8760h0m0s
-  renewBefore: 7320h0m0s
+  renewBefore: 1440h0m0s
   privateKey:
     rotationPolicy: Always
     algorithm: ECDSA
@@ -351,7 +351,7 @@ spec:
   # This is a two-day duration, rotating slightly over a day before
   # expiry. Feel free to set this as you like.
   duration: 48h0m0s
-  renewBefore: 25h0m0s
+  renewBefore: 23h0m0s
   privateKey:
     rotationPolicy: Always
     algorithm: ECDSA

--- a/linkerd.io/content/2.15/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.15/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -234,7 +234,7 @@ spec:
   # Feel free to reduce this, but remember that there is a manual
   # process for rotating the trust anchor!
   duration: 8760h0m0s
-  renewBefore: 7320h0m0s
+  renewBefore: 1440h0m0s
   privateKey:
     rotationPolicy: Always
     algorithm: ECDSA
@@ -351,7 +351,7 @@ spec:
   # This is a two-day duration, rotating slightly over a day before
   # expiry. Feel free to set this as you like.
   duration: 48h0m0s
-  renewBefore: 25h0m0s
+  renewBefore: 23h0m0s
   privateKey:
     rotationPolicy: Always
     algorithm: ECDSA

--- a/linkerd.io/content/2.16/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.16/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -234,7 +234,7 @@ spec:
   # Feel free to reduce this, but remember that there is a manual
   # process for rotating the trust anchor!
   duration: 8760h0m0s
-  renewBefore: 7320h0m0s
+  renewBefore: 1440h0m0s
   privateKey:
     rotationPolicy: Always
     algorithm: ECDSA
@@ -351,7 +351,7 @@ spec:
   # This is a two-day duration, rotating slightly over a day before
   # expiry. Feel free to set this as you like.
   duration: 48h0m0s
-  renewBefore: 25h0m0s
+  renewBefore: 23h0m0s
   privateKey:
     rotationPolicy: Always
     algorithm: ECDSA

--- a/linkerd.io/content/2.17/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.17/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -234,7 +234,7 @@ spec:
   # Feel free to reduce this, but remember that there is a manual
   # process for rotating the trust anchor!
   duration: 8760h0m0s
-  renewBefore: 7320h0m0s
+  renewBefore: 1440h0m0s
   privateKey:
     rotationPolicy: Always
     algorithm: ECDSA
@@ -351,7 +351,7 @@ spec:
   # This is a two-day duration, rotating slightly over a day before
   # expiry. Feel free to set this as you like.
   duration: 48h0m0s
-  renewBefore: 25h0m0s
+  renewBefore: 23h0m0s
   privateKey:
     rotationPolicy: Always
     algorithm: ECDSA

--- a/linkerd.io/content/2.18/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.18/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -234,7 +234,7 @@ spec:
   # Feel free to reduce this, but remember that there is a manual
   # process for rotating the trust anchor!
   duration: 8760h0m0s
-  renewBefore: 7320h0m0s
+  renewBefore: 1440h0m0s
   privateKey:
     rotationPolicy: Always
     algorithm: ECDSA
@@ -351,7 +351,7 @@ spec:
   # This is a two-day duration, rotating slightly over a day before
   # expiry. Feel free to set this as you like.
   duration: 48h0m0s
-  renewBefore: 25h0m0s
+  renewBefore: 23h0m0s
   privateKey:
     rotationPolicy: Always
     algorithm: ECDSA

--- a/linkerd.io/content/2.19/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.19/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -234,7 +234,7 @@ spec:
   # Feel free to reduce this, but remember that there is a manual
   # process for rotating the trust anchor!
   duration: 8760h0m0s
-  renewBefore: 7320h0m0s
+  renewBefore: 1440h0m0s
   privateKey:
     rotationPolicy: Always
     algorithm: ECDSA
@@ -351,7 +351,7 @@ spec:
   # This is a two-day duration, rotating slightly over a day before
   # expiry. Feel free to set this as you like.
   duration: 48h0m0s
-  renewBefore: 25h0m0s
+  renewBefore: 23h0m0s
   privateKey:
     rotationPolicy: Always
     algorithm: ECDSA


### PR DESCRIPTION
As per definition the renewBefore is the value which specifies how long before expiry a certificate should be renewed. Having the duration on 8760h (24*365) and the renewBefore on 7320h (24x305) will renew the certificate after 60 days (365-305). To have the certificate renewed 2 months before, the renewBefore value should be 1440h (24*60). Similar for the linkerd-identity-issuer certificate.