### PR TITLE
Allow HTML content in Hugo v0.162.0

### DIFF
--- a/linkerd.io/config/_default/security.yaml
+++ b/linkerd.io/config/_default/security.yaml
@@ -1,0 +1,1 @@
+allowContent: ['.*']


### PR DESCRIPTION
With Hugo v0.162.0, HTML content files are denied by default, resulting in the build failing. A new `security.allowContent` policy controls which content media types may be used for pages under the `/content` directory. HTML content can opt back in with `security.allowContent: ['.*']`.

For reviewers: a new security param has been added, but since we do not build the production site with v0.162.0, this should be a no-op.
