### PR TITLE
docs: fix typo in HTTPRoute reference docs

### DIFF
--- a/linkerd.io/content/2-edge/reference/httproute.md
+++ b/linkerd.io/content/2-edge/reference/httproute.md
@@ -240,13 +240,13 @@ A filter which modifies HTTP request or response headers.
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
 | `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
-| `path`       | An [httpPathModfier](#httppathmodfier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
+| `path`       | An [HTTPPathModifier](#httppathmodifier) which modifies the path of the incoming request and uses the modified path in the `Location` header.|
 | `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
 | `statusCode` | The HTTP status code to be used in response.                                                                                                |
 
 {{< /keyval >}}
 
-### httpPathModfier
+### HTTPPathModifier
 
 `HTTPPathModifier` defines configuration for path modifiers.
 

--- a/linkerd.io/content/2-edge/reference/httproute.md
+++ b/linkerd.io/content/2-edge/reference/httproute.md
@@ -110,7 +110,7 @@ GEP-1426][ns-boundaries] for details on producer and consumer routes.
 
 {{< /keyval >}}
 
-### httpRouteRule
+### HTTPRouteRule
 
 HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 (matches) and processing it (filters).
@@ -119,14 +119,14 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 
 | field         | value                                                                                                                                                       |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `matches`     | A list of [httpRouteMatches](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
-| `filters`     | A list of [httpRouteFilters](#httproutefilter) which will be applied to each request which matches this rule.                                               |
-| `backendRefs` | An array of [HTTPBackendRefs](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
-| `timeouts`    | An optional [httpRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
+| `matches`     | A list of [HTTPRouteMatch](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
+| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) which will be applied to each request which matches this rule.                                               |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
+| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
 
 {{< /keyval >}}
 
-### httpRouteMatch
+### HTTPRouteMatch
 
 HTTPRouteMatch defines the predicate used to match requests to a given action.
 Multiple match types are ANDed together, i.e. the match will evaluate to true
@@ -136,14 +136,14 @@ only if all conditions are satisfied.
 
 | field         | value                                                                                                                   |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `path`        | An [httpPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
-| `headers`     | A list of [httpHeaderMatches](#httpheadermatch). Multiple match values are ANDed together.                              |
-| `queryParams` | A list of [httpQueryParamMatches](#httpqueryparammatch). Multiple match values are ANDed together.                      |
+| `path`        | An [HTTPPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
+| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch). Multiple match values are ANDed together.                              |
+| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch). Multiple match values are ANDed together.                      |
 | `method`      | When specified, this route will be matched only if the request has the specified method.                                |
 
 {{< /keyval >}}
 
-### httpPathMatch
+### HTTPPathMatch
 
 `HTTPPathMatch` describes how to select a HTTP route by matching the HTTP
 request path.
@@ -157,7 +157,7 @@ request path.
 
 {{< /keyval >}}
 
-### httpHeaderMatch
+### HTTPHeaderMatch
 
 `HTTPHeaderMatch` describes how to select a HTTP route by matching HTTP request
 headers.
@@ -187,7 +187,7 @@ query parameters.
 
 {{< /keyval >}}
 
-### httpRouteFilter
+### HTTPRouteFilter
 
 HTTPRouteFilter defines processing steps that must be completed during the
 request or response lifecycle.
@@ -197,13 +197,13 @@ request or response lifecycle.
 | field                    | value                                                                      |
 | ------------------------ | -------------------------------------------------------------------------- |
 | `type`                   | One of: RequestHeaderModifier, ResponseHeaderModifier, or RequestRedirect. |
-| `requestHeaderModifier`  | An [httpHeaderFilter](#httpheaderfilter) which modifies request headers.   |
-| `responseHeaderModifier` | An [httpHeaderFilter](#httpheaderfilter) which modifies response headers.  |
-| `requestRedirect`        | An [httpRequestRedirectFilter](#httprequestredirectfilter).                |
+| `requestHeaderModifier`  | An [HTTPHeaderFilter](#httpheaderfilter) which modifies request headers.   |
+| `responseHeaderModifier` | An [HTTPHeaderFilter](#httpheaderfilter) which modifies response headers.  |
+| `requestRedirect`        | An [HTTPRequestRedirectFilter](#httprequestredirectfilter).                |
 
 {{< /keyval >}}
 
-### httpHeaderFilter
+### HTTPHeaderFilter
 
 A filter which modifies HTTP request or response headers.
 
@@ -211,13 +211,13 @@ A filter which modifies HTTP request or response headers.
 
 | field    | value                                                                                                       |
 | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `set`    | A list of [httpHeaders](#httpheader) to overwrite on the request or response.                               |
-| `add`    | A list of [httpHeaders](#httpheader) to add on to the request or response, appending to any existing value. |
+| `set`    | A list of [HTTPHeader](#httpheader) to overwrite on the request or response.                               |
+| `add`    | A list of [HTTPHeader](#httpheader) to add on to the request or response, appending to any existing value. |
 | `remove` | A list of header names to remove from the request or response.                                              |
 
 {{< /keyval >}}
 
-### httpHeader
+### HTTPHeader
 
 `HTTPHeader` represents an HTTP Header name and value as defined by RFC 7230.
 
@@ -230,7 +230,7 @@ A filter which modifies HTTP request or response headers.
 
 {{< /keyval >}}
 
-### httpRequestRedirectFilter
+### HTTPRequestRedirectFilter
 
 `HTTPRequestRedirect` defines a filter that redirects a request.
 
@@ -260,7 +260,7 @@ A filter which modifies HTTP request or response headers.
 
 {{< /keyval >}}
 
-### httpBackendRef
+### HTTPBackendRef
 
 `HTTPBackendRef` defines the list of objects where matching requests should be
 sent to. Only allowed when a route has Service [parentRefs](#parentreference).
@@ -276,7 +276,7 @@ sent to. Only allowed when a route has Service [parentRefs](#parentreference).
 
 {{< /keyval >}}
 
-### httpRouteTimeouts
+### HTTPRouteTimeouts
 
 `HTTPRouteTimeouts` defines the timeouts that can be configured for an HTTP
 request.

--- a/linkerd.io/content/2-edge/reference/httproute.md
+++ b/linkerd.io/content/2-edge/reference/httproute.md
@@ -121,7 +121,7 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `matches`     | A list of [HTTPRouteMatch](#httproutematch) resources. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
 | `filters`     | A list of [HTTPRouteFilter](#httproutefilter) resources which will be applied to each request which matches this rule.                                       |
-| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) resources to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
 | `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                        |
 
 {{< /keyval >}}

--- a/linkerd.io/content/2-edge/reference/httproute.md
+++ b/linkerd.io/content/2-edge/reference/httproute.md
@@ -117,12 +117,12 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 
 {{< keyval >}}
 
-| field         | value                                                                                                                                                       |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `matches`     | A list of [HTTPRouteMatch](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
-| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) which will be applied to each request which matches this rule.                                               |
-| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
-| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
+| field         | value                                                                                                                                                        |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `matches`     | A list of [HTTPRouteMatch](#httproutematch) resources. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
+| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) resources which will be applied to each request which matches this rule.                                       |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
+| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                        |
 
 {{< /keyval >}}
 
@@ -137,8 +137,8 @@ only if all conditions are satisfied.
 | field         | value                                                                                                                   |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `path`        | An [HTTPPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
-| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch). Multiple match values are ANDed together.                              |
-| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch). Multiple match values are ANDed together.                      |
+| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch) resources. Multiple match values are ANDed together.                      |
+| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch) resources. Multiple match values are ANDed together.              |
 | `method`      | When specified, this route will be matched only if the request has the specified method.                                |
 
 {{< /keyval >}}
@@ -209,11 +209,11 @@ A filter which modifies HTTP request or response headers.
 
 {{< keyval >}}
 
-| field    | value                                                                                                       |
-| -------- | ----------------------------------------------------------------------------------------------------------- |
-| `set`    | A list of [HTTPHeader](#httpheader) to overwrite on the request or response.                               |
-| `add`    | A list of [HTTPHeader](#httpheader) to add on to the request or response, appending to any existing value. |
-| `remove` | A list of header names to remove from the request or response.                                              |
+| field    | value                                                                                                                |
+| -------- | -------------------------------------------------------------------------------------------------------------------- |
+| `set`    | A list of [HTTPHeader](#httpheader) resources to overwrite on the request or response.                               |
+| `add`    | A list of [HTTPHeader](#httpheader) resources to add on to the request or response, appending to any existing value. |
+| `remove` | A list of header names to remove from the request or response.                                                       |
 
 {{< /keyval >}}
 
@@ -236,13 +236,13 @@ A filter which modifies HTTP request or response headers.
 
 {{< keyval >}}
 
-| field        | value                                                                                                                                       |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
-| `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
-| `path`       | An [HTTPPathModifier](#httppathmodifier) which modifies the path of the incoming request and uses the modified path in the `Location` header.|
-| `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
-| `statusCode` | The HTTP status code to be used in response.                                                                                                |
+| field        | value                                                                                                                                         |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                   |
+| `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.               |
+| `path`       | An [HTTPPathModifier](#httppathmodifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
+| `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.            |
+| `statusCode` | The HTTP status code to be used in response.                                                                                                  |
 
 {{< /keyval >}}
 

--- a/linkerd.io/content/2-edge/reference/httproute.md
+++ b/linkerd.io/content/2-edge/reference/httproute.md
@@ -172,7 +172,7 @@ headers.
 
 {{< /keyval >}}
 
-### httpQueryParamMatch
+### HTTPQueryParamMatch
 
 `HTTPQueryParamMatch` describes how to select a HTTP route by matching HTTP
 query parameters.

--- a/linkerd.io/content/2.12/reference/authorization-policy.md
+++ b/linkerd.io/content/2.12/reference/authorization-policy.md
@@ -315,13 +315,13 @@ A filter which modifies request headers.
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
 | `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
-| `path`       | An [httpPathModfier](#httppathmodfier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
+| `path`       | An [HTTPPathModifier](#HTTPPathModifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
 | `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
 | `statusCode` | The HTTP status code to be used in response.                                                                                                |
 
 {{< /keyval >}}
 
-#### httpPathModfier
+#### HTTPPathModifier
 
 `HTTPPathModifier` defines configuration for path modifiers.
 

--- a/linkerd.io/content/2.12/reference/authorization-policy.md
+++ b/linkerd.io/content/2.12/reference/authorization-policy.md
@@ -188,7 +188,7 @@ A reference to the [Servers] this `HTTPRoute` is a part of.
 
 {{< /keyval >}}
 
-#### httpRouteRule
+#### HTTPRouteRule
 
 `HTTPRouteRule` defines semantics for matching an HTTP request based on
 conditions (matches) and processing it (filters).
@@ -197,12 +197,12 @@ conditions (matches) and processing it (filters).
 
 | field     | value                                                                                                                                                |
 | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `matches` | A list of [httpRouteMatches](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
-| `filters` | A list of [httpRouteFilters](#httproutefilter) which will be applied to each request which matches this rule.                                        |
+| `matches` | A list of [HTTPRouteMatch](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
+| `filters` | A list of [HTTPRouteFilter](#httproutefilter) which will be applied to each request which matches this rule.                                        |
 
 {{< /keyval >}}
 
-#### httpRouteMatch
+#### HTTPRouteMatch
 
 `HTTPRouteMatch` defines the predicate used to match requests to a given action.
 Multiple match types are ANDed together, i.e. the match will evaluate to true
@@ -212,14 +212,14 @@ only if all conditions are satisfied.
 
 | field         | value                                                                                                                   |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `path`        | An [httpPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
-| `headers`     | A list of [httpHeaderMatches](#httpheadermatch). Multiple match values are ANDed together.                              |
-| `queryParams` | A list of [httpQueryParamMatches](#httpqueryparammatch). Multiple match values are ANDed together.                      |
+| `path`        | An [HTTPPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
+| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch). Multiple match values are ANDed together.                              |
+| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch). Multiple match values are ANDed together.                      |
 | `method`      | When specified, this route will be matched only if the request has the specified method.                                |
 
 {{< /keyval >}}
 
-#### httpPathMatch
+#### HTTPPathMatch
 
 `HTTPPathMatch` describes how to select a HTTP route by matching the HTTP
 request path.
@@ -233,7 +233,7 @@ request path.
 
 {{< /keyval >}}
 
-#### httpHeaderMatch
+#### HTTPHeaderMatch
 
 `HTTPHeaderMatch` describes how to select a HTTP route by matching HTTP request
 headers.
@@ -248,7 +248,7 @@ headers.
 
 {{< /keyval >}}
 
-#### httpQueryParamMatch
+#### HTTPQueryParamMatch
 
 `HTTPQueryParamMatch` describes how to select a HTTP route by matching HTTP
 query parameters.
@@ -263,7 +263,7 @@ query parameters.
 
 {{< /keyval >}}
 
-#### httpRouteFilter
+#### HTTPRouteFilter
 
 `HTTPRouteFilter` defines processing steps that must be completed during the
 request or response lifecycle.
@@ -273,12 +273,12 @@ request or response lifecycle.
 | field                   | value                                                       |
 | ----------------------- | ----------------------------------------------------------- |
 | `type`                  | One of: RequestHeaderModifier, RequestRedirect.             |
-| `requestHeaderModifier` | An [httpRequestHeaderFilter](#httprequestheaderfilter).     |
-| `requestRedirect`       | An [httpRequestRedirectFilter](#httprequestredirectfilter). |
+| `requestHeaderModifier` | An [HTTPRequestHeaderFilter](#httprequestheaderfilter).     |
+| `requestRedirect`       | An [HTTPRequestRedirectFilter](#httprequestredirectfilter). |
 
 {{< /keyval >}}
 
-#### httpRequestHeaderFilter
+#### HTTPRequestHeaderFilter
 
 A filter which modifies request headers.
 
@@ -286,13 +286,13 @@ A filter which modifies request headers.
 
 | field    | value                                                                                        |
 | -------- | -------------------------------------------------------------------------------------------- |
-| `set`    | A list of [httpHeaders](#httpheader) to overwrites on the request.                           |
-| `add`    | A list of [httpHeaders](#httpheader) to add on the request, appending to any existing value. |
+| `set`    | A list of [HTTPHeader](#httpheader) to overwrites on the request.                           |
+| `add`    | A list of [HTTPHeader](#httpheader) to add on the request, appending to any existing value. |
 | `remove` | A list of header names to remove from the request.                                           |
 
 {{< /keyval >}}
 
-#### httpHeader
+#### HTTPHeader
 
 `HTTPHeader` represents an HTTP Header name and value as defined by RFC 7230.
 
@@ -305,7 +305,7 @@ A filter which modifies request headers.
 
 {{< /keyval >}}
 
-#### httpRequestRedirectFilter
+#### HTTPRequestRedirectFilter
 
 `HTTPRequestRedirect` defines a filter that redirects a request.
 

--- a/linkerd.io/content/2.12/reference/authorization-policy.md
+++ b/linkerd.io/content/2.12/reference/authorization-policy.md
@@ -195,10 +195,10 @@ conditions (matches) and processing it (filters).
 
 {{< keyval >}}
 
-| field     | value                                                                                                                                                |
-| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `matches` | A list of [HTTPRouteMatch](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
-| `filters` | A list of [HTTPRouteFilter](#httproutefilter) which will be applied to each request which matches this rule.                                        |
+| field     | value                                                                                                                                                        |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `matches` | A list of [HTTPRouteMatch](#httproutematch) resources. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
+| `filters` | A list of [HTTPRouteFilter](#httproutefilter) resources which will be applied to each request which matches this rule.                                       |
 
 {{< /keyval >}}
 
@@ -213,8 +213,8 @@ only if all conditions are satisfied.
 | field         | value                                                                                                                   |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `path`        | An [HTTPPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
-| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch). Multiple match values are ANDed together.                              |
-| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch). Multiple match values are ANDed together.                      |
+| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch) resources. Multiple match values are ANDed together.                      |
+| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch) resources. Multiple match values are ANDed together.              |
 | `method`      | When specified, this route will be matched only if the request has the specified method.                                |
 
 {{< /keyval >}}
@@ -284,11 +284,11 @@ A filter which modifies request headers.
 
 {{< keyval >}}
 
-| field    | value                                                                                        |
-| -------- | -------------------------------------------------------------------------------------------- |
-| `set`    | A list of [HTTPHeader](#httpheader) to overwrites on the request.                           |
-| `add`    | A list of [HTTPHeader](#httpheader) to add on the request, appending to any existing value. |
-| `remove` | A list of header names to remove from the request.                                           |
+| field    | value                                                                                                 |
+| -------- | ----------------------------------------------------------------------------------------------------- |
+| `set`    | A list of [HTTPHeader](#httpheader) resources to overwrites on the request.                           |
+| `add`    | A list of [HTTPHeader](#httpheader) resources to add on the request, appending to any existing value. |
+| `remove` | A list of header names to remove from the request.                                                    |
 
 {{< /keyval >}}
 
@@ -311,13 +311,13 @@ A filter which modifies request headers.
 
 {{< keyval >}}
 
-| field        | value                                                                                                                                       |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
-| `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
+| field        | value                                                                                                                                         |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                   |
+| `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.               |
 | `path`       | An [HTTPPathModifier](#httppathmodifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
-| `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
-| `statusCode` | The HTTP status code to be used in response.                                                                                                |
+| `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.            |
+| `statusCode` | The HTTP status code to be used in response.                                                                                                  |
 
 {{< /keyval >}}
 

--- a/linkerd.io/content/2.12/reference/authorization-policy.md
+++ b/linkerd.io/content/2.12/reference/authorization-policy.md
@@ -315,7 +315,7 @@ A filter which modifies request headers.
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
 | `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
-| `path`       | An [HTTPPathModifier](#HTTPPathModifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
+| `path`       | An [HTTPPathModifier](#httppathmodifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
 | `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
 | `statusCode` | The HTTP status code to be used in response.                                                                                                |
 

--- a/linkerd.io/content/2.13/reference/httproute.md
+++ b/linkerd.io/content/2.13/reference/httproute.md
@@ -180,13 +180,13 @@ A filter which modifies request headers.
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
 | `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
-| `path`       | An [httpPathModfier](#httppathmodfier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
+| `path`       | An [HTTPPathModifier](#HTTPPathModifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
 | `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
 | `statusCode` | The HTTP status code to be used in response.                                                                                                |
 
 {{< /keyval >}}
 
-### httpPathModfier
+### HTTPPathModifier
 
 `HTTPPathModifier` defines configuration for path modifiers.
 

--- a/linkerd.io/content/2.13/reference/httproute.md
+++ b/linkerd.io/content/2.13/reference/httproute.md
@@ -59,11 +59,11 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 
 {{< keyval >}}
 
-| field         | value                                                                                                                                                       |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `matches`     | A list of [HTTPRouteMatch](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
-| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) which will be applied to each request which matches this rule.                                               |
-| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
+| field         | value                                                                                                                                                        |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `matches`     | A list of [HTTPRouteMatch](#httproutematch) resources. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
+| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) resources which will be applied to each request which matches this rule.                                       |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
 
 {{< /keyval >}}
 
@@ -78,8 +78,8 @@ only if all conditions are satisfied.
 | field         | value                                                                                                                   |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `path`        | An [HTTPPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
-| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch). Multiple match values are ANDed together.                              |
-| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch). Multiple match values are ANDed together.                      |
+| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch) resources. Multiple match values are ANDed together.                      |
+| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch) resources. Multiple match values are ANDed together.              |
 | `method`      | When specified, this route will be matched only if the request has the specified method.                                |
 
 {{< /keyval >}}
@@ -149,11 +149,11 @@ A filter which modifies request headers.
 
 {{< keyval >}}
 
-| field    | value                                                                                        |
-| -------- | -------------------------------------------------------------------------------------------- |
-| `set`    | A list of [HTTPHeader](#httpheader) to overwrites on the request.                           |
-| `add`    | A list of [HTTPHeader](#httpheader) to add on the request, appending to any existing value. |
-| `remove` | A list of header names to remove from the request.                                           |
+| field    | value                                                                                                 |
+| -------- | ----------------------------------------------------------------------------------------------------- |
+| `set`    | A list of [HTTPHeader](#httpheader) resources to overwrites on the request.                           |
+| `add`    | A list of [HTTPHeader](#httpheader) resources to add on the request, appending to any existing value. |
+| `remove` | A list of header names to remove from the request.                                                    |
 
 {{< /keyval >}}
 
@@ -176,13 +176,13 @@ A filter which modifies request headers.
 
 {{< keyval >}}
 
-| field        | value                                                                                                                                       |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
-| `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
+| field        | value                                                                                                                                         |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                   |
+| `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.               |
 | `path`       | An [HTTPPathModifier](#httppathmodifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
-| `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
-| `statusCode` | The HTTP status code to be used in response.                                                                                                |
+| `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.            |
+| `statusCode` | The HTTP status code to be used in response.                                                                                                  |
 
 {{< /keyval >}}
 

--- a/linkerd.io/content/2.13/reference/httproute.md
+++ b/linkerd.io/content/2.13/reference/httproute.md
@@ -63,7 +63,7 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `matches`     | A list of [HTTPRouteMatch](#httproutematch) resources. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
 | `filters`     | A list of [HTTPRouteFilter](#httproutefilter) resources which will be applied to each request which matches this rule.                                       |
-| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) resources to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
 
 {{< /keyval >}}
 

--- a/linkerd.io/content/2.13/reference/httproute.md
+++ b/linkerd.io/content/2.13/reference/httproute.md
@@ -52,7 +52,7 @@ HTTPRoute configuration, as long as the ServiceProfile exists.
 
 {{< /keyval >}}
 
-### httpRouteRule
+### HTTPRouteRule
 
 HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 (matches) and processing it (filters).
@@ -61,13 +61,13 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 
 | field         | value                                                                                                                                                       |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `matches`     | A list of [httpRouteMatches](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
-| `filters`     | A list of [httpRouteFilters](#httproutefilter) which will be applied to each request which matches this rule.                                               |
-| `backendRefs` | An array of [HTTPBackendRefs](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
+| `matches`     | A list of [HTTPRouteMatch](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
+| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) which will be applied to each request which matches this rule.                                               |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
 
 {{< /keyval >}}
 
-### httpRouteMatch
+### HTTPRouteMatch
 
 HTTPRouteMatch defines the predicate used to match requests to a given action.
 Multiple match types are ANDed together, i.e. the match will evaluate to true
@@ -77,14 +77,14 @@ only if all conditions are satisfied.
 
 | field         | value                                                                                                                   |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `path`        | An [httpPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
-| `headers`     | A list of [httpHeaderMatches](#httpheadermatch). Multiple match values are ANDed together.                              |
-| `queryParams` | A list of [httpQueryParamMatches](#httpqueryparammatch). Multiple match values are ANDed together.                      |
+| `path`        | An [HTTPPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
+| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch). Multiple match values are ANDed together.                              |
+| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch). Multiple match values are ANDed together.                      |
 | `method`      | When specified, this route will be matched only if the request has the specified method.                                |
 
 {{< /keyval >}}
 
-### httpPathMatch
+### HTTPPathMatch
 
 `HTTPPathMatch` describes how to select a HTTP route by matching the HTTP
 request path.
@@ -98,7 +98,7 @@ request path.
 
 {{< /keyval >}}
 
-### httpHeaderMatch
+### HTTPHeaderMatch
 
 `HTTPHeaderMatch` describes how to select a HTTP route by matching HTTP request
 headers.
@@ -113,7 +113,7 @@ headers.
 
 {{< /keyval >}}
 
-### httpQueryParamMatch
+### HTTPQueryParamMatch
 
 `HTTPQueryParamMatch` describes how to select a HTTP route by matching HTTP
 query parameters.
@@ -128,7 +128,7 @@ query parameters.
 
 {{< /keyval >}}
 
-### httpRouteFilter
+### HTTPRouteFilter
 
 HTTPRouteFilter defines processing steps that must be completed during the
 request or response lifecycle.
@@ -138,12 +138,12 @@ request or response lifecycle.
 | field                   | value                                                       |
 | ----------------------- | ----------------------------------------------------------- |
 | `type`                  | One of: RequestHeaderModifier, RequestRedirect.             |
-| `requestHeaderModifier` | An [httpRequestHeaderFilter](#httprequestheaderfilter).     |
-| `requestRedirect`       | An [httpRequestRedirectFilter](#httprequestredirectfilter). |
+| `requestHeaderModifier` | An [HTTPRequestHeaderFilter](#httprequestheaderfilter).     |
+| `requestRedirect`       | An [HTTPRequestRedirectFilter](#httprequestredirectfilter). |
 
 {{< /keyval >}}
 
-### httpRequestHeaderFilter
+### HTTPRequestHeaderFilter
 
 A filter which modifies request headers.
 
@@ -151,13 +151,13 @@ A filter which modifies request headers.
 
 | field    | value                                                                                        |
 | -------- | -------------------------------------------------------------------------------------------- |
-| `set`    | A list of [httpHeaders](#httpheader) to overwrites on the request.                           |
-| `add`    | A list of [httpHeaders](#httpheader) to add on the request, appending to any existing value. |
+| `set`    | A list of [HTTPHeader](#httpheader) to overwrites on the request.                           |
+| `add`    | A list of [HTTPHeader](#httpheader) to add on the request, appending to any existing value. |
 | `remove` | A list of header names to remove from the request.                                           |
 
 {{< /keyval >}}
 
-### httpHeader
+### HTTPHeader
 
 `HTTPHeader` represents an HTTP Header name and value as defined by RFC 7230.
 
@@ -170,7 +170,7 @@ A filter which modifies request headers.
 
 {{< /keyval >}}
 
-### httpRequestRedirectFilter
+### HTTPRequestRedirectFilter
 
 `HTTPRequestRedirect` defines a filter that redirects a request.
 
@@ -180,7 +180,7 @@ A filter which modifies request headers.
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
 | `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
-| `path`       | An [HTTPPathModifier](#HTTPPathModifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
+| `path`       | An [HTTPPathModifier](#httppathmodifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
 | `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
 | `statusCode` | The HTTP status code to be used in response.                                                                                                |
 
@@ -200,7 +200,7 @@ A filter which modifies request headers.
 
 {{< /keyval >}}
 
-### httpBackendRef
+### HTTPBackendRef
 
 `HTTPBackendRef` defines the list of objects where matching requests should be
 sent to. Only allowed when a route has Service [parentRefs](#parentreference).

--- a/linkerd.io/content/2.14/reference/httproute.md
+++ b/linkerd.io/content/2.14/reference/httproute.md
@@ -213,13 +213,13 @@ A filter which modifies HTTP request or response headers.
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
 | `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
-| `path`       | An [httpPathModfier](#httppathmodfier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
+| `path`       | An [HTTPPathModifier](#HTTPPathModifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
 | `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
 | `statusCode` | The HTTP status code to be used in response.                                                                                                |
 
 {{< /keyval >}}
 
-### httpPathModfier
+### HTTPPathModifier
 
 `HTTPPathModifier` defines configuration for path modifiers.
 

--- a/linkerd.io/content/2.14/reference/httproute.md
+++ b/linkerd.io/content/2.14/reference/httproute.md
@@ -90,12 +90,12 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 
 {{< keyval >}}
 
-| field         | value                                                                                                                                                       |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `matches`     | A list of [HTTPRouteMatch](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
-| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) which will be applied to each request which matches this rule.                                               |
-| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
-| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
+| field         | value                                                                                                                                                        |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `matches`     | A list of [HTTPRouteMatch](#httproutematch) resources. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
+| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) resources which will be applied to each request which matches this rule.                                       |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
+| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                        |
 
 {{< /keyval >}}
 
@@ -110,8 +110,8 @@ only if all conditions are satisfied.
 | field         | value                                                                                                                   |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `path`        | An [HTTPPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
-| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch). Multiple match values are ANDed together.                              |
-| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch). Multiple match values are ANDed together.                      |
+| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch) resources. Multiple match values are ANDed together.                      |
+| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch) resources. Multiple match values are ANDed together.              |
 | `method`      | When specified, this route will be matched only if the request has the specified method.                                |
 
 {{< /keyval >}}
@@ -182,11 +182,11 @@ A filter which modifies HTTP request or response headers.
 
 {{< keyval >}}
 
-| field    | value                                                                                                       |
-| -------- | ----------------------------------------------------------------------------------------------------------- |
-| `set`    | A list of [HTTPHeader](#httpheader) to overwrite on the request or response.                               |
-| `add`    | A list of [HTTPHeader](#httpheader) to add on to the request or response, appending to any existing value. |
-| `remove` | A list of header names to remove from the request or response.                                              |
+| field    | value                                                                                                                |
+| -------- | -------------------------------------------------------------------------------------------------------------------- |
+| `set`    | A list of [HTTPHeader](#httpheader) resources to overwrite on the request or response.                               |
+| `add`    | A list of [HTTPHeader](#httpheader) resources to add on to the request or response, appending to any existing value. |
+| `remove` | A list of header names to remove from the request or response.                                                       |
 
 {{< /keyval >}}
 
@@ -209,13 +209,13 @@ A filter which modifies HTTP request or response headers.
 
 {{< keyval >}}
 
-| field        | value                                                                                                                                       |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
-| `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
+| field        | value                                                                                                                                         |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                   |
+| `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.               |
 | `path`       | An [HTTPPathModifier](#httppathmodifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
-| `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
-| `statusCode` | The HTTP status code to be used in response.                                                                                                |
+| `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.            |
+| `statusCode` | The HTTP status code to be used in response.                                                                                                  |
 
 {{< /keyval >}}
 

--- a/linkerd.io/content/2.14/reference/httproute.md
+++ b/linkerd.io/content/2.14/reference/httproute.md
@@ -83,7 +83,7 @@ GEP-1426][ns-boundaries] for details on producer and consumer routes.
 
 {{< /keyval >}}
 
-### httpRouteRule
+### HTTPRouteRule
 
 HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 (matches) and processing it (filters).
@@ -92,14 +92,14 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 
 | field         | value                                                                                                                                                       |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `matches`     | A list of [httpRouteMatches](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
-| `filters`     | A list of [httpRouteFilters](#httproutefilter) which will be applied to each request which matches this rule.                                               |
-| `backendRefs` | An array of [HTTPBackendRefs](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
-| `timeouts`    | An optional [httpRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
+| `matches`     | A list of [HTTPRouteMatch](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
+| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) which will be applied to each request which matches this rule.                                               |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
+| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
 
 {{< /keyval >}}
 
-### httpRouteMatch
+### HTTPRouteMatch
 
 HTTPRouteMatch defines the predicate used to match requests to a given action.
 Multiple match types are ANDed together, i.e. the match will evaluate to true
@@ -109,14 +109,14 @@ only if all conditions are satisfied.
 
 | field         | value                                                                                                                   |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `path`        | An [httpPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
-| `headers`     | A list of [httpHeaderMatches](#httpheadermatch). Multiple match values are ANDed together.                              |
-| `queryParams` | A list of [httpQueryParamMatches](#httpqueryparammatch). Multiple match values are ANDed together.                      |
+| `path`        | An [HTTPPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
+| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch). Multiple match values are ANDed together.                              |
+| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch). Multiple match values are ANDed together.                      |
 | `method`      | When specified, this route will be matched only if the request has the specified method.                                |
 
 {{< /keyval >}}
 
-### httpPathMatch
+### HTTPPathMatch
 
 `HTTPPathMatch` describes how to select a HTTP route by matching the HTTP
 request path.
@@ -130,7 +130,7 @@ request path.
 
 {{< /keyval >}}
 
-### httpHeaderMatch
+### HTTPHeaderMatch
 
 `HTTPHeaderMatch` describes how to select a HTTP route by matching HTTP request
 headers.
@@ -145,7 +145,7 @@ headers.
 
 {{< /keyval >}}
 
-### httpQueryParamMatch
+### HTTPQueryParamMatch
 
 `HTTPQueryParamMatch` describes how to select a HTTP route by matching HTTP
 query parameters.
@@ -160,7 +160,7 @@ query parameters.
 
 {{< /keyval >}}
 
-### httpRouteFilter
+### HTTPRouteFilter
 
 HTTPRouteFilter defines processing steps that must be completed during the
 request or response lifecycle.
@@ -170,13 +170,13 @@ request or response lifecycle.
 | field                    | value                                                                      |
 | ------------------------ | -------------------------------------------------------------------------- |
 | `type`                   | One of: RequestHeaderModifier, ResponseHeaderModifier, or RequestRedirect. |
-| `requestHeaderModifier`  | An [httpHeaderFilter](#httpheaderfilter) which modifies request headers.   |
-| `responseHeaderModifier` | An [httpHeaderFilter](#httpheaderfilter) which modifies response headers.  |
-| `requestRedirect`        | An [httpRequestRedirectFilter](#httprequestredirectfilter).                |
+| `requestHeaderModifier`  | An [HTTPHeaderFilter](#httpheaderfilter) which modifies request headers.   |
+| `responseHeaderModifier` | An [HTTPHeaderFilter](#httpheaderfilter) which modifies response headers.  |
+| `requestRedirect`        | An [HTTPRequestRedirectFilter](#httprequestredirectfilter).                |
 
 {{< /keyval >}}
 
-### httpHeaderFilter
+### HTTPHeaderFilter
 
 A filter which modifies HTTP request or response headers.
 
@@ -184,13 +184,13 @@ A filter which modifies HTTP request or response headers.
 
 | field    | value                                                                                                       |
 | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `set`    | A list of [httpHeaders](#httpheader) to overwrite on the request or response.                               |
-| `add`    | A list of [httpHeaders](#httpheader) to add on to the request or response, appending to any existing value. |
+| `set`    | A list of [HTTPHeader](#httpheader) to overwrite on the request or response.                               |
+| `add`    | A list of [HTTPHeader](#httpheader) to add on to the request or response, appending to any existing value. |
 | `remove` | A list of header names to remove from the request or response.                                              |
 
 {{< /keyval >}}
 
-### httpHeader
+### HTTPHeader
 
 `HTTPHeader` represents an HTTP Header name and value as defined by RFC 7230.
 
@@ -203,7 +203,7 @@ A filter which modifies HTTP request or response headers.
 
 {{< /keyval >}}
 
-### httpRequestRedirectFilter
+### HTTPRequestRedirectFilter
 
 `HTTPRequestRedirect` defines a filter that redirects a request.
 
@@ -213,7 +213,7 @@ A filter which modifies HTTP request or response headers.
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
 | `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
-| `path`       | An [HTTPPathModifier](#HTTPPathModifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
+| `path`       | An [HTTPPathModifier](#httppathmodifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
 | `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
 | `statusCode` | The HTTP status code to be used in response.                                                                                                |
 
@@ -233,7 +233,7 @@ A filter which modifies HTTP request or response headers.
 
 {{< /keyval >}}
 
-### httpBackendRef
+### HTTPBackendRef
 
 `HTTPBackendRef` defines the list of objects where matching requests should be
 sent to. Only allowed when a route has Service [parentRefs](#parentreference).
@@ -249,7 +249,7 @@ sent to. Only allowed when a route has Service [parentRefs](#parentreference).
 
 {{< /keyval >}}
 
-### httpRouteTimeouts
+### HTTPRouteTimeouts
 
 `HTTPRouteTimeouts` defines the timeouts that can be configured for an HTTP
 request.

--- a/linkerd.io/content/2.14/reference/httproute.md
+++ b/linkerd.io/content/2.14/reference/httproute.md
@@ -94,7 +94,7 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `matches`     | A list of [HTTPRouteMatch](#httproutematch) resources. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
 | `filters`     | A list of [HTTPRouteFilter](#httproutefilter) resources which will be applied to each request which matches this rule.                                       |
-| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) resources to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
 | `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                        |
 
 {{< /keyval >}}

--- a/linkerd.io/content/2.15/reference/httproute.md
+++ b/linkerd.io/content/2.15/reference/httproute.md
@@ -213,13 +213,13 @@ A filter which modifies HTTP request or response headers.
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
 | `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
-| `path`       | An [httpPathModfier](#httppathmodfier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
+| `path`       | An [HTTPPathModifier](#HTTPPathModifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
 | `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
 | `statusCode` | The HTTP status code to be used in response.                                                                                                |
 
 {{< /keyval >}}
 
-### httpPathModfier
+### HTTPPathModifier
 
 `HTTPPathModifier` defines configuration for path modifiers.
 

--- a/linkerd.io/content/2.15/reference/httproute.md
+++ b/linkerd.io/content/2.15/reference/httproute.md
@@ -90,12 +90,12 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 
 {{< keyval >}}
 
-| field         | value                                                                                                                                                       |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `matches`     | A list of [HTTPRouteMatch](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
-| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) which will be applied to each request which matches this rule.                                               |
-| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
-| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
+| field         | value                                                                                                                                                        |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `matches`     | A list of [HTTPRouteMatch](#httproutematch) resources. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
+| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) resources which will be applied to each request which matches this rule.                                       |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
+| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                        |
 
 {{< /keyval >}}
 
@@ -110,8 +110,8 @@ only if all conditions are satisfied.
 | field         | value                                                                                                                   |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `path`        | An [HTTPPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
-| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch). Multiple match values are ANDed together.                              |
-| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch). Multiple match values are ANDed together.                      |
+| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch) resources. Multiple match values are ANDed together.                      |
+| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch) resources. Multiple match values are ANDed together.              |
 | `method`      | When specified, this route will be matched only if the request has the specified method.                                |
 
 {{< /keyval >}}
@@ -182,11 +182,11 @@ A filter which modifies HTTP request or response headers.
 
 {{< keyval >}}
 
-| field    | value                                                                                                       |
-| -------- | ----------------------------------------------------------------------------------------------------------- |
-| `set`    | A list of [HTTPHeader](#httpheader) to overwrite on the request or response.                               |
-| `add`    | A list of [HTTPHeader](#httpheader) to add on to the request or response, appending to any existing value. |
-| `remove` | A list of header names to remove from the request or response.                                              |
+| field    | value                                                                                                                |
+| -------- | -------------------------------------------------------------------------------------------------------------------- |
+| `set`    | A list of [HTTPHeader](#httpheader) resources to overwrite on the request or response.                               |
+| `add`    | A list of [HTTPHeader](#httpheader) resources to add on to the request or response, appending to any existing value. |
+| `remove` | A list of header names to remove from the request or response.                                                       |
 
 {{< /keyval >}}
 
@@ -209,13 +209,13 @@ A filter which modifies HTTP request or response headers.
 
 {{< keyval >}}
 
-| field        | value                                                                                                                                       |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
-| `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
+| field        | value                                                                                                                                         |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                   |
+| `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.               |
 | `path`       | An [HTTPPathModifier](#httppathmodifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
-| `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
-| `statusCode` | The HTTP status code to be used in response.                                                                                                |
+| `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.            |
+| `statusCode` | The HTTP status code to be used in response.                                                                                                  |
 
 {{< /keyval >}}
 

--- a/linkerd.io/content/2.15/reference/httproute.md
+++ b/linkerd.io/content/2.15/reference/httproute.md
@@ -83,7 +83,7 @@ GEP-1426][ns-boundaries] for details on producer and consumer routes.
 
 {{< /keyval >}}
 
-### httpRouteRule
+### HTTPRouteRule
 
 HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 (matches) and processing it (filters).
@@ -92,14 +92,14 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 
 | field         | value                                                                                                                                                       |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `matches`     | A list of [httpRouteMatches](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
-| `filters`     | A list of [httpRouteFilters](#httproutefilter) which will be applied to each request which matches this rule.                                               |
-| `backendRefs` | An array of [HTTPBackendRefs](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
-| `timeouts`    | An optional [httpRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
+| `matches`     | A list of [HTTPRouteMatch](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
+| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) which will be applied to each request which matches this rule.                                               |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
+| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
 
 {{< /keyval >}}
 
-### httpRouteMatch
+### HTTPRouteMatch
 
 HTTPRouteMatch defines the predicate used to match requests to a given action.
 Multiple match types are ANDed together, i.e. the match will evaluate to true
@@ -109,14 +109,14 @@ only if all conditions are satisfied.
 
 | field         | value                                                                                                                   |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `path`        | An [httpPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
-| `headers`     | A list of [httpHeaderMatches](#httpheadermatch). Multiple match values are ANDed together.                              |
-| `queryParams` | A list of [httpQueryParamMatches](#httpqueryparammatch). Multiple match values are ANDed together.                      |
+| `path`        | An [HTTPPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
+| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch). Multiple match values are ANDed together.                              |
+| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch). Multiple match values are ANDed together.                      |
 | `method`      | When specified, this route will be matched only if the request has the specified method.                                |
 
 {{< /keyval >}}
 
-### httpPathMatch
+### HTTPPathMatch
 
 `HTTPPathMatch` describes how to select a HTTP route by matching the HTTP
 request path.
@@ -130,7 +130,7 @@ request path.
 
 {{< /keyval >}}
 
-### httpHeaderMatch
+### HTTPHeaderMatch
 
 `HTTPHeaderMatch` describes how to select a HTTP route by matching HTTP request
 headers.
@@ -145,7 +145,7 @@ headers.
 
 {{< /keyval >}}
 
-### httpQueryParamMatch
+### HTTPQueryParamMatch
 
 `HTTPQueryParamMatch` describes how to select a HTTP route by matching HTTP
 query parameters.
@@ -160,7 +160,7 @@ query parameters.
 
 {{< /keyval >}}
 
-### httpRouteFilter
+### HTTPRouteFilter
 
 HTTPRouteFilter defines processing steps that must be completed during the
 request or response lifecycle.
@@ -170,13 +170,13 @@ request or response lifecycle.
 | field                    | value                                                                      |
 | ------------------------ | -------------------------------------------------------------------------- |
 | `type`                   | One of: RequestHeaderModifier, ResponseHeaderModifier, or RequestRedirect. |
-| `requestHeaderModifier`  | An [httpHeaderFilter](#httpheaderfilter) which modifies request headers.   |
-| `responseHeaderModifier` | An [httpHeaderFilter](#httpheaderfilter) which modifies response headers.  |
-| `requestRedirect`        | An [httpRequestRedirectFilter](#httprequestredirectfilter).                |
+| `requestHeaderModifier`  | An [HTTPHeaderFilter](#httpheaderfilter) which modifies request headers.   |
+| `responseHeaderModifier` | An [HTTPHeaderFilter](#httpheaderfilter) which modifies response headers.  |
+| `requestRedirect`        | An [HTTPRequestRedirectFilter](#httprequestredirectfilter).                |
 
 {{< /keyval >}}
 
-### httpHeaderFilter
+### HTTPHeaderFilter
 
 A filter which modifies HTTP request or response headers.
 
@@ -184,13 +184,13 @@ A filter which modifies HTTP request or response headers.
 
 | field    | value                                                                                                       |
 | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `set`    | A list of [httpHeaders](#httpheader) to overwrite on the request or response.                               |
-| `add`    | A list of [httpHeaders](#httpheader) to add on to the request or response, appending to any existing value. |
+| `set`    | A list of [HTTPHeader](#httpheader) to overwrite on the request or response.                               |
+| `add`    | A list of [HTTPHeader](#httpheader) to add on to the request or response, appending to any existing value. |
 | `remove` | A list of header names to remove from the request or response.                                              |
 
 {{< /keyval >}}
 
-### httpHeader
+### HTTPHeader
 
 `HTTPHeader` represents an HTTP Header name and value as defined by RFC 7230.
 
@@ -203,7 +203,7 @@ A filter which modifies HTTP request or response headers.
 
 {{< /keyval >}}
 
-### httpRequestRedirectFilter
+### HTTPRequestRedirectFilter
 
 `HTTPRequestRedirect` defines a filter that redirects a request.
 
@@ -213,7 +213,7 @@ A filter which modifies HTTP request or response headers.
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
 | `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
-| `path`       | An [HTTPPathModifier](#HTTPPathModifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
+| `path`       | An [HTTPPathModifier](#httppathmodifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
 | `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
 | `statusCode` | The HTTP status code to be used in response.                                                                                                |
 
@@ -233,7 +233,7 @@ A filter which modifies HTTP request or response headers.
 
 {{< /keyval >}}
 
-### httpBackendRef
+### HTTPBackendRef
 
 `HTTPBackendRef` defines the list of objects where matching requests should be
 sent to. Only allowed when a route has Service [parentRefs](#parentreference).
@@ -249,7 +249,7 @@ sent to. Only allowed when a route has Service [parentRefs](#parentreference).
 
 {{< /keyval >}}
 
-### httpRouteTimeouts
+### HTTPRouteTimeouts
 
 `HTTPRouteTimeouts` defines the timeouts that can be configured for an HTTP
 request.

--- a/linkerd.io/content/2.15/reference/httproute.md
+++ b/linkerd.io/content/2.15/reference/httproute.md
@@ -94,7 +94,7 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `matches`     | A list of [HTTPRouteMatch](#httproutematch) resources. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
 | `filters`     | A list of [HTTPRouteFilter](#httproutefilter) resources which will be applied to each request which matches this rule.                                       |
-| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) resources to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
 | `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                        |
 
 {{< /keyval >}}

--- a/linkerd.io/content/2.16/reference/httproute.md
+++ b/linkerd.io/content/2.16/reference/httproute.md
@@ -240,13 +240,13 @@ A filter which modifies HTTP request or response headers.
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
 | `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
-| `path`       | An [httpPathModfier](#httppathmodfier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
+| `path`       | An [HTTPPathModifier](#HTTPPathModifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
 | `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
 | `statusCode` | The HTTP status code to be used in response.                                                                                                |
 
 {{< /keyval >}}
 
-### httpPathModfier
+### HTTPPathModifier
 
 `HTTPPathModifier` defines configuration for path modifiers.
 

--- a/linkerd.io/content/2.16/reference/httproute.md
+++ b/linkerd.io/content/2.16/reference/httproute.md
@@ -121,7 +121,7 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `matches`     | A list of [HTTPRouteMatch](#httproutematch) resources. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
 | `filters`     | A list of [HTTPRouteFilter](#httproutefilter) resources which will be applied to each request which matches this rule.                                       |
-| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) resources to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
 | `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                        |
 
 {{< /keyval >}}

--- a/linkerd.io/content/2.16/reference/httproute.md
+++ b/linkerd.io/content/2.16/reference/httproute.md
@@ -117,12 +117,12 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 
 {{< keyval >}}
 
-| field         | value                                                                                                                                                       |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `matches`     | A list of [HTTPRouteMatch](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
-| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) which will be applied to each request which matches this rule.                                               |
-| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
-| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
+| field         | value                                                                                                                                                        |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `matches`     | A list of [HTTPRouteMatch](#httproutematch) resources. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
+| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) resources which will be applied to each request which matches this rule.                                       |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
+| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                        |
 
 {{< /keyval >}}
 
@@ -137,8 +137,8 @@ only if all conditions are satisfied.
 | field         | value                                                                                                                   |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `path`        | An [HTTPPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
-| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch). Multiple match values are ANDed together.                              |
-| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch). Multiple match values are ANDed together.                      |
+| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch) resources. Multiple match values are ANDed together.                      |
+| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch) resources. Multiple match values are ANDed together.              |
 | `method`      | When specified, this route will be matched only if the request has the specified method.                                |
 
 {{< /keyval >}}
@@ -209,11 +209,11 @@ A filter which modifies HTTP request or response headers.
 
 {{< keyval >}}
 
-| field    | value                                                                                                       |
-| -------- | ----------------------------------------------------------------------------------------------------------- |
-| `set`    | A list of [HTTPHeader](#httpheader) to overwrite on the request or response.                               |
-| `add`    | A list of [HTTPHeader](#httpheader) to add on to the request or response, appending to any existing value. |
-| `remove` | A list of header names to remove from the request or response.                                              |
+| field    | value                                                                                                                |
+| -------- | -------------------------------------------------------------------------------------------------------------------- |
+| `set`    | A list of [HTTPHeader](#httpheader) resources to overwrite on the request or response.                               |
+| `add`    | A list of [HTTPHeader](#httpheader) resources to add on to the request or response, appending to any existing value. |
+| `remove` | A list of header names to remove from the request or response.                                                       |
 
 {{< /keyval >}}
 
@@ -236,13 +236,13 @@ A filter which modifies HTTP request or response headers.
 
 {{< keyval >}}
 
-| field        | value                                                                                                                                       |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
-| `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
+| field        | value                                                                                                                                         |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                   |
+| `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.               |
 | `path`       | An [HTTPPathModifier](#httppathmodifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
-| `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
-| `statusCode` | The HTTP status code to be used in response.                                                                                                |
+| `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.            |
+| `statusCode` | The HTTP status code to be used in response.                                                                                                  |
 
 {{< /keyval >}}
 

--- a/linkerd.io/content/2.16/reference/httproute.md
+++ b/linkerd.io/content/2.16/reference/httproute.md
@@ -110,7 +110,7 @@ GEP-1426][ns-boundaries] for details on producer and consumer routes.
 
 {{< /keyval >}}
 
-### httpRouteRule
+### HTTPRouteRule
 
 HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 (matches) and processing it (filters).
@@ -119,14 +119,14 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 
 | field         | value                                                                                                                                                       |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `matches`     | A list of [httpRouteMatches](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
-| `filters`     | A list of [httpRouteFilters](#httproutefilter) which will be applied to each request which matches this rule.                                               |
-| `backendRefs` | An array of [HTTPBackendRefs](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
-| `timeouts`    | An optional [httpRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
+| `matches`     | A list of [HTTPRouteMatch](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
+| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) which will be applied to each request which matches this rule.                                               |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
+| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
 
 {{< /keyval >}}
 
-### httpRouteMatch
+### HTTPRouteMatch
 
 HTTPRouteMatch defines the predicate used to match requests to a given action.
 Multiple match types are ANDed together, i.e. the match will evaluate to true
@@ -136,14 +136,14 @@ only if all conditions are satisfied.
 
 | field         | value                                                                                                                   |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `path`        | An [httpPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
-| `headers`     | A list of [httpHeaderMatches](#httpheadermatch). Multiple match values are ANDed together.                              |
-| `queryParams` | A list of [httpQueryParamMatches](#httpqueryparammatch). Multiple match values are ANDed together.                      |
+| `path`        | An [HTTPPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
+| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch). Multiple match values are ANDed together.                              |
+| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch). Multiple match values are ANDed together.                      |
 | `method`      | When specified, this route will be matched only if the request has the specified method.                                |
 
 {{< /keyval >}}
 
-### httpPathMatch
+### HTTPPathMatch
 
 `HTTPPathMatch` describes how to select a HTTP route by matching the HTTP
 request path.
@@ -157,7 +157,7 @@ request path.
 
 {{< /keyval >}}
 
-### httpHeaderMatch
+### HTTPHeaderMatch
 
 `HTTPHeaderMatch` describes how to select a HTTP route by matching HTTP request
 headers.
@@ -172,7 +172,7 @@ headers.
 
 {{< /keyval >}}
 
-### httpQueryParamMatch
+### HTTPQueryParamMatch
 
 `HTTPQueryParamMatch` describes how to select a HTTP route by matching HTTP
 query parameters.
@@ -187,7 +187,7 @@ query parameters.
 
 {{< /keyval >}}
 
-### httpRouteFilter
+### HTTPRouteFilter
 
 HTTPRouteFilter defines processing steps that must be completed during the
 request or response lifecycle.
@@ -197,13 +197,13 @@ request or response lifecycle.
 | field                    | value                                                                      |
 | ------------------------ | -------------------------------------------------------------------------- |
 | `type`                   | One of: RequestHeaderModifier, ResponseHeaderModifier, or RequestRedirect. |
-| `requestHeaderModifier`  | An [httpHeaderFilter](#httpheaderfilter) which modifies request headers.   |
-| `responseHeaderModifier` | An [httpHeaderFilter](#httpheaderfilter) which modifies response headers.  |
-| `requestRedirect`        | An [httpRequestRedirectFilter](#httprequestredirectfilter).                |
+| `requestHeaderModifier`  | An [HTTPHeaderFilter](#httpheaderfilter) which modifies request headers.   |
+| `responseHeaderModifier` | An [HTTPHeaderFilter](#httpheaderfilter) which modifies response headers.  |
+| `requestRedirect`        | An [HTTPRequestRedirectFilter](#httprequestredirectfilter).                |
 
 {{< /keyval >}}
 
-### httpHeaderFilter
+### HTTPHeaderFilter
 
 A filter which modifies HTTP request or response headers.
 
@@ -211,13 +211,13 @@ A filter which modifies HTTP request or response headers.
 
 | field    | value                                                                                                       |
 | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `set`    | A list of [httpHeaders](#httpheader) to overwrite on the request or response.                               |
-| `add`    | A list of [httpHeaders](#httpheader) to add on to the request or response, appending to any existing value. |
+| `set`    | A list of [HTTPHeader](#httpheader) to overwrite on the request or response.                               |
+| `add`    | A list of [HTTPHeader](#httpheader) to add on to the request or response, appending to any existing value. |
 | `remove` | A list of header names to remove from the request or response.                                              |
 
 {{< /keyval >}}
 
-### httpHeader
+### HTTPHeader
 
 `HTTPHeader` represents an HTTP Header name and value as defined by RFC 7230.
 
@@ -230,7 +230,7 @@ A filter which modifies HTTP request or response headers.
 
 {{< /keyval >}}
 
-### httpRequestRedirectFilter
+### HTTPRequestRedirectFilter
 
 `HTTPRequestRedirect` defines a filter that redirects a request.
 
@@ -240,7 +240,7 @@ A filter which modifies HTTP request or response headers.
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
 | `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
-| `path`       | An [HTTPPathModifier](#HTTPPathModifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
+| `path`       | An [HTTPPathModifier](#httppathmodifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
 | `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
 | `statusCode` | The HTTP status code to be used in response.                                                                                                |
 
@@ -260,7 +260,7 @@ A filter which modifies HTTP request or response headers.
 
 {{< /keyval >}}
 
-### httpBackendRef
+### HTTPBackendRef
 
 `HTTPBackendRef` defines the list of objects where matching requests should be
 sent to. Only allowed when a route has Service [parentRefs](#parentreference).
@@ -276,7 +276,7 @@ sent to. Only allowed when a route has Service [parentRefs](#parentreference).
 
 {{< /keyval >}}
 
-### httpRouteTimeouts
+### HTTPRouteTimeouts
 
 `HTTPRouteTimeouts` defines the timeouts that can be configured for an HTTP
 request.

--- a/linkerd.io/content/2.17/reference/httproute.md
+++ b/linkerd.io/content/2.17/reference/httproute.md
@@ -240,13 +240,13 @@ A filter which modifies HTTP request or response headers.
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
 | `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
-| `path`       | An [httpPathModfier](#httppathmodfier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
+| `path`       | An [HTTPPathModifier](#HTTPPathModifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
 | `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
 | `statusCode` | The HTTP status code to be used in response.                                                                                                |
 
 {{< /keyval >}}
 
-### httpPathModfier
+### HTTPPathModifier
 
 `HTTPPathModifier` defines configuration for path modifiers.
 

--- a/linkerd.io/content/2.17/reference/httproute.md
+++ b/linkerd.io/content/2.17/reference/httproute.md
@@ -121,7 +121,7 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `matches`     | A list of [HTTPRouteMatch](#httproutematch) resources. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
 | `filters`     | A list of [HTTPRouteFilter](#httproutefilter) resources which will be applied to each request which matches this rule.                                       |
-| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) resources to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
 | `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                        |
 
 {{< /keyval >}}

--- a/linkerd.io/content/2.17/reference/httproute.md
+++ b/linkerd.io/content/2.17/reference/httproute.md
@@ -117,12 +117,12 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 
 {{< keyval >}}
 
-| field         | value                                                                                                                                                       |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `matches`     | A list of [HTTPRouteMatch](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
-| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) which will be applied to each request which matches this rule.                                               |
-| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
-| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
+| field         | value                                                                                                                                                        |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `matches`     | A list of [HTTPRouteMatch](#httproutematch) resources. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
+| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) resources which will be applied to each request which matches this rule.                                       |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
+| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                        |
 
 {{< /keyval >}}
 
@@ -137,8 +137,8 @@ only if all conditions are satisfied.
 | field         | value                                                                                                                   |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `path`        | An [HTTPPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
-| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch). Multiple match values are ANDed together.                              |
-| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch). Multiple match values are ANDed together.                      |
+| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch) resources. Multiple match values are ANDed together.                      |
+| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch) resources. Multiple match values are ANDed together.              |
 | `method`      | When specified, this route will be matched only if the request has the specified method.                                |
 
 {{< /keyval >}}
@@ -209,11 +209,11 @@ A filter which modifies HTTP request or response headers.
 
 {{< keyval >}}
 
-| field    | value                                                                                                       |
-| -------- | ----------------------------------------------------------------------------------------------------------- |
-| `set`    | A list of [HTTPHeader](#httpheader) to overwrite on the request or response.                               |
-| `add`    | A list of [HTTPHeader](#httpheader) to add on to the request or response, appending to any existing value. |
-| `remove` | A list of header names to remove from the request or response.                                              |
+| field    | value                                                                                                                |
+| -------- | -------------------------------------------------------------------------------------------------------------------- |
+| `set`    | A list of [HTTPHeader](#httpheader) resources to overwrite on the request or response.                               |
+| `add`    | A list of [HTTPHeader](#httpheader) resources to add on to the request or response, appending to any existing value. |
+| `remove` | A list of header names to remove from the request or response.                                                       |
 
 {{< /keyval >}}
 
@@ -236,13 +236,13 @@ A filter which modifies HTTP request or response headers.
 
 {{< keyval >}}
 
-| field        | value                                                                                                                                       |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
-| `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
+| field        | value                                                                                                                                         |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                   |
+| `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.               |
 | `path`       | An [HTTPPathModifier](#httppathmodifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
-| `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
-| `statusCode` | The HTTP status code to be used in response.                                                                                                |
+| `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.            |
+| `statusCode` | The HTTP status code to be used in response.                                                                                                  |
 
 {{< /keyval >}}
 

--- a/linkerd.io/content/2.17/reference/httproute.md
+++ b/linkerd.io/content/2.17/reference/httproute.md
@@ -110,7 +110,7 @@ GEP-1426][ns-boundaries] for details on producer and consumer routes.
 
 {{< /keyval >}}
 
-### httpRouteRule
+### HTTPRouteRule
 
 HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 (matches) and processing it (filters).
@@ -119,14 +119,14 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 
 | field         | value                                                                                                                                                       |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `matches`     | A list of [httpRouteMatches](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
-| `filters`     | A list of [httpRouteFilters](#httproutefilter) which will be applied to each request which matches this rule.                                               |
-| `backendRefs` | An array of [HTTPBackendRefs](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
-| `timeouts`    | An optional [httpRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
+| `matches`     | A list of [HTTPRouteMatch](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
+| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) which will be applied to each request which matches this rule.                                               |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
+| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
 
 {{< /keyval >}}
 
-### httpRouteMatch
+### HTTPRouteMatch
 
 HTTPRouteMatch defines the predicate used to match requests to a given action.
 Multiple match types are ANDed together, i.e. the match will evaluate to true
@@ -136,14 +136,14 @@ only if all conditions are satisfied.
 
 | field         | value                                                                                                                   |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `path`        | An [httpPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
-| `headers`     | A list of [httpHeaderMatches](#httpheadermatch). Multiple match values are ANDed together.                              |
-| `queryParams` | A list of [httpQueryParamMatches](#httpqueryparammatch). Multiple match values are ANDed together.                      |
+| `path`        | An [HTTPPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
+| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch). Multiple match values are ANDed together.                              |
+| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch). Multiple match values are ANDed together.                      |
 | `method`      | When specified, this route will be matched only if the request has the specified method.                                |
 
 {{< /keyval >}}
 
-### httpPathMatch
+### HTTPPathMatch
 
 `HTTPPathMatch` describes how to select a HTTP route by matching the HTTP
 request path.
@@ -157,7 +157,7 @@ request path.
 
 {{< /keyval >}}
 
-### httpHeaderMatch
+### HTTPHeaderMatch
 
 `HTTPHeaderMatch` describes how to select a HTTP route by matching HTTP request
 headers.
@@ -172,7 +172,7 @@ headers.
 
 {{< /keyval >}}
 
-### httpQueryParamMatch
+### HTTPQueryParamMatch
 
 `HTTPQueryParamMatch` describes how to select a HTTP route by matching HTTP
 query parameters.
@@ -187,7 +187,7 @@ query parameters.
 
 {{< /keyval >}}
 
-### httpRouteFilter
+### HTTPRouteFilter
 
 HTTPRouteFilter defines processing steps that must be completed during the
 request or response lifecycle.
@@ -197,13 +197,13 @@ request or response lifecycle.
 | field                    | value                                                                      |
 | ------------------------ | -------------------------------------------------------------------------- |
 | `type`                   | One of: RequestHeaderModifier, ResponseHeaderModifier, or RequestRedirect. |
-| `requestHeaderModifier`  | An [httpHeaderFilter](#httpheaderfilter) which modifies request headers.   |
-| `responseHeaderModifier` | An [httpHeaderFilter](#httpheaderfilter) which modifies response headers.  |
-| `requestRedirect`        | An [httpRequestRedirectFilter](#httprequestredirectfilter).                |
+| `requestHeaderModifier`  | An [HTTPHeaderFilter](#httpheaderfilter) which modifies request headers.   |
+| `responseHeaderModifier` | An [HTTPHeaderFilter](#httpheaderfilter) which modifies response headers.  |
+| `requestRedirect`        | An [HTTPRequestRedirectFilter](#httprequestredirectfilter).                |
 
 {{< /keyval >}}
 
-### httpHeaderFilter
+### HTTPHeaderFilter
 
 A filter which modifies HTTP request or response headers.
 
@@ -211,13 +211,13 @@ A filter which modifies HTTP request or response headers.
 
 | field    | value                                                                                                       |
 | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `set`    | A list of [httpHeaders](#httpheader) to overwrite on the request or response.                               |
-| `add`    | A list of [httpHeaders](#httpheader) to add on to the request or response, appending to any existing value. |
+| `set`    | A list of [HTTPHeader](#httpheader) to overwrite on the request or response.                               |
+| `add`    | A list of [HTTPHeader](#httpheader) to add on to the request or response, appending to any existing value. |
 | `remove` | A list of header names to remove from the request or response.                                              |
 
 {{< /keyval >}}
 
-### httpHeader
+### HTTPHeader
 
 `HTTPHeader` represents an HTTP Header name and value as defined by RFC 7230.
 
@@ -230,7 +230,7 @@ A filter which modifies HTTP request or response headers.
 
 {{< /keyval >}}
 
-### httpRequestRedirectFilter
+### HTTPRequestRedirectFilter
 
 `HTTPRequestRedirect` defines a filter that redirects a request.
 
@@ -240,7 +240,7 @@ A filter which modifies HTTP request or response headers.
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
 | `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
-| `path`       | An [HTTPPathModifier](#HTTPPathModifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
+| `path`       | An [HTTPPathModifier](#httppathmodifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
 | `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
 | `statusCode` | The HTTP status code to be used in response.                                                                                                |
 
@@ -260,7 +260,7 @@ A filter which modifies HTTP request or response headers.
 
 {{< /keyval >}}
 
-### httpBackendRef
+### HTTPBackendRef
 
 `HTTPBackendRef` defines the list of objects where matching requests should be
 sent to. Only allowed when a route has Service [parentRefs](#parentreference).
@@ -276,7 +276,7 @@ sent to. Only allowed when a route has Service [parentRefs](#parentreference).
 
 {{< /keyval >}}
 
-### httpRouteTimeouts
+### HTTPRouteTimeouts
 
 `HTTPRouteTimeouts` defines the timeouts that can be configured for an HTTP
 request.

--- a/linkerd.io/content/2.18/reference/httproute.md
+++ b/linkerd.io/content/2.18/reference/httproute.md
@@ -240,13 +240,13 @@ A filter which modifies HTTP request or response headers.
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
 | `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
-| `path`       | An [httpPathModfier](#httppathmodfier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
+| `path`       | An [HTTPPathModifier](#HTTPPathModifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
 | `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
 | `statusCode` | The HTTP status code to be used in response.                                                                                                |
 
 {{< /keyval >}}
 
-### httpPathModfier
+### HTTPPathModifier
 
 `HTTPPathModifier` defines configuration for path modifiers.
 

--- a/linkerd.io/content/2.18/reference/httproute.md
+++ b/linkerd.io/content/2.18/reference/httproute.md
@@ -121,7 +121,7 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `matches`     | A list of [HTTPRouteMatch](#httproutematch) resources. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
 | `filters`     | A list of [HTTPRouteFilter](#httproutefilter) resources which will be applied to each request which matches this rule.                                       |
-| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) resources to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
 | `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                        |
 
 {{< /keyval >}}

--- a/linkerd.io/content/2.18/reference/httproute.md
+++ b/linkerd.io/content/2.18/reference/httproute.md
@@ -117,12 +117,12 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 
 {{< keyval >}}
 
-| field         | value                                                                                                                                                       |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `matches`     | A list of [HTTPRouteMatch](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
-| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) which will be applied to each request which matches this rule.                                               |
-| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
-| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
+| field         | value                                                                                                                                                        |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `matches`     | A list of [HTTPRouteMatch](#httproutematch) resources. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
+| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) resources which will be applied to each request which matches this rule.                                       |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
+| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                        |
 
 {{< /keyval >}}
 
@@ -137,8 +137,8 @@ only if all conditions are satisfied.
 | field         | value                                                                                                                   |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `path`        | An [HTTPPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
-| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch). Multiple match values are ANDed together.                              |
-| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch). Multiple match values are ANDed together.                      |
+| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch) resources. Multiple match values are ANDed together.                      |
+| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch) resources. Multiple match values are ANDed together.              |
 | `method`      | When specified, this route will be matched only if the request has the specified method.                                |
 
 {{< /keyval >}}
@@ -209,11 +209,11 @@ A filter which modifies HTTP request or response headers.
 
 {{< keyval >}}
 
-| field    | value                                                                                                       |
-| -------- | ----------------------------------------------------------------------------------------------------------- |
-| `set`    | A list of [HTTPHeader](#httpheader) to overwrite on the request or response.                               |
-| `add`    | A list of [HTTPHeader](#httpheader) to add on to the request or response, appending to any existing value. |
-| `remove` | A list of header names to remove from the request or response.                                              |
+| field    | value                                                                                                                |
+| -------- | -------------------------------------------------------------------------------------------------------------------- |
+| `set`    | A list of [HTTPHeader](#httpheader) resources to overwrite on the request or response.                               |
+| `add`    | A list of [HTTPHeader](#httpheader) resources to add on to the request or response, appending to any existing value. |
+| `remove` | A list of header names to remove from the request or response.                                                       |
 
 {{< /keyval >}}
 
@@ -236,13 +236,13 @@ A filter which modifies HTTP request or response headers.
 
 {{< keyval >}}
 
-| field        | value                                                                                                                                       |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
-| `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
+| field        | value                                                                                                                                         |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                   |
+| `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.               |
 | `path`       | An [HTTPPathModifier](#httppathmodifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
-| `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
-| `statusCode` | The HTTP status code to be used in response.                                                                                                |
+| `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.            |
+| `statusCode` | The HTTP status code to be used in response.                                                                                                  |
 
 {{< /keyval >}}
 

--- a/linkerd.io/content/2.18/reference/httproute.md
+++ b/linkerd.io/content/2.18/reference/httproute.md
@@ -110,7 +110,7 @@ GEP-1426][ns-boundaries] for details on producer and consumer routes.
 
 {{< /keyval >}}
 
-### httpRouteRule
+### HTTPRouteRule
 
 HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 (matches) and processing it (filters).
@@ -119,14 +119,14 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 
 | field         | value                                                                                                                                                       |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `matches`     | A list of [httpRouteMatches](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
-| `filters`     | A list of [httpRouteFilters](#httproutefilter) which will be applied to each request which matches this rule.                                               |
-| `backendRefs` | An array of [HTTPBackendRefs](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
-| `timeouts`    | An optional [httpRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
+| `matches`     | A list of [HTTPRouteMatch](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
+| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) which will be applied to each request which matches this rule.                                               |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
+| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
 
 {{< /keyval >}}
 
-### httpRouteMatch
+### HTTPRouteMatch
 
 HTTPRouteMatch defines the predicate used to match requests to a given action.
 Multiple match types are ANDed together, i.e. the match will evaluate to true
@@ -136,14 +136,14 @@ only if all conditions are satisfied.
 
 | field         | value                                                                                                                   |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `path`        | An [httpPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
-| `headers`     | A list of [httpHeaderMatches](#httpheadermatch). Multiple match values are ANDed together.                              |
-| `queryParams` | A list of [httpQueryParamMatches](#httpqueryparammatch). Multiple match values are ANDed together.                      |
+| `path`        | An [HTTPPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
+| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch). Multiple match values are ANDed together.                              |
+| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch). Multiple match values are ANDed together.                      |
 | `method`      | When specified, this route will be matched only if the request has the specified method.                                |
 
 {{< /keyval >}}
 
-### httpPathMatch
+### HTTPPathMatch
 
 `HTTPPathMatch` describes how to select a HTTP route by matching the HTTP
 request path.
@@ -157,7 +157,7 @@ request path.
 
 {{< /keyval >}}
 
-### httpHeaderMatch
+### HTTPHeaderMatch
 
 `HTTPHeaderMatch` describes how to select a HTTP route by matching HTTP request
 headers.
@@ -172,7 +172,7 @@ headers.
 
 {{< /keyval >}}
 
-### httpQueryParamMatch
+### HTTPQueryParamMatch
 
 `HTTPQueryParamMatch` describes how to select a HTTP route by matching HTTP
 query parameters.
@@ -187,7 +187,7 @@ query parameters.
 
 {{< /keyval >}}
 
-### httpRouteFilter
+### HTTPRouteFilter
 
 HTTPRouteFilter defines processing steps that must be completed during the
 request or response lifecycle.
@@ -197,13 +197,13 @@ request or response lifecycle.
 | field                    | value                                                                      |
 | ------------------------ | -------------------------------------------------------------------------- |
 | `type`                   | One of: RequestHeaderModifier, ResponseHeaderModifier, or RequestRedirect. |
-| `requestHeaderModifier`  | An [httpHeaderFilter](#httpheaderfilter) which modifies request headers.   |
-| `responseHeaderModifier` | An [httpHeaderFilter](#httpheaderfilter) which modifies response headers.  |
-| `requestRedirect`        | An [httpRequestRedirectFilter](#httprequestredirectfilter).                |
+| `requestHeaderModifier`  | An [HTTPHeaderFilter](#httpheaderfilter) which modifies request headers.   |
+| `responseHeaderModifier` | An [HTTPHeaderFilter](#httpheaderfilter) which modifies response headers.  |
+| `requestRedirect`        | An [HTTPRequestRedirectFilter](#httprequestredirectfilter).                |
 
 {{< /keyval >}}
 
-### httpHeaderFilter
+### HTTPHeaderFilter
 
 A filter which modifies HTTP request or response headers.
 
@@ -211,13 +211,13 @@ A filter which modifies HTTP request or response headers.
 
 | field    | value                                                                                                       |
 | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `set`    | A list of [httpHeaders](#httpheader) to overwrite on the request or response.                               |
-| `add`    | A list of [httpHeaders](#httpheader) to add on to the request or response, appending to any existing value. |
+| `set`    | A list of [HTTPHeader](#httpheader) to overwrite on the request or response.                               |
+| `add`    | A list of [HTTPHeader](#httpheader) to add on to the request or response, appending to any existing value. |
 | `remove` | A list of header names to remove from the request or response.                                              |
 
 {{< /keyval >}}
 
-### httpHeader
+### HTTPHeader
 
 `HTTPHeader` represents an HTTP Header name and value as defined by RFC 7230.
 
@@ -230,7 +230,7 @@ A filter which modifies HTTP request or response headers.
 
 {{< /keyval >}}
 
-### httpRequestRedirectFilter
+### HTTPRequestRedirectFilter
 
 `HTTPRequestRedirect` defines a filter that redirects a request.
 
@@ -240,7 +240,7 @@ A filter which modifies HTTP request or response headers.
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
 | `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
-| `path`       | An [HTTPPathModifier](#HTTPPathModifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
+| `path`       | An [HTTPPathModifier](#httppathmodifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
 | `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
 | `statusCode` | The HTTP status code to be used in response.                                                                                                |
 
@@ -260,7 +260,7 @@ A filter which modifies HTTP request or response headers.
 
 {{< /keyval >}}
 
-### httpBackendRef
+### HTTPBackendRef
 
 `HTTPBackendRef` defines the list of objects where matching requests should be
 sent to. Only allowed when a route has Service [parentRefs](#parentreference).
@@ -276,7 +276,7 @@ sent to. Only allowed when a route has Service [parentRefs](#parentreference).
 
 {{< /keyval >}}
 
-### httpRouteTimeouts
+### HTTPRouteTimeouts
 
 `HTTPRouteTimeouts` defines the timeouts that can be configured for an HTTP
 request.

--- a/linkerd.io/content/2.19/reference/httproute.md
+++ b/linkerd.io/content/2.19/reference/httproute.md
@@ -240,13 +240,13 @@ A filter which modifies HTTP request or response headers.
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
 | `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
-| `path`       | An [httpPathModfier](#httppathmodfier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
+| `path`       | An [HTTPPathModifier](#HTTPPathModifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
 | `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
 | `statusCode` | The HTTP status code to be used in response.                                                                                                |
 
 {{< /keyval >}}
 
-### httpPathModfier
+### HTTPPathModifier
 
 `HTTPPathModifier` defines configuration for path modifiers.
 

--- a/linkerd.io/content/2.19/reference/httproute.md
+++ b/linkerd.io/content/2.19/reference/httproute.md
@@ -121,7 +121,7 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `matches`     | A list of [HTTPRouteMatch](#httproutematch) resources. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
 | `filters`     | A list of [HTTPRouteFilter](#httproutefilter) resources which will be applied to each request which matches this rule.                                       |
-| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) resources to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
 | `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                        |
 
 {{< /keyval >}}

--- a/linkerd.io/content/2.19/reference/httproute.md
+++ b/linkerd.io/content/2.19/reference/httproute.md
@@ -117,12 +117,12 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 
 {{< keyval >}}
 
-| field         | value                                                                                                                                                       |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `matches`     | A list of [HTTPRouteMatch](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
-| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) which will be applied to each request which matches this rule.                                               |
-| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
-| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
+| field         | value                                                                                                                                                        |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `matches`     | A list of [HTTPRouteMatch](#httproutematch) resources. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
+| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) resources which will be applied to each request which matches this rule.                                       |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
+| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                        |
 
 {{< /keyval >}}
 
@@ -137,8 +137,8 @@ only if all conditions are satisfied.
 | field         | value                                                                                                                   |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `path`        | An [HTTPPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
-| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch). Multiple match values are ANDed together.                              |
-| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch). Multiple match values are ANDed together.                      |
+| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch) resources. Multiple match values are ANDed together.                      |
+| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch) resources. Multiple match values are ANDed together.              |
 | `method`      | When specified, this route will be matched only if the request has the specified method.                                |
 
 {{< /keyval >}}
@@ -209,11 +209,11 @@ A filter which modifies HTTP request or response headers.
 
 {{< keyval >}}
 
-| field    | value                                                                                                       |
-| -------- | ----------------------------------------------------------------------------------------------------------- |
-| `set`    | A list of [HTTPHeader](#httpheader) to overwrite on the request or response.                               |
-| `add`    | A list of [HTTPHeader](#httpheader) to add on to the request or response, appending to any existing value. |
-| `remove` | A list of header names to remove from the request or response.                                              |
+| field    | value                                                                                                                |
+| -------- | -------------------------------------------------------------------------------------------------------------------- |
+| `set`    | A list of [HTTPHeader](#httpheader) resources to overwrite on the request or response.                               |
+| `add`    | A list of [HTTPHeader](#httpheader) resources to add on to the request or response, appending to any existing value. |
+| `remove` | A list of header names to remove from the request or response.                                                       |
 
 {{< /keyval >}}
 
@@ -236,13 +236,13 @@ A filter which modifies HTTP request or response headers.
 
 {{< keyval >}}
 
-| field        | value                                                                                                                                       |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
-| `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
+| field        | value                                                                                                                                         |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                   |
+| `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.               |
 | `path`       | An [HTTPPathModifier](#httppathmodifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
-| `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
-| `statusCode` | The HTTP status code to be used in response.                                                                                                |
+| `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.            |
+| `statusCode` | The HTTP status code to be used in response.                                                                                                  |
 
 {{< /keyval >}}
 

--- a/linkerd.io/content/2.19/reference/httproute.md
+++ b/linkerd.io/content/2.19/reference/httproute.md
@@ -110,7 +110,7 @@ GEP-1426][ns-boundaries] for details on producer and consumer routes.
 
 {{< /keyval >}}
 
-### httpRouteRule
+### HTTPRouteRule
 
 HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 (matches) and processing it (filters).
@@ -119,14 +119,14 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 
 | field         | value                                                                                                                                                       |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `matches`     | A list of [httpRouteMatches](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
-| `filters`     | A list of [httpRouteFilters](#httproutefilter) which will be applied to each request which matches this rule.                                               |
-| `backendRefs` | An array of [HTTPBackendRefs](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
-| `timeouts`    | An optional [httpRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
+| `matches`     | A list of [HTTPRouteMatch](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
+| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) which will be applied to each request which matches this rule.                                               |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
+| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
 
 {{< /keyval >}}
 
-### httpRouteMatch
+### HTTPRouteMatch
 
 HTTPRouteMatch defines the predicate used to match requests to a given action.
 Multiple match types are ANDed together, i.e. the match will evaluate to true
@@ -136,14 +136,14 @@ only if all conditions are satisfied.
 
 | field         | value                                                                                                                   |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `path`        | An [httpPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
-| `headers`     | A list of [httpHeaderMatches](#httpheadermatch). Multiple match values are ANDed together.                              |
-| `queryParams` | A list of [httpQueryParamMatches](#httpqueryparammatch). Multiple match values are ANDed together.                      |
+| `path`        | An [HTTPPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
+| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch). Multiple match values are ANDed together.                              |
+| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch). Multiple match values are ANDed together.                      |
 | `method`      | When specified, this route will be matched only if the request has the specified method.                                |
 
 {{< /keyval >}}
 
-### httpPathMatch
+### HTTPPathMatch
 
 `HTTPPathMatch` describes how to select a HTTP route by matching the HTTP
 request path.
@@ -157,7 +157,7 @@ request path.
 
 {{< /keyval >}}
 
-### httpHeaderMatch
+### HTTPHeaderMatch
 
 `HTTPHeaderMatch` describes how to select a HTTP route by matching HTTP request
 headers.
@@ -172,7 +172,7 @@ headers.
 
 {{< /keyval >}}
 
-### httpQueryParamMatch
+### HTTPQueryParamMatch
 
 `HTTPQueryParamMatch` describes how to select a HTTP route by matching HTTP
 query parameters.
@@ -187,7 +187,7 @@ query parameters.
 
 {{< /keyval >}}
 
-### httpRouteFilter
+### HTTPRouteFilter
 
 HTTPRouteFilter defines processing steps that must be completed during the
 request or response lifecycle.
@@ -197,13 +197,13 @@ request or response lifecycle.
 | field                    | value                                                                      |
 | ------------------------ | -------------------------------------------------------------------------- |
 | `type`                   | One of: RequestHeaderModifier, ResponseHeaderModifier, or RequestRedirect. |
-| `requestHeaderModifier`  | An [httpHeaderFilter](#httpheaderfilter) which modifies request headers.   |
-| `responseHeaderModifier` | An [httpHeaderFilter](#httpheaderfilter) which modifies response headers.  |
-| `requestRedirect`        | An [httpRequestRedirectFilter](#httprequestredirectfilter).                |
+| `requestHeaderModifier`  | An [HTTPHeaderFilter](#httpheaderfilter) which modifies request headers.   |
+| `responseHeaderModifier` | An [HTTPHeaderFilter](#httpheaderfilter) which modifies response headers.  |
+| `requestRedirect`        | An [HTTPRequestRedirectFilter](#httprequestredirectfilter).                |
 
 {{< /keyval >}}
 
-### httpHeaderFilter
+### HTTPHeaderFilter
 
 A filter which modifies HTTP request or response headers.
 
@@ -211,13 +211,13 @@ A filter which modifies HTTP request or response headers.
 
 | field    | value                                                                                                       |
 | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `set`    | A list of [httpHeaders](#httpheader) to overwrite on the request or response.                               |
-| `add`    | A list of [httpHeaders](#httpheader) to add on to the request or response, appending to any existing value. |
+| `set`    | A list of [HTTPHeader](#httpheader) to overwrite on the request or response.                               |
+| `add`    | A list of [HTTPHeader](#httpheader) to add on to the request or response, appending to any existing value. |
 | `remove` | A list of header names to remove from the request or response.                                              |
 
 {{< /keyval >}}
 
-### httpHeader
+### HTTPHeader
 
 `HTTPHeader` represents an HTTP Header name and value as defined by RFC 7230.
 
@@ -230,7 +230,7 @@ A filter which modifies HTTP request or response headers.
 
 {{< /keyval >}}
 
-### httpRequestRedirectFilter
+### HTTPRequestRedirectFilter
 
 `HTTPRequestRedirect` defines a filter that redirects a request.
 
@@ -240,7 +240,7 @@ A filter which modifies HTTP request or response headers.
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
 | `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
-| `path`       | An [HTTPPathModifier](#HTTPPathModifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
+| `path`       | An [HTTPPathModifier](#httppathmodifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
 | `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
 | `statusCode` | The HTTP status code to be used in response.                                                                                                |
 
@@ -260,7 +260,7 @@ A filter which modifies HTTP request or response headers.
 
 {{< /keyval >}}
 
-### httpBackendRef
+### HTTPBackendRef
 
 `HTTPBackendRef` defines the list of objects where matching requests should be
 sent to. Only allowed when a route has Service [parentRefs](#parentreference).
@@ -276,7 +276,7 @@ sent to. Only allowed when a route has Service [parentRefs](#parentreference).
 
 {{< /keyval >}}
 
-### httpRouteTimeouts
+### HTTPRouteTimeouts
 
 `HTTPRouteTimeouts` defines the timeouts that can be configured for an HTTP
 request.

--- a/linkerd.io/content/docs/reference/httproute.md
+++ b/linkerd.io/content/docs/reference/httproute.md
@@ -240,13 +240,13 @@ A filter which modifies HTTP request or response headers.
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
 | `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
-| `path`       | An [httpPathModfier](#httppathmodfier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
+| `path`       | An [HTTPPathModifier](#HTTPPathModifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
 | `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
 | `statusCode` | The HTTP status code to be used in response.                                                                                                |
 
 {{< /keyval >}}
 
-### httpPathModfier
+### HTTPPathModifier
 
 `HTTPPathModifier` defines configuration for path modifiers.
 

--- a/linkerd.io/content/docs/reference/httproute.md
+++ b/linkerd.io/content/docs/reference/httproute.md
@@ -121,7 +121,7 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `matches`     | A list of [HTTPRouteMatch](#httproutematch) resources. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
 | `filters`     | A list of [HTTPRouteFilter](#httproutefilter) resources which will be applied to each request which matches this rule.                                       |
-| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) resources to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
 | `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                        |
 
 {{< /keyval >}}

--- a/linkerd.io/content/docs/reference/httproute.md
+++ b/linkerd.io/content/docs/reference/httproute.md
@@ -117,12 +117,12 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 
 {{< keyval >}}
 
-| field         | value                                                                                                                                                       |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `matches`     | A list of [HTTPRouteMatch](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
-| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) which will be applied to each request which matches this rule.                                               |
-| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
-| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
+| field         | value                                                                                                                                                        |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `matches`     | A list of [HTTPRouteMatch](#httproutematch) resources. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
+| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) resources which will be applied to each request which matches this rule.                                       |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)).   |
+| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                        |
 
 {{< /keyval >}}
 
@@ -137,8 +137,8 @@ only if all conditions are satisfied.
 | field         | value                                                                                                                   |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `path`        | An [HTTPPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
-| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch). Multiple match values are ANDed together.                              |
-| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch). Multiple match values are ANDed together.                      |
+| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch) resources. Multiple match values are ANDed together.                      |
+| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch) resources. Multiple match values are ANDed together.              |
 | `method`      | When specified, this route will be matched only if the request has the specified method.                                |
 
 {{< /keyval >}}
@@ -209,11 +209,11 @@ A filter which modifies HTTP request or response headers.
 
 {{< keyval >}}
 
-| field    | value                                                                                                       |
-| -------- | ----------------------------------------------------------------------------------------------------------- |
-| `set`    | A list of [HTTPHeader](#httpheader) to overwrite on the request or response.                               |
-| `add`    | A list of [HTTPHeader](#httpheader) to add on to the request or response, appending to any existing value. |
-| `remove` | A list of header names to remove from the request or response.                                              |
+| field    | value                                                                                                                |
+| -------- | -------------------------------------------------------------------------------------------------------------------- |
+| `set`    | A list of [HTTPHeader](#httpheader) resources to overwrite on the request or response.                               |
+| `add`    | A list of [HTTPHeader](#httpheader) resources to add on to the request or response, appending to any existing value. |
+| `remove` | A list of header names to remove from the request or response.                                                       |
 
 {{< /keyval >}}
 
@@ -236,13 +236,13 @@ A filter which modifies HTTP request or response headers.
 
 {{< keyval >}}
 
-| field        | value                                                                                                                                       |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
-| `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
+| field        | value                                                                                                                                         |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                   |
+| `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.               |
 | `path`       | An [HTTPPathModifier](#httppathmodifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
-| `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
-| `statusCode` | The HTTP status code to be used in response.                                                                                                |
+| `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.            |
+| `statusCode` | The HTTP status code to be used in response.                                                                                                  |
 
 {{< /keyval >}}
 

--- a/linkerd.io/content/docs/reference/httproute.md
+++ b/linkerd.io/content/docs/reference/httproute.md
@@ -110,7 +110,7 @@ GEP-1426][ns-boundaries] for details on producer and consumer routes.
 
 {{< /keyval >}}
 
-### httpRouteRule
+### HTTPRouteRule
 
 HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 (matches) and processing it (filters).
@@ -119,14 +119,14 @@ HTTPRouteRule defines semantics for matching an HTTP request based on conditions
 
 | field         | value                                                                                                                                                       |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `matches`     | A list of [httpRouteMatches](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
-| `filters`     | A list of [httpRouteFilters](#httproutefilter) which will be applied to each request which matches this rule.                                               |
-| `backendRefs` | An array of [HTTPBackendRefs](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
-| `timeouts`    | An optional [httpRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
+| `matches`     | A list of [HTTPRouteMatch](#httproutematch). Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.        |
+| `filters`     | A list of [HTTPRouteFilter](#httproutefilter) which will be applied to each request which matches this rule.                                               |
+| `backendRefs` | An array of [HTTPBackendRef](#httpbackendref) to declare where the traffic should be routed to (only allowed with Service [parentRefs](#parentreference)). |
+| `timeouts`    | An optional [HTTPRouteTimeouts](#httproutetimeouts) object which configures timeouts for requests matching this rule.                                       |
 
 {{< /keyval >}}
 
-### httpRouteMatch
+### HTTPRouteMatch
 
 HTTPRouteMatch defines the predicate used to match requests to a given action.
 Multiple match types are ANDed together, i.e. the match will evaluate to true
@@ -136,14 +136,14 @@ only if all conditions are satisfied.
 
 | field         | value                                                                                                                   |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `path`        | An [httpPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
-| `headers`     | A list of [httpHeaderMatches](#httpheadermatch). Multiple match values are ANDed together.                              |
-| `queryParams` | A list of [httpQueryParamMatches](#httpqueryparammatch). Multiple match values are ANDed together.                      |
+| `path`        | An [HTTPPathMatch](#httppathmatch). If this field is not specified, a default prefix match on the "/" path is provided. |
+| `headers`     | A list of [HTTPHeaderMatch](#httpheadermatch). Multiple match values are ANDed together.                              |
+| `queryParams` | A list of [HTTPQueryParamMatch](#httpqueryparammatch). Multiple match values are ANDed together.                      |
 | `method`      | When specified, this route will be matched only if the request has the specified method.                                |
 
 {{< /keyval >}}
 
-### httpPathMatch
+### HTTPPathMatch
 
 `HTTPPathMatch` describes how to select a HTTP route by matching the HTTP
 request path.
@@ -157,7 +157,7 @@ request path.
 
 {{< /keyval >}}
 
-### httpHeaderMatch
+### HTTPHeaderMatch
 
 `HTTPHeaderMatch` describes how to select a HTTP route by matching HTTP request
 headers.
@@ -172,7 +172,7 @@ headers.
 
 {{< /keyval >}}
 
-### httpQueryParamMatch
+### HTTPQueryParamMatch
 
 `HTTPQueryParamMatch` describes how to select a HTTP route by matching HTTP
 query parameters.
@@ -187,7 +187,7 @@ query parameters.
 
 {{< /keyval >}}
 
-### httpRouteFilter
+### HTTPRouteFilter
 
 HTTPRouteFilter defines processing steps that must be completed during the
 request or response lifecycle.
@@ -197,13 +197,13 @@ request or response lifecycle.
 | field                    | value                                                                      |
 | ------------------------ | -------------------------------------------------------------------------- |
 | `type`                   | One of: RequestHeaderModifier, ResponseHeaderModifier, or RequestRedirect. |
-| `requestHeaderModifier`  | An [httpHeaderFilter](#httpheaderfilter) which modifies request headers.   |
-| `responseHeaderModifier` | An [httpHeaderFilter](#httpheaderfilter) which modifies response headers.  |
-| `requestRedirect`        | An [httpRequestRedirectFilter](#httprequestredirectfilter).                |
+| `requestHeaderModifier`  | An [HTTPHeaderFilter](#httpheaderfilter) which modifies request headers.   |
+| `responseHeaderModifier` | An [HTTPHeaderFilter](#httpheaderfilter) which modifies response headers.  |
+| `requestRedirect`        | An [HTTPRequestRedirectFilter](#httprequestredirectfilter).                |
 
 {{< /keyval >}}
 
-### httpHeaderFilter
+### HTTPHeaderFilter
 
 A filter which modifies HTTP request or response headers.
 
@@ -211,13 +211,13 @@ A filter which modifies HTTP request or response headers.
 
 | field    | value                                                                                                       |
 | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `set`    | A list of [httpHeaders](#httpheader) to overwrite on the request or response.                               |
-| `add`    | A list of [httpHeaders](#httpheader) to add on to the request or response, appending to any existing value. |
+| `set`    | A list of [HTTPHeader](#httpheader) to overwrite on the request or response.                               |
+| `add`    | A list of [HTTPHeader](#httpheader) to add on to the request or response, appending to any existing value. |
 | `remove` | A list of header names to remove from the request or response.                                              |
 
 {{< /keyval >}}
 
-### httpHeader
+### HTTPHeader
 
 `HTTPHeader` represents an HTTP Header name and value as defined by RFC 7230.
 
@@ -230,7 +230,7 @@ A filter which modifies HTTP request or response headers.
 
 {{< /keyval >}}
 
-### httpRequestRedirectFilter
+### HTTPRequestRedirectFilter
 
 `HTTPRequestRedirect` defines a filter that redirects a request.
 
@@ -240,7 +240,7 @@ A filter which modifies HTTP request or response headers.
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `scheme`     | The scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used.                 |
 | `hostname`   | The hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used.             |
-| `path`       | An [HTTPPathModifier](#HTTPPathModifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
+| `path`       | An [HTTPPathModifier](#httppathmodifier) which modifies the path of the incoming request and uses the modified path in the `Location` header. |
 | `port`       | The port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.          |
 | `statusCode` | The HTTP status code to be used in response.                                                                                                |
 
@@ -260,7 +260,7 @@ A filter which modifies HTTP request or response headers.
 
 {{< /keyval >}}
 
-### httpBackendRef
+### HTTPBackendRef
 
 `HTTPBackendRef` defines the list of objects where matching requests should be
 sent to. Only allowed when a route has Service [parentRefs](#parentreference).
@@ -276,7 +276,7 @@ sent to. Only allowed when a route has Service [parentRefs](#parentreference).
 
 {{< /keyval >}}
 
-### httpRouteTimeouts
+### HTTPRouteTimeouts
 
 `HTTPRouteTimeouts` defines the timeouts that can be configured for an HTTP
 request.


### PR DESCRIPTION
Correct a typo in linkerd.io content/2-edge/reference/httproute.md to improve documentation clarity and accuracy.

This change fixes a spelling error in the HTTPRoute reference page for the 2-edge docs, ensuring the Linkerd documentation remains professional and easy to understand.