### PR TITLE
fix: clarify ingress mode header warning

### DIFF
--- a/linkerd.io/content/2-edge/tasks/using-ingress.md
+++ b/linkerd.io/content/2-edge/tasks/using-ingress.md
@@ -51,9 +51,10 @@ other resources in the ingress namespace are be meshed normally.
 
 {{< warning id=open-relay-warning >}}
 
-When an ingress is meshed in ingress mode, you _must_ configure it to remove the
-`l5d-dst-override` header to avoid creating an open relay to cluster-local and
-external endpoints.
+When an ingress is meshed in ingress mode, you _must_ configure it to strip any
+incoming `l5d-dst-override` header from client traffic to avoid creating an
+open relay to cluster-local and external endpoints. The ingress controller can
+still add its own `l5d-dst-override` header for requests to internal services.
 
 {{< /warning >}}
 

--- a/linkerd.io/content/2.18/tasks/using-ingress.md
+++ b/linkerd.io/content/2.18/tasks/using-ingress.md
@@ -51,9 +51,10 @@ other resources in the ingress namespace are be meshed normally.
 
 {{< warning id=open-relay-warning >}}
 
-When an ingress is meshed in ingress mode, you _must_ configure it to remove the
-`l5d-dst-override` header to avoid creating an open relay to cluster-local and
-external endpoints.
+When an ingress is meshed in ingress mode, you _must_ configure it to strip any
+incoming `l5d-dst-override` header from client traffic to avoid creating an
+open relay to cluster-local and external endpoints. The ingress controller can
+still add its own `l5d-dst-override` header for requests to internal services.
 
 {{< /warning >}}
 

--- a/linkerd.io/content/docs/tasks/using-ingress.md
+++ b/linkerd.io/content/docs/tasks/using-ingress.md
@@ -51,9 +51,10 @@ other resources in the ingress namespace are be meshed normally.
 
 {{< warning id=open-relay-warning >}}
 
-When an ingress is meshed in ingress mode, you _must_ configure it to remove the
-`l5d-dst-override` header to avoid creating an open relay to cluster-local and
-external endpoints.
+When an ingress is meshed in ingress mode, you _must_ configure it to strip any
+incoming `l5d-dst-override` header from client traffic to avoid creating an
+open relay to cluster-local and external endpoints. The ingress controller can
+still add its own `l5d-dst-override` header for requests to internal services.
 
 {{< /warning >}}
 


### PR DESCRIPTION
Fixes #1837

Bug
The live ingress docs say ingress mode must remove `l5d-dst-override`, but the same page later tells Traefik to add it. Kinda mixed signals, and easy to read the wrong way.

Fix
Clarify that ingress mode must strip `l5d-dst-override` from incoming client traffic, while still allowing the ingress controller to add its own header for in-cluster routing.

Repro
1. Open `https://linkerd.io/docs/tasks/using-ingress/`
2. Read the warning in the ingress mode section
3. Scroll to the Traefik examples
4. See the warning says remove the header, while the examples add it

Checks
- `make lint`
- `PATH="/tmp/bin:/tmp/linkerd-tools/node_modules/.bin:$PATH" make check`
