### PR TITLE
Improve template logic to find subcommands

### DIFF
--- a/linkerd.io/layouts/shortcodes/docs/cli-subcommands.html
+++ b/linkerd.io/layouts/shortcodes/docs/cli-subcommands.html
@@ -13,21 +13,19 @@
       </tr>
     </thead>
     <tbody>
-      {{ range $data.CLIReference }}
-        {{ if hasPrefix .Name (printf "%s " $cmd) }}
-          {{ $subcmd := index (split .Name " ") 1 }}
-          {{ $href := printf "#%s" $subcmd }}
-          <tr>
-            <td>
-              <a href="{{ $href }}">
-                <code>{{ $subcmd }}</code>
-              </a>
-            </td>
-            <td>
-              {{ .Synopsis | markdownify }}
-            </td>
-          </tr>
-        {{ end }}
+      {{ range where $data.CLIReference "Name" "like" (printf `^%s .+` $cmd) }}
+        {{ $subcmd := index (split .Name " ") 1 }}
+        {{ $href := printf "#%s" $subcmd }}
+        <tr>
+          <td>
+            <a href="{{ $href }}">
+              <code>{{ $subcmd }}</code>
+            </a>
+          </td>
+          <td>
+            {{ .Synopsis | markdownify }}
+          </td>
+        </tr>
       {{ end }}
     </tbody>
   </table>


### PR DESCRIPTION
On the current site, to find the subcommands for a certain command we loop through all of the commands looking for a certain prefix.

With this PR, the logic has been optimized to find these subcommands using the `like` operator.

There should not be any visible changes to the site:
https://linkerd.io/docs/reference/cli/multicluster/#subcommands
https://deploy-preview-2117--linkerdio.netlify.app/docs/reference/cli/multicluster/#subcommands
