### PR TITLE
fix: avoid copying cert-manager labels/annotations to linkerd-previous-anchor

### DIFF
--- a/linkerd.io/content/2-edge/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2-edge/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -407,10 +407,9 @@ you'll need to modify this command to do the right thing for your resource type.
 {{< /note >}}
 
 ```bash
-kubectl get secret -n cert-manager linkerd-trust-anchor -o yaml \
-        | sed -e s/linkerd-trust-anchor/linkerd-previous-anchor/ \
-        | egrep -v '^  *(resourceVersion|uid)' \
-        | kubectl apply -f -
+kubectl -n cert-manager get secret linkerd-trust-anchor -o json \
+  | jq '{apiVersion: .apiVersion, kind: .kind, metadata: {name: "linkerd-previous-anchor", namespace: .metadata.namespace}, type: .type, data: .data}' \
+  | kubectl apply -f -
 ```
 
 This way, when cert-manager rotates the trust anchor and updates the
@@ -928,10 +927,9 @@ you'll need to modify this command to do the right thing for your resource type.
 {{< /note >}}
 
 ```bash
-kubectl get secret -n cert-manager linkerd-trust-anchor -o yaml \
-        | sed -e s/linkerd-trust-anchor/linkerd-previous-anchor/ \
-        | egrep -v '^  *(resourceVersion|uid)' \
-        | kubectl apply -f -
+kubectl -n cert-manager get secret linkerd-trust-anchor -o json \
+  | jq '{apiVersion: .apiVersion, kind: .kind, metadata: {name: "linkerd-previous-anchor", namespace: .metadata.namespace}, type: .type, data: .data}' \
+  | kubectl apply -f -
 ```
 
 You can doublecheck this with `kubectl` again:

--- a/linkerd.io/content/2.14/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.14/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -407,10 +407,9 @@ you'll need to modify this command to do the right thing for your resource type.
 {{< /note >}}
 
 ```bash
-kubectl get secret -n cert-manager linkerd-trust-anchor -o yaml \
-        | sed -e s/linkerd-trust-anchor/linkerd-previous-anchor/ \
-        | egrep -v '^  *(resourceVersion|uid)' \
-        | kubectl apply -f -
+kubectl -n cert-manager get secret linkerd-trust-anchor -o json \
+  | jq '{apiVersion: .apiVersion, kind: .kind, metadata: {name: "linkerd-previous-anchor", namespace: .metadata.namespace}, type: .type, data: .data}' \
+  | kubectl apply -f -
 ```
 
 This way, when cert-manager rotates the trust anchor and updates the
@@ -928,10 +927,9 @@ you'll need to modify this command to do the right thing for your resource type.
 {{< /note >}}
 
 ```bash
-kubectl get secret -n cert-manager linkerd-trust-anchor -o yaml \
-        | sed -e s/linkerd-trust-anchor/linkerd-previous-anchor/ \
-        | egrep -v '^  *(resourceVersion|uid)' \
-        | kubectl apply -f -
+kubectl -n cert-manager get secret linkerd-trust-anchor -o json \
+  | jq '{apiVersion: .apiVersion, kind: .kind, metadata: {name: "linkerd-previous-anchor", namespace: .metadata.namespace}, type: .type, data: .data}' \
+  | kubectl apply -f -
 ```
 
 You can doublecheck this with `kubectl` again:

--- a/linkerd.io/content/2.15/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.15/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -407,10 +407,9 @@ you'll need to modify this command to do the right thing for your resource type.
 {{< /note >}}
 
 ```bash
-kubectl get secret -n cert-manager linkerd-trust-anchor -o yaml \
-        | sed -e s/linkerd-trust-anchor/linkerd-previous-anchor/ \
-        | egrep -v '^  *(resourceVersion|uid)' \
-        | kubectl apply -f -
+kubectl -n cert-manager get secret linkerd-trust-anchor -o json \
+  | jq '{apiVersion: .apiVersion, kind: .kind, metadata: {name: "linkerd-previous-anchor", namespace: .metadata.namespace}, type: .type, data: .data}' \
+  | kubectl apply -f -
 ```
 
 This way, when cert-manager rotates the trust anchor and updates the
@@ -928,10 +927,9 @@ you'll need to modify this command to do the right thing for your resource type.
 {{< /note >}}
 
 ```bash
-kubectl get secret -n cert-manager linkerd-trust-anchor -o yaml \
-        | sed -e s/linkerd-trust-anchor/linkerd-previous-anchor/ \
-        | egrep -v '^  *(resourceVersion|uid)' \
-        | kubectl apply -f -
+kubectl -n cert-manager get secret linkerd-trust-anchor -o json \
+  | jq '{apiVersion: .apiVersion, kind: .kind, metadata: {name: "linkerd-previous-anchor", namespace: .metadata.namespace}, type: .type, data: .data}' \
+  | kubectl apply -f -
 ```
 
 You can doublecheck this with `kubectl` again:

--- a/linkerd.io/content/2.16/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.16/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -407,10 +407,9 @@ you'll need to modify this command to do the right thing for your resource type.
 {{< /note >}}
 
 ```bash
-kubectl get secret -n cert-manager linkerd-trust-anchor -o yaml \
-        | sed -e s/linkerd-trust-anchor/linkerd-previous-anchor/ \
-        | egrep -v '^  *(resourceVersion|uid)' \
-        | kubectl apply -f -
+kubectl -n cert-manager get secret linkerd-trust-anchor -o json \
+  | jq '{apiVersion: .apiVersion, kind: .kind, metadata: {name: "linkerd-previous-anchor", namespace: .metadata.namespace}, type: .type, data: .data}' \
+  | kubectl apply -f -
 ```
 
 This way, when cert-manager rotates the trust anchor and updates the
@@ -928,10 +927,9 @@ you'll need to modify this command to do the right thing for your resource type.
 {{< /note >}}
 
 ```bash
-kubectl get secret -n cert-manager linkerd-trust-anchor -o yaml \
-        | sed -e s/linkerd-trust-anchor/linkerd-previous-anchor/ \
-        | egrep -v '^  *(resourceVersion|uid)' \
-        | kubectl apply -f -
+kubectl -n cert-manager get secret linkerd-trust-anchor -o json \
+  | jq '{apiVersion: .apiVersion, kind: .kind, metadata: {name: "linkerd-previous-anchor", namespace: .metadata.namespace}, type: .type, data: .data}' \
+  | kubectl apply -f -
 ```
 
 You can doublecheck this with `kubectl` again:

--- a/linkerd.io/content/2.17/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.17/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -407,10 +407,9 @@ you'll need to modify this command to do the right thing for your resource type.
 {{< /note >}}
 
 ```bash
-kubectl get secret -n cert-manager linkerd-trust-anchor -o yaml \
-        | sed -e s/linkerd-trust-anchor/linkerd-previous-anchor/ \
-        | egrep -v '^  *(resourceVersion|uid)' \
-        | kubectl apply -f -
+kubectl -n cert-manager get secret linkerd-trust-anchor -o json \
+  | jq '{apiVersion: .apiVersion, kind: .kind, metadata: {name: "linkerd-previous-anchor", namespace: .metadata.namespace}, type: .type, data: .data}' \
+  | kubectl apply -f -
 ```
 
 This way, when cert-manager rotates the trust anchor and updates the
@@ -928,10 +927,9 @@ you'll need to modify this command to do the right thing for your resource type.
 {{< /note >}}
 
 ```bash
-kubectl get secret -n cert-manager linkerd-trust-anchor -o yaml \
-        | sed -e s/linkerd-trust-anchor/linkerd-previous-anchor/ \
-        | egrep -v '^  *(resourceVersion|uid)' \
-        | kubectl apply -f -
+kubectl -n cert-manager get secret linkerd-trust-anchor -o json \
+  | jq '{apiVersion: .apiVersion, kind: .kind, metadata: {name: "linkerd-previous-anchor", namespace: .metadata.namespace}, type: .type, data: .data}' \
+  | kubectl apply -f -
 ```
 
 You can doublecheck this with `kubectl` again:

--- a/linkerd.io/content/2.18/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/2.18/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -407,10 +407,9 @@ you'll need to modify this command to do the right thing for your resource type.
 {{< /note >}}
 
 ```bash
-kubectl get secret -n cert-manager linkerd-trust-anchor -o yaml \
-        | sed -e s/linkerd-trust-anchor/linkerd-previous-anchor/ \
-        | egrep -v '^  *(resourceVersion|uid)' \
-        | kubectl apply -f -
+kubectl -n cert-manager get secret linkerd-trust-anchor -o json \
+  | jq '{apiVersion: .apiVersion, kind: .kind, metadata: {name: "linkerd-previous-anchor", namespace: .metadata.namespace}, type: .type, data: .data}' \
+  | kubectl apply -f -
 ```
 
 This way, when cert-manager rotates the trust anchor and updates the
@@ -928,10 +927,9 @@ you'll need to modify this command to do the right thing for your resource type.
 {{< /note >}}
 
 ```bash
-kubectl get secret -n cert-manager linkerd-trust-anchor -o yaml \
-        | sed -e s/linkerd-trust-anchor/linkerd-previous-anchor/ \
-        | egrep -v '^  *(resourceVersion|uid)' \
-        | kubectl apply -f -
+kubectl -n cert-manager get secret linkerd-trust-anchor -o json \
+  | jq '{apiVersion: .apiVersion, kind: .kind, metadata: {name: "linkerd-previous-anchor", namespace: .metadata.namespace}, type: .type, data: .data}' \
+  | kubectl apply -f -
 ```
 
 You can doublecheck this with `kubectl` again:

--- a/linkerd.io/content/docs/tasks/automatically-rotating-control-plane-tls-credentials.md
+++ b/linkerd.io/content/docs/tasks/automatically-rotating-control-plane-tls-credentials.md
@@ -407,10 +407,9 @@ you'll need to modify this command to do the right thing for your resource type.
 {{< /note >}}
 
 ```bash
-kubectl get secret -n cert-manager linkerd-trust-anchor -o yaml \
-        | sed -e s/linkerd-trust-anchor/linkerd-previous-anchor/ \
-        | egrep -v '^  *(resourceVersion|uid)' \
-        | kubectl apply -f -
+kubectl -n cert-manager get secret linkerd-trust-anchor -o json \
+  | jq '{apiVersion: .apiVersion, kind: .kind, metadata: {name: "linkerd-previous-anchor", namespace: .metadata.namespace}, type: .type, data: .data}' \
+  | kubectl apply -f -
 ```
 
 This way, when cert-manager rotates the trust anchor and updates the
@@ -928,10 +927,9 @@ you'll need to modify this command to do the right thing for your resource type.
 {{< /note >}}
 
 ```bash
-kubectl get secret -n cert-manager linkerd-trust-anchor -o yaml \
-        | sed -e s/linkerd-trust-anchor/linkerd-previous-anchor/ \
-        | egrep -v '^  *(resourceVersion|uid)' \
-        | kubectl apply -f -
+kubectl -n cert-manager get secret linkerd-trust-anchor -o json \
+  | jq '{apiVersion: .apiVersion, kind: .kind, metadata: {name: "linkerd-previous-anchor", namespace: .metadata.namespace}, type: .type, data: .data}' \
+  | kubectl apply -f -
 ```
 
 You can doublecheck this with `kubectl` again:


### PR DESCRIPTION
The previous sed/egrep pipeline copied cert-manager labels/annotations to linkerd-previous-anchor, causing cainjector to log "unable to fetch certificate that owns the secret".

Replaced it with a `jq` filter that reconstructs only the necessary fields, so no cert-manager labels or annotations are carried over.