### PR TITLE
fix: use sass-embedded in local setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ ifndef HAS_HUGO
 	@printf "Install hugo first. For OSX: brew install hugo\n"; exit 1
 endif
 ifndef HAS_SASS
-	@printf "Install Dart Sass first: npm install sass\n"; exit 1
+	@printf "Install Dart Sass Embedded first: npm install -g sass-embedded\n"; exit 1
 endif
 	cd tmp/linkerd.io && ./build
 

--- a/linkerd.io/README.md
+++ b/linkerd.io/README.md
@@ -12,11 +12,13 @@ docker run \
 
 ### Install Hugo to develop locally
 
-Install Dart Sass first:
+Install Dart Sass Embedded first:
 
 ```bash
-brew install sass/sass/sass
+npm install -g sass-embedded
 ```
+
+This installs the `sass` executable that Hugo expects when building the site.
 
 Then install Hugo:
 


### PR DESCRIPTION
Problem
Fresh local setup still points people at plain `sass`, but that can break the Hugo build with `TOCSS-DART ... got unexpected EOF when executing "sass"`. Pretty easy to hit.

Fix
Point the README and Makefile hint to `sass-embedded`, which makes the same build pass.

Repro
1. `tmp=$(mktemp -d) && cd "$tmp"`
2. `npm init -y >/dev/null 2>&1 && npm install --save-dev sass >/dev/null 2>&1`
3. `PATH="$tmp/node_modules/.bin:$PATH" hugo -s /path/to/website/linkerd.io --minify --cleanDestinationDir`
4. see the `TOCSS-DART` error
