### PR TITLE
Add tap subcommand section with skipped ports note to viz CLI docs

### DIFF
--- a/linkerd.io/content/2.19/reference/cli/viz.md
+++ b/linkerd.io/content/2.19/reference/cli/viz.md
@@ -150,7 +150,6 @@ Because retries are only performed on the _outbound_ (client) side, the
 
 {{< docs/cli-flags "viz stat" >}}
 
-### tap
 
 ### tap
 

--- a/linkerd.io/content/2.19/reference/cli/viz.md
+++ b/linkerd.io/content/2.19/reference/cli/viz.md
@@ -152,7 +152,15 @@ Because retries are only performed on the _outbound_ (client) side, the
 
 ### tap
 
+### tap
+
 {{< docs/cli-description "viz tap" >}}
+
+{{< note >}}If a pod is configured with the annotations
+`config.linkerd.io/skip-inbound-ports` or
+`config.linkerd.io/skip-outbound-ports`, traffic on those ports bypasses the
+Linkerd proxy. Because `linkerd tap` observes traffic through the proxy,
+**traffic on skipped ports cannot be tapped**.{{< /note >}}
 
 {{< docs/cli-examples "viz tap" >}}
 


### PR DESCRIPTION
## Problem

The `linkerd viz tap` subcommand is not explicitly documented in the CLI reference, and behavior related to skipped ports is not clear to users.

## Solution

Add a `tap` subcommand section under `viz.md`, including:
- CLI description, examples, and flags via shortcodes
- A note explaining that traffic on skipped ports cannot be tapped

## Result

Improves discoverability and clarity for users troubleshooting `linkerd viz tap`.

This follows up on feedback from #2105.