### PR TITLE
Improve CLI reference pages

### DIFF
--- a/linkerd.io/content/2-edge/reference/cli/diagnostics.md
+++ b/linkerd.io/content/2-edge/reference/cli/diagnostics.md
@@ -10,6 +10,8 @@ title: diagnostics
 
 ## Subcommands
 
+{{< docs/cli-subcommands "diagnostics" >}}
+
 ### controller-metrics
 
 {{< docs/cli-description "diagnostics controller-metrics" >}}

--- a/linkerd.io/content/2-edge/reference/cli/multicluster.md
+++ b/linkerd.io/content/2-edge/reference/cli/multicluster.md
@@ -10,6 +10,8 @@ title: multicluster
 
 ## Subcommands
 
+{{< docs/cli-subcommands "multicluster" >}}
+
 ### allow
 
 {{< docs/cli-description "multicluster allow" >}}

--- a/linkerd.io/content/2-edge/reference/cli/viz.md
+++ b/linkerd.io/content/2-edge/reference/cli/viz.md
@@ -10,7 +10,9 @@ title: viz
 
 ## Subcommands
 
-## allow-scrapes
+{{< docs/cli-subcommands "viz" >}}
+
+### allow-scrapes
 
 {{< docs/cli-description "viz allow-scrapes" >}}
 
@@ -18,7 +20,7 @@ title: viz
 
 {{< docs/cli-flags "viz allow-scrapes" >}}
 
-## authz
+### authz
 
 {{< docs/cli-description "viz authz" >}}
 
@@ -89,7 +91,7 @@ that is receiving the requests. For more information about how to create a
 service profile, see [service profiles](../../features/service-profiles/). and
 the [profile](profile) command reference.
 
-## Inbound Metrics
+#### Inbound Metrics
 
 By default, `routes` displays _inbound_ metrics for a target. In other words, it
 shows information about requests which are sent to the target and responses
@@ -104,7 +106,7 @@ Displays the request volume, success rate, and latency of requests to the
 perspective, which means that, for example, these latencies do not include the
 network latency between a client and the `webapp` deployment.
 
-## Outbound Metrics
+#### Outbound Metrics
 
 If you specify the `--to` flag then `linkerd viz routes` displays _outbound_
 metrics from the target resource to the resource in the `--to` flag. In contrast
@@ -119,7 +121,7 @@ linkerd viz routes deploy/traffic --to deploy/webapp
 Displays the request volume, success rate, and latency of requests from
 `traffic` to `webapp` from the perspective of the `traffic` deployment.
 
-## Effective and Actual Metrics
+#### Effective and Actual Metrics
 
 If you are looking at _outbound_ metrics (by specifying the `--to` flag) you can
 also supply the `-o wide` flag to differentiate between _effective_ and _actual_

--- a/linkerd.io/content/2.10/reference/cli/diagnostics.md
+++ b/linkerd.io/content/2.10/reference/cli/diagnostics.md
@@ -10,6 +10,8 @@ title: diagnostics
 
 ## Subcommands
 
+{{< docs/cli-subcommands "diagnostics" >}}
+
 ### controller-metrics
 
 {{< docs/cli-description "diagnostics controller-metrics" >}}

--- a/linkerd.io/content/2.10/reference/cli/jaeger.md
+++ b/linkerd.io/content/2.10/reference/cli/jaeger.md
@@ -10,6 +10,8 @@ title: jaeger
 
 ## Subcommands
 
+{{< docs/cli-subcommands "jaeger" >}}
+
 ### check
 
 {{< docs/cli-description "jaeger check" >}}

--- a/linkerd.io/content/2.10/reference/cli/multicluster.md
+++ b/linkerd.io/content/2.10/reference/cli/multicluster.md
@@ -10,6 +10,8 @@ title: multicluster
 
 ## Subcommands
 
+{{< docs/cli-subcommands "multicluster" >}}
+
 ### allow
 
 {{< docs/cli-description "multicluster allow" >}}

--- a/linkerd.io/content/2.10/reference/cli/viz.md
+++ b/linkerd.io/content/2.10/reference/cli/viz.md
@@ -10,6 +10,8 @@ title: viz
 
 ## Subcommands
 
+{{< docs/cli-subcommands "viz" >}}
+
 ### check
 
 {{< docs/cli-description "viz check" >}}
@@ -73,7 +75,7 @@ that is receiving the requests. For more information about how to create a
 service profile, see [service profiles](../../features/service-profiles/). and
 the [profile](profile) command reference.
 
-## Inbound Metrics
+#### Inbound Metrics
 
 By default, `routes` displays _inbound_ metrics for a target. In other words, it
 shows information about requests which are sent to the target and responses
@@ -88,7 +90,7 @@ Displays the request volume, success rate, and latency of requests to the
 perspective, which means that, for example, these latencies do not include the
 network latency between a client and the `webapp` deployment.
 
-## Outbound Metrics
+#### Outbound Metrics
 
 If you specify the `--to` flag then `linkerd viz routes` displays _outbound_
 metrics from the target resource to the resource in the `--to` flag. In contrast
@@ -103,7 +105,7 @@ linkerd viz routes deploy/traffic --to deploy/webapp
 Displays the request volume, success rate, and latency of requests from
 `traffic` to `webapp` from the perspective of the `traffic` deployment.
 
-## Effective and Actual Metrics
+#### Effective and Actual Metrics
 
 If you are looking at _outbound_ metrics (by specifying the `--to` flag) you can
 also supply the `-o wide` flag to differentiate between _effective_ and _actual_

--- a/linkerd.io/content/2.11/reference/cli/diagnostics.md
+++ b/linkerd.io/content/2.11/reference/cli/diagnostics.md
@@ -10,6 +10,8 @@ title: diagnostics
 
 ## Subcommands
 
+{{< docs/cli-subcommands "diagnostics" >}}
+
 ### controller-metrics
 
 {{< docs/cli-description "diagnostics controller-metrics" >}}

--- a/linkerd.io/content/2.11/reference/cli/jaeger.md
+++ b/linkerd.io/content/2.11/reference/cli/jaeger.md
@@ -10,6 +10,8 @@ title: jaeger
 
 ## Subcommands
 
+{{< docs/cli-subcommands "jaeger" >}}
+
 ### check
 
 {{< docs/cli-description "jaeger check" >}}

--- a/linkerd.io/content/2.11/reference/cli/multicluster.md
+++ b/linkerd.io/content/2.11/reference/cli/multicluster.md
@@ -10,6 +10,8 @@ title: multicluster
 
 ## Subcommands
 
+{{< docs/cli-subcommands "multicluster" >}}
+
 ### allow
 
 {{< docs/cli-description "multicluster allow" >}}

--- a/linkerd.io/content/2.11/reference/cli/viz.md
+++ b/linkerd.io/content/2.11/reference/cli/viz.md
@@ -10,6 +10,8 @@ title: viz
 
 ## Subcommands
 
+{{< docs/cli-subcommands "viz" >}}
+
 ### check
 
 {{< docs/cli-description "viz check" >}}
@@ -73,7 +75,7 @@ that is receiving the requests. For more information about how to create a
 service profile, see [service profiles](../../features/service-profiles/). and
 the [profile](profile) command reference.
 
-## Inbound Metrics
+#### Inbound Metrics
 
 By default, `routes` displays _inbound_ metrics for a target. In other words, it
 shows information about requests which are sent to the target and responses
@@ -88,7 +90,7 @@ Displays the request volume, success rate, and latency of requests to the
 perspective, which means that, for example, these latencies do not include the
 network latency between a client and the `webapp` deployment.
 
-## Outbound Metrics
+#### Outbound Metrics
 
 If you specify the `--to` flag then `linkerd viz routes` displays _outbound_
 metrics from the target resource to the resource in the `--to` flag. In contrast
@@ -103,7 +105,7 @@ linkerd viz routes deploy/traffic --to deploy/webapp
 Displays the request volume, success rate, and latency of requests from
 `traffic` to `webapp` from the perspective of the `traffic` deployment.
 
-## Effective and Actual Metrics
+#### Effective and Actual Metrics
 
 If you are looking at _outbound_ metrics (by specifying the `--to` flag) you can
 also supply the `-o wide` flag to differentiate between _effective_ and _actual_

--- a/linkerd.io/content/2.12/reference/cli/diagnostics.md
+++ b/linkerd.io/content/2.12/reference/cli/diagnostics.md
@@ -10,6 +10,8 @@ title: diagnostics
 
 ## Subcommands
 
+{{< docs/cli-subcommands "diagnostics" >}}
+
 ### controller-metrics
 
 {{< docs/cli-description "diagnostics controller-metrics" >}}

--- a/linkerd.io/content/2.12/reference/cli/jaeger.md
+++ b/linkerd.io/content/2.12/reference/cli/jaeger.md
@@ -10,6 +10,8 @@ title: jaeger
 
 ## Subcommands
 
+{{< docs/cli-subcommands "jaeger" >}}
+
 ### check
 
 {{< docs/cli-description "jaeger check" >}}

--- a/linkerd.io/content/2.12/reference/cli/multicluster.md
+++ b/linkerd.io/content/2.12/reference/cli/multicluster.md
@@ -10,6 +10,8 @@ title: multicluster
 
 ## Subcommands
 
+{{< docs/cli-subcommands "multicluster" >}}
+
 ### allow
 
 {{< docs/cli-description "multicluster allow" >}}

--- a/linkerd.io/content/2.12/reference/cli/viz.md
+++ b/linkerd.io/content/2.12/reference/cli/viz.md
@@ -10,7 +10,9 @@ title: viz
 
 ## Subcommands
 
-## allow-scrapes
+{{< docs/cli-subcommands "viz" >}}
+
+### allow-scrapes
 
 {{< docs/cli-description "viz allow-scrapes" >}}
 
@@ -18,7 +20,7 @@ title: viz
 
 {{< docs/cli-flags "viz allow-scrapes" >}}
 
-## authz
+### authz
 
 {{< docs/cli-description "viz authz" >}}
 
@@ -89,7 +91,7 @@ that is receiving the requests. For more information about how to create a
 service profile, see [service profiles](../../features/service-profiles/). and
 the [profile](profile) command reference.
 
-## Inbound Metrics
+#### Inbound Metrics
 
 By default, `routes` displays _inbound_ metrics for a target. In other words, it
 shows information about requests which are sent to the target and responses
@@ -104,7 +106,7 @@ Displays the request volume, success rate, and latency of requests to the
 perspective, which means that, for example, these latencies do not include the
 network latency between a client and the `webapp` deployment.
 
-## Outbound Metrics
+#### Outbound Metrics
 
 If you specify the `--to` flag then `linkerd viz routes` displays _outbound_
 metrics from the target resource to the resource in the `--to` flag. In contrast
@@ -119,7 +121,7 @@ linkerd viz routes deploy/traffic --to deploy/webapp
 Displays the request volume, success rate, and latency of requests from
 `traffic` to `webapp` from the perspective of the `traffic` deployment.
 
-## Effective and Actual Metrics
+#### Effective and Actual Metrics
 
 If you are looking at _outbound_ metrics (by specifying the `--to` flag) you can
 also supply the `-o wide` flag to differentiate between _effective_ and _actual_

--- a/linkerd.io/content/2.13/reference/cli/diagnostics.md
+++ b/linkerd.io/content/2.13/reference/cli/diagnostics.md
@@ -10,6 +10,8 @@ title: diagnostics
 
 ## Subcommands
 
+{{< docs/cli-subcommands "diagnostics" >}}
+
 ### controller-metrics
 
 {{< docs/cli-description "diagnostics controller-metrics" >}}

--- a/linkerd.io/content/2.13/reference/cli/jaeger.md
+++ b/linkerd.io/content/2.13/reference/cli/jaeger.md
@@ -10,6 +10,8 @@ title: jaeger
 
 ## Subcommands
 
+{{< docs/cli-subcommands "jaeger" >}}
+
 ### check
 
 {{< docs/cli-description "jaeger check" >}}

--- a/linkerd.io/content/2.13/reference/cli/multicluster.md
+++ b/linkerd.io/content/2.13/reference/cli/multicluster.md
@@ -10,6 +10,8 @@ title: multicluster
 
 ## Subcommands
 
+{{< docs/cli-subcommands "multicluster" >}}
+
 ### allow
 
 {{< docs/cli-description "multicluster allow" >}}

--- a/linkerd.io/content/2.13/reference/cli/viz.md
+++ b/linkerd.io/content/2.13/reference/cli/viz.md
@@ -10,7 +10,9 @@ title: viz
 
 ## Subcommands
 
-## allow-scrapes
+{{< docs/cli-subcommands "viz" >}}
+
+### allow-scrapes
 
 {{< docs/cli-description "viz allow-scrapes" >}}
 
@@ -18,7 +20,7 @@ title: viz
 
 {{< docs/cli-flags "viz allow-scrapes" >}}
 
-## authz
+### authz
 
 {{< docs/cli-description "viz authz" >}}
 
@@ -89,7 +91,7 @@ that is receiving the requests. For more information about how to create a
 service profile, see [service profiles](../../features/service-profiles/). and
 the [profile](profile) command reference.
 
-## Inbound Metrics
+#### Inbound Metrics
 
 By default, `routes` displays _inbound_ metrics for a target. In other words, it
 shows information about requests which are sent to the target and responses
@@ -104,7 +106,7 @@ Displays the request volume, success rate, and latency of requests to the
 perspective, which means that, for example, these latencies do not include the
 network latency between a client and the `webapp` deployment.
 
-## Outbound Metrics
+#### Outbound Metrics
 
 If you specify the `--to` flag then `linkerd viz routes` displays _outbound_
 metrics from the target resource to the resource in the `--to` flag. In contrast
@@ -119,7 +121,7 @@ linkerd viz routes deploy/traffic --to deploy/webapp
 Displays the request volume, success rate, and latency of requests from
 `traffic` to `webapp` from the perspective of the `traffic` deployment.
 
-## Effective and Actual Metrics
+#### Effective and Actual Metrics
 
 If you are looking at _outbound_ metrics (by specifying the `--to` flag) you can
 also supply the `-o wide` flag to differentiate between _effective_ and _actual_

--- a/linkerd.io/content/2.14/reference/cli/diagnostics.md
+++ b/linkerd.io/content/2.14/reference/cli/diagnostics.md
@@ -10,6 +10,8 @@ title: diagnostics
 
 ## Subcommands
 
+{{< docs/cli-subcommands "diagnostics" >}}
+
 ### controller-metrics
 
 {{< docs/cli-description "diagnostics controller-metrics" >}}

--- a/linkerd.io/content/2.14/reference/cli/jaeger.md
+++ b/linkerd.io/content/2.14/reference/cli/jaeger.md
@@ -10,6 +10,8 @@ title: jaeger
 
 ## Subcommands
 
+{{< docs/cli-subcommands "jaeger" >}}
+
 ### check
 
 {{< docs/cli-description "jaeger check" >}}

--- a/linkerd.io/content/2.14/reference/cli/multicluster.md
+++ b/linkerd.io/content/2.14/reference/cli/multicluster.md
@@ -10,6 +10,8 @@ title: multicluster
 
 ## Subcommands
 
+{{< docs/cli-subcommands "multicluster" >}}
+
 ### allow
 
 {{< docs/cli-description "multicluster allow" >}}

--- a/linkerd.io/content/2.14/reference/cli/viz.md
+++ b/linkerd.io/content/2.14/reference/cli/viz.md
@@ -10,7 +10,9 @@ title: viz
 
 ## Subcommands
 
-## allow-scrapes
+{{< docs/cli-subcommands "viz" >}}
+
+### allow-scrapes
 
 {{< docs/cli-description "viz allow-scrapes" >}}
 
@@ -18,7 +20,7 @@ title: viz
 
 {{< docs/cli-flags "viz allow-scrapes" >}}
 
-## authz
+### authz
 
 {{< docs/cli-description "viz authz" >}}
 
@@ -89,7 +91,7 @@ that is receiving the requests. For more information about how to create a
 service profile, see [service profiles](../../features/service-profiles/). and
 the [profile](profile) command reference.
 
-## Inbound Metrics
+#### Inbound Metrics
 
 By default, `routes` displays _inbound_ metrics for a target. In other words, it
 shows information about requests which are sent to the target and responses
@@ -104,7 +106,7 @@ Displays the request volume, success rate, and latency of requests to the
 perspective, which means that, for example, these latencies do not include the
 network latency between a client and the `webapp` deployment.
 
-## Outbound Metrics
+#### Outbound Metrics
 
 If you specify the `--to` flag then `linkerd viz routes` displays _outbound_
 metrics from the target resource to the resource in the `--to` flag. In contrast
@@ -119,7 +121,7 @@ linkerd viz routes deploy/traffic --to deploy/webapp
 Displays the request volume, success rate, and latency of requests from
 `traffic` to `webapp` from the perspective of the `traffic` deployment.
 
-## Effective and Actual Metrics
+#### Effective and Actual Metrics
 
 If you are looking at _outbound_ metrics (by specifying the `--to` flag) you can
 also supply the `-o wide` flag to differentiate between _effective_ and _actual_

--- a/linkerd.io/content/2.15/reference/cli/diagnostics.md
+++ b/linkerd.io/content/2.15/reference/cli/diagnostics.md
@@ -10,6 +10,8 @@ title: diagnostics
 
 ## Subcommands
 
+{{< docs/cli-subcommands "diagnostics" >}}
+
 ### controller-metrics
 
 {{< docs/cli-description "diagnostics controller-metrics" >}}

--- a/linkerd.io/content/2.15/reference/cli/jaeger.md
+++ b/linkerd.io/content/2.15/reference/cli/jaeger.md
@@ -10,6 +10,8 @@ title: jaeger
 
 ## Subcommands
 
+{{< docs/cli-subcommands "jaeger" >}}
+
 ### check
 
 {{< docs/cli-description "jaeger check" >}}

--- a/linkerd.io/content/2.15/reference/cli/multicluster.md
+++ b/linkerd.io/content/2.15/reference/cli/multicluster.md
@@ -10,6 +10,8 @@ title: multicluster
 
 ## Subcommands
 
+{{< docs/cli-subcommands "multicluster" >}}
+
 ### allow
 
 {{< docs/cli-description "multicluster allow" >}}

--- a/linkerd.io/content/2.15/reference/cli/viz.md
+++ b/linkerd.io/content/2.15/reference/cli/viz.md
@@ -10,7 +10,9 @@ title: viz
 
 ## Subcommands
 
-## allow-scrapes
+{{< docs/cli-subcommands "viz" >}}
+
+### allow-scrapes
 
 {{< docs/cli-description "viz allow-scrapes" >}}
 
@@ -18,7 +20,7 @@ title: viz
 
 {{< docs/cli-flags "viz allow-scrapes" >}}
 
-## authz
+### authz
 
 {{< docs/cli-description "viz authz" >}}
 
@@ -89,7 +91,7 @@ that is receiving the requests. For more information about how to create a
 service profile, see [service profiles](../../features/service-profiles/). and
 the [profile](profile) command reference.
 
-## Inbound Metrics
+#### Inbound Metrics
 
 By default, `routes` displays _inbound_ metrics for a target. In other words, it
 shows information about requests which are sent to the target and responses
@@ -104,7 +106,7 @@ Displays the request volume, success rate, and latency of requests to the
 perspective, which means that, for example, these latencies do not include the
 network latency between a client and the `webapp` deployment.
 
-## Outbound Metrics
+#### Outbound Metrics
 
 If you specify the `--to` flag then `linkerd viz routes` displays _outbound_
 metrics from the target resource to the resource in the `--to` flag. In contrast
@@ -119,7 +121,7 @@ linkerd viz routes deploy/traffic --to deploy/webapp
 Displays the request volume, success rate, and latency of requests from
 `traffic` to `webapp` from the perspective of the `traffic` deployment.
 
-## Effective and Actual Metrics
+#### Effective and Actual Metrics
 
 If you are looking at _outbound_ metrics (by specifying the `--to` flag) you can
 also supply the `-o wide` flag to differentiate between _effective_ and _actual_

--- a/linkerd.io/content/2.16/reference/cli/diagnostics.md
+++ b/linkerd.io/content/2.16/reference/cli/diagnostics.md
@@ -10,6 +10,8 @@ title: diagnostics
 
 ## Subcommands
 
+{{< docs/cli-subcommands "diagnostics" >}}
+
 ### controller-metrics
 
 {{< docs/cli-description "diagnostics controller-metrics" >}}

--- a/linkerd.io/content/2.16/reference/cli/jaeger.md
+++ b/linkerd.io/content/2.16/reference/cli/jaeger.md
@@ -10,6 +10,8 @@ title: jaeger
 
 ## Subcommands
 
+{{< docs/cli-subcommands "jaeger" >}}
+
 ### check
 
 {{< docs/cli-description "jaeger check" >}}

--- a/linkerd.io/content/2.16/reference/cli/multicluster.md
+++ b/linkerd.io/content/2.16/reference/cli/multicluster.md
@@ -10,6 +10,8 @@ title: multicluster
 
 ## Subcommands
 
+{{< docs/cli-subcommands "multicluster" >}}
+
 ### allow
 
 {{< docs/cli-description "multicluster allow" >}}

--- a/linkerd.io/content/2.16/reference/cli/viz.md
+++ b/linkerd.io/content/2.16/reference/cli/viz.md
@@ -10,7 +10,9 @@ title: viz
 
 ## Subcommands
 
-## allow-scrapes
+{{< docs/cli-subcommands "viz" >}}
+
+### allow-scrapes
 
 {{< docs/cli-description "viz allow-scrapes" >}}
 
@@ -18,7 +20,7 @@ title: viz
 
 {{< docs/cli-flags "viz allow-scrapes" >}}
 
-## authz
+### authz
 
 {{< docs/cli-description "viz authz" >}}
 
@@ -89,7 +91,7 @@ that is receiving the requests. For more information about how to create a
 service profile, see [service profiles](../../features/service-profiles/). and
 the [profile](profile) command reference.
 
-## Inbound Metrics
+#### Inbound Metrics
 
 By default, `routes` displays _inbound_ metrics for a target. In other words, it
 shows information about requests which are sent to the target and responses
@@ -104,7 +106,7 @@ Displays the request volume, success rate, and latency of requests to the
 perspective, which means that, for example, these latencies do not include the
 network latency between a client and the `webapp` deployment.
 
-## Outbound Metrics
+#### Outbound Metrics
 
 If you specify the `--to` flag then `linkerd viz routes` displays _outbound_
 metrics from the target resource to the resource in the `--to` flag. In contrast
@@ -119,7 +121,7 @@ linkerd viz routes deploy/traffic --to deploy/webapp
 Displays the request volume, success rate, and latency of requests from
 `traffic` to `webapp` from the perspective of the `traffic` deployment.
 
-## Effective and Actual Metrics
+#### Effective and Actual Metrics
 
 If you are looking at _outbound_ metrics (by specifying the `--to` flag) you can
 also supply the `-o wide` flag to differentiate between _effective_ and _actual_

--- a/linkerd.io/content/2.17/reference/cli/diagnostics.md
+++ b/linkerd.io/content/2.17/reference/cli/diagnostics.md
@@ -10,6 +10,8 @@ title: diagnostics
 
 ## Subcommands
 
+{{< docs/cli-subcommands "diagnostics" >}}
+
 ### controller-metrics
 
 {{< docs/cli-description "diagnostics controller-metrics" >}}

--- a/linkerd.io/content/2.17/reference/cli/jaeger.md
+++ b/linkerd.io/content/2.17/reference/cli/jaeger.md
@@ -10,6 +10,8 @@ title: jaeger
 
 ## Subcommands
 
+{{< docs/cli-subcommands "jaeger" >}}
+
 ### check
 
 {{< docs/cli-description "jaeger check" >}}

--- a/linkerd.io/content/2.17/reference/cli/multicluster.md
+++ b/linkerd.io/content/2.17/reference/cli/multicluster.md
@@ -10,6 +10,8 @@ title: multicluster
 
 ## Subcommands
 
+{{< docs/cli-subcommands "multicluster" >}}
+
 ### allow
 
 {{< docs/cli-description "multicluster allow" >}}

--- a/linkerd.io/content/2.17/reference/cli/viz.md
+++ b/linkerd.io/content/2.17/reference/cli/viz.md
@@ -10,7 +10,9 @@ title: viz
 
 ## Subcommands
 
-## allow-scrapes
+{{< docs/cli-subcommands "viz" >}}
+
+### allow-scrapes
 
 {{< docs/cli-description "viz allow-scrapes" >}}
 
@@ -18,7 +20,7 @@ title: viz
 
 {{< docs/cli-flags "viz allow-scrapes" >}}
 
-## authz
+### authz
 
 {{< docs/cli-description "viz authz" >}}
 
@@ -89,7 +91,7 @@ that is receiving the requests. For more information about how to create a
 service profile, see [service profiles](../../features/service-profiles/). and
 the [profile](profile) command reference.
 
-## Inbound Metrics
+#### Inbound Metrics
 
 By default, `routes` displays _inbound_ metrics for a target. In other words, it
 shows information about requests which are sent to the target and responses
@@ -104,7 +106,7 @@ Displays the request volume, success rate, and latency of requests to the
 perspective, which means that, for example, these latencies do not include the
 network latency between a client and the `webapp` deployment.
 
-## Outbound Metrics
+#### Outbound Metrics
 
 If you specify the `--to` flag then `linkerd viz routes` displays _outbound_
 metrics from the target resource to the resource in the `--to` flag. In contrast
@@ -119,7 +121,7 @@ linkerd viz routes deploy/traffic --to deploy/webapp
 Displays the request volume, success rate, and latency of requests from
 `traffic` to `webapp` from the perspective of the `traffic` deployment.
 
-## Effective and Actual Metrics
+#### Effective and Actual Metrics
 
 If you are looking at _outbound_ metrics (by specifying the `--to` flag) you can
 also supply the `-o wide` flag to differentiate between _effective_ and _actual_

--- a/linkerd.io/content/2.18/reference/cli/diagnostics.md
+++ b/linkerd.io/content/2.18/reference/cli/diagnostics.md
@@ -10,6 +10,8 @@ title: diagnostics
 
 ## Subcommands
 
+{{< docs/cli-subcommands "diagnostics" >}}
+
 ### controller-metrics
 
 {{< docs/cli-description "diagnostics controller-metrics" >}}

--- a/linkerd.io/content/2.18/reference/cli/jaeger.md
+++ b/linkerd.io/content/2.18/reference/cli/jaeger.md
@@ -10,6 +10,8 @@ title: jaeger
 
 ## Subcommands
 
+{{< docs/cli-subcommands "jaeger" >}}
+
 ### check
 
 {{< docs/cli-description "jaeger check" >}}

--- a/linkerd.io/content/2.18/reference/cli/multicluster.md
+++ b/linkerd.io/content/2.18/reference/cli/multicluster.md
@@ -10,6 +10,8 @@ title: multicluster
 
 ## Subcommands
 
+{{< docs/cli-subcommands "multicluster" >}}
+
 ### allow
 
 {{< docs/cli-description "multicluster allow" >}}

--- a/linkerd.io/content/2.18/reference/cli/viz.md
+++ b/linkerd.io/content/2.18/reference/cli/viz.md
@@ -10,7 +10,9 @@ title: viz
 
 ## Subcommands
 
-## allow-scrapes
+{{< docs/cli-subcommands "viz" >}}
+
+### allow-scrapes
 
 {{< docs/cli-description "viz allow-scrapes" >}}
 
@@ -18,7 +20,7 @@ title: viz
 
 {{< docs/cli-flags "viz allow-scrapes" >}}
 
-## authz
+### authz
 
 {{< docs/cli-description "viz authz" >}}
 
@@ -89,7 +91,7 @@ that is receiving the requests. For more information about how to create a
 service profile, see [service profiles](../../features/service-profiles/). and
 the [profile](profile) command reference.
 
-## Inbound Metrics
+#### Inbound Metrics
 
 By default, `routes` displays _inbound_ metrics for a target. In other words, it
 shows information about requests which are sent to the target and responses
@@ -104,7 +106,7 @@ Displays the request volume, success rate, and latency of requests to the
 perspective, which means that, for example, these latencies do not include the
 network latency between a client and the `webapp` deployment.
 
-## Outbound Metrics
+#### Outbound Metrics
 
 If you specify the `--to` flag then `linkerd viz routes` displays _outbound_
 metrics from the target resource to the resource in the `--to` flag. In contrast
@@ -119,7 +121,7 @@ linkerd viz routes deploy/traffic --to deploy/webapp
 Displays the request volume, success rate, and latency of requests from
 `traffic` to `webapp` from the perspective of the `traffic` deployment.
 
-## Effective and Actual Metrics
+#### Effective and Actual Metrics
 
 If you are looking at _outbound_ metrics (by specifying the `--to` flag) you can
 also supply the `-o wide` flag to differentiate between _effective_ and _actual_

--- a/linkerd.io/content/2.19/reference/cli/diagnostics.md
+++ b/linkerd.io/content/2.19/reference/cli/diagnostics.md
@@ -10,6 +10,8 @@ title: diagnostics
 
 ## Subcommands
 
+{{< docs/cli-subcommands "diagnostics" >}}
+
 ### controller-metrics
 
 {{< docs/cli-description "diagnostics controller-metrics" >}}

--- a/linkerd.io/content/2.19/reference/cli/multicluster.md
+++ b/linkerd.io/content/2.19/reference/cli/multicluster.md
@@ -10,6 +10,8 @@ title: multicluster
 
 ## Subcommands
 
+{{< docs/cli-subcommands "multicluster" >}}
+
 ### allow
 
 {{< docs/cli-description "multicluster allow" >}}

--- a/linkerd.io/content/2.19/reference/cli/viz.md
+++ b/linkerd.io/content/2.19/reference/cli/viz.md
@@ -10,7 +10,9 @@ title: viz
 
 ## Subcommands
 
-## allow-scrapes
+{{< docs/cli-subcommands "viz" >}}
+
+### allow-scrapes
 
 {{< docs/cli-description "viz allow-scrapes" >}}
 
@@ -18,7 +20,7 @@ title: viz
 
 {{< docs/cli-flags "viz allow-scrapes" >}}
 
-## authz
+### authz
 
 {{< docs/cli-description "viz authz" >}}
 
@@ -89,7 +91,7 @@ that is receiving the requests. For more information about how to create a
 service profile, see [service profiles](../../features/service-profiles/). and
 the [profile](profile) command reference.
 
-## Inbound Metrics
+#### Inbound Metrics
 
 By default, `routes` displays _inbound_ metrics for a target. In other words, it
 shows information about requests which are sent to the target and responses
@@ -104,7 +106,7 @@ Displays the request volume, success rate, and latency of requests to the
 perspective, which means that, for example, these latencies do not include the
 network latency between a client and the `webapp` deployment.
 
-## Outbound Metrics
+#### Outbound Metrics
 
 If you specify the `--to` flag then `linkerd viz routes` displays _outbound_
 metrics from the target resource to the resource in the `--to` flag. In contrast
@@ -119,7 +121,7 @@ linkerd viz routes deploy/traffic --to deploy/webapp
 Displays the request volume, success rate, and latency of requests from
 `traffic` to `webapp` from the perspective of the `traffic` deployment.
 
-## Effective and Actual Metrics
+#### Effective and Actual Metrics
 
 If you are looking at _outbound_ metrics (by specifying the `--to` flag) you can
 also supply the `-o wide` flag to differentiate between _effective_ and _actual_

--- a/linkerd.io/layouts/shortcodes/docs/cli-examples.html
+++ b/linkerd.io/layouts/shortcodes/docs/cli-examples.html
@@ -4,9 +4,9 @@
 {{- /* Output data */}}
 {{ range where $data.CLIReference "Name" (.Get 0) }}
   {{ with .Example }}
-    <h2>
+    <h4>
       Examples
-    </h2>
+    </h4>
     {{ highlight (replaceRE "(?m)^[ ]{2}" "" .) "bash" }}
   {{ end }}
 {{ end }}

--- a/linkerd.io/layouts/shortcodes/docs/cli-flags.html
+++ b/linkerd.io/layouts/shortcodes/docs/cli-flags.html
@@ -5,9 +5,9 @@
 {{ range where $data.CLIReference "Name" (.Get 0) }}
   {{ $opts := where .Options "Name" "!=" "help" }}
   {{ if ge (len $opts) 1 }}
-    <h2>
+    <h4>
       Flags
-    </h2>
+    </h4>
     <table class="keyval">
       <thead>
         <tr>

--- a/linkerd.io/layouts/shortcodes/docs/cli-subcommands.html
+++ b/linkerd.io/layouts/shortcodes/docs/cli-subcommands.html
@@ -1,0 +1,37 @@
+{{- /* Get the CLI data file for the current linkerd version */}}
+{{- $file := replace .Page.Section "." "-" }}
+{{- $data := index site.Data.cli $file }}
+{{- $cmd := .Get 0 }}
+{{- /* Output data */}}
+{{ if $cmd }}
+  <table class="keyval">
+    <thead>
+      <tr>
+        <th>
+          Subcommand
+        </th>
+        <th>
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      {{ range $data.CLIReference }}
+        {{ if hasPrefix .Name (printf "%s " $cmd) }}
+          {{ $subcmd := index (split .Name " ") 1 }}
+          {{ $href := printf "#%s" $subcmd }}
+          <tr>
+            <td>
+              <a href="{{ $href }}">
+                <code>{{ $subcmd }}</code>
+              </a>
+            </td>
+            <td>
+              {{ .Synopsis | markdownify }}
+            </td>
+          </tr>
+        {{ end }}
+      {{ end }}
+    </tbody>
+  </table>
+{{ end }}


### PR DESCRIPTION
This PR fixes 2 things:

1. On the [cli reference pages](https://linkerd.io/2.19/reference/cli/viz/#subcommands), the headers for Flags and Examples and a few other headers are the wrong level (for instance, Flags is an h2 but the command name is an h3).
2. The visibility of the subcommands is not great. For instance, if you're looking for the `tap` subcommand it can be hard to find.

With this PR:

- Fix header level consistency in cli reference pages
- Add table of subcommand on a command detail page

**Preview**
https://deploy-preview-2112--linkerdio.netlify.app/2.19/reference/cli/viz/#subcommands