### PR TITLE
Add /reference redirect to latest version (#1849)

### DIFF
--- a/linkerd.io/content/reference/_index.md
+++ b/linkerd.io/content/reference/_index.md
@@ -1,0 +1,9 @@
+---
+title: Reference
+
+# Redirect
+type: _default
+layout: redirect
+params:
+  redirect: /2/reference/
+---


### PR DESCRIPTION
Issue #1849 reports that `https://linkerd.io/reference` 404s. The versioned reference docs live at `linkerd.io/{version}/reference/`, but a reader needs to already know the version number to find them. The same problem was solved years ago for `/docs` via `linkerd.io/content/docs/_index.md`, which redirects through the Hugo `redirect` layout to `/2/getting-started/` and then onward to `/{latestMajorVersion}/getting-started/`.

This PR adds the equivalent file for `/reference/`. The new `linkerd.io/content/reference/_index.md` reuses the same `_default/redirect` layout with `params.redirect: /2/reference/`. The existing `redirect.html` template (`linkerd.io/layouts/_default/redirect.html`) rewrites `/2/{path}` into `/{latestMajorVersion}/{path}` at render time, so this entry will keep pointing at the current latest reference docs every time a new minor ships, without any further code change.

No existing pages live under `/reference/`, so there is no collision: a `gh api .../contents/linkerd.io/content/reference` lookup currently 404s on `main`.

Fixes #1849
