### PR TITLE
fix(docs): correct typos in PSP and contributor docs

### DIFF
--- a/linkerd.io/README.md
+++ b/linkerd.io/README.md
@@ -109,14 +109,14 @@ params:
 ```
 
 **Note:** If an author only has a single blog post, but there's a chance they
-will have more in the future, please not use the inline method.
+will have more in the future, please do not use the inline method.
 
 #### Naming images
 
 To associate a cover, thumbnail, or feature image to a blog post, you do not
 have to specify them in the frontmatter. You can simply name them `cover`,
 `thumbnail` or `feature`, place them in the blog post folder, and they will
-automattically be used. For example:
+automatically be used. For example:
 
 ```text
 blog/
@@ -171,7 +171,7 @@ params:
   thumbnailRatio: fit
 ```
 
-You can automattically show the cover image at the top of the blog post by
+You can automatically show the cover image at the top of the blog post by
 adding the `showCover` frontmatter param. For example:
 
 ```yaml

--- a/linkerd.io/assets/js/highlight-copy.js
+++ b/linkerd.io/assets/js/highlight-copy.js
@@ -1,4 +1,4 @@
-// Add copy button to all codeblocks that have been highlighed by Hugo
+// Add copy button to all code blocks that have been highlighted by Hugo
 window.addEventListener(
   "DOMContentLoaded",
   function (event) {

--- a/linkerd.io/content/2-edge/tasks/using-psp.md
+++ b/linkerd.io/content/2-edge/tasks/using-psp.md
@@ -1,10 +1,10 @@
 ---
 title: Linkerd and Pod Security Policies (PSP)
-description: Using Linkerd with a pod security policies enabled.
+description: Using Linkerd with pod security policies enabled.
 ---
 
 [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)
-have been deprecated in Kuberenetes v1.21 and removed in v1.25. However, for
+have been deprecated in Kubernetes v1.21 and removed in v1.25. However, for
 users who still want them, the Linkerd control plane comes with its own
 minimally privileged Pod Security Policy and the associated RBAC resources which
 can be optionally created by setting the `--set enablePSP=true` flag during

--- a/linkerd.io/content/2.10/tasks/using-psp.md
+++ b/linkerd.io/content/2.10/tasks/using-psp.md
@@ -1,6 +1,6 @@
 ---
 title: Linkerd and Pod Security Policies (PSP)
-description: Using Linkerd with a pod security policies enabled.
+description: Using Linkerd with pod security policies enabled.
 ---
 
 The Linkerd control plane comes with its own minimally privileged

--- a/linkerd.io/content/2.11/tasks/using-psp.md
+++ b/linkerd.io/content/2.11/tasks/using-psp.md
@@ -1,6 +1,6 @@
 ---
 title: Linkerd and Pod Security Policies (PSP)
-description: Using Linkerd with a pod security policies enabled.
+description: Using Linkerd with pod security policies enabled.
 ---
 
 The Linkerd control plane comes with its own minimally privileged

--- a/linkerd.io/content/2.12/tasks/using-psp.md
+++ b/linkerd.io/content/2.12/tasks/using-psp.md
@@ -1,10 +1,10 @@
 ---
 title: Linkerd and Pod Security Policies (PSP)
-description: Using Linkerd with a pod security policies enabled.
+description: Using Linkerd with pod security policies enabled.
 ---
 
 [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)
-have been deprecated in Kuberenetes v1.21 and removed in v1.25. However, for
+have been deprecated in Kubernetes v1.21 and removed in v1.25. However, for
 users who still want them, the Linkerd control plane comes with its own
 minimally privileged Pod Security Policy and the associated RBAC resources which
 can be optionally created by setting the `--set enablePSP=true` flag during

--- a/linkerd.io/content/2.13/tasks/using-psp.md
+++ b/linkerd.io/content/2.13/tasks/using-psp.md
@@ -1,10 +1,10 @@
 ---
 title: Linkerd and Pod Security Policies (PSP)
-description: Using Linkerd with a pod security policies enabled.
+description: Using Linkerd with pod security policies enabled.
 ---
 
 [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)
-have been deprecated in Kuberenetes v1.21 and removed in v1.25. However, for
+have been deprecated in Kubernetes v1.21 and removed in v1.25. However, for
 users who still want them, the Linkerd control plane comes with its own
 minimally privileged Pod Security Policy and the associated RBAC resources which
 can be optionally created by setting the `--set enablePSP=true` flag during

--- a/linkerd.io/content/2.14/tasks/using-psp.md
+++ b/linkerd.io/content/2.14/tasks/using-psp.md
@@ -1,10 +1,10 @@
 ---
 title: Linkerd and Pod Security Policies (PSP)
-description: Using Linkerd with a pod security policies enabled.
+description: Using Linkerd with pod security policies enabled.
 ---
 
 [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)
-have been deprecated in Kuberenetes v1.21 and removed in v1.25. However, for
+have been deprecated in Kubernetes v1.21 and removed in v1.25. However, for
 users who still want them, the Linkerd control plane comes with its own
 minimally privileged Pod Security Policy and the associated RBAC resources which
 can be optionally created by setting the `--set enablePSP=true` flag during

--- a/linkerd.io/content/2.15/tasks/using-psp.md
+++ b/linkerd.io/content/2.15/tasks/using-psp.md
@@ -1,10 +1,10 @@
 ---
 title: Linkerd and Pod Security Policies (PSP)
-description: Using Linkerd with a pod security policies enabled.
+description: Using Linkerd with pod security policies enabled.
 ---
 
 [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)
-have been deprecated in Kuberenetes v1.21 and removed in v1.25. However, for
+have been deprecated in Kubernetes v1.21 and removed in v1.25. However, for
 users who still want them, the Linkerd control plane comes with its own
 minimally privileged Pod Security Policy and the associated RBAC resources which
 can be optionally created by setting the `--set enablePSP=true` flag during

--- a/linkerd.io/content/2.16/tasks/using-psp.md
+++ b/linkerd.io/content/2.16/tasks/using-psp.md
@@ -1,10 +1,10 @@
 ---
 title: Linkerd and Pod Security Policies (PSP)
-description: Using Linkerd with a pod security policies enabled.
+description: Using Linkerd with pod security policies enabled.
 ---
 
 [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)
-have been deprecated in Kuberenetes v1.21 and removed in v1.25. However, for
+have been deprecated in Kubernetes v1.21 and removed in v1.25. However, for
 users who still want them, the Linkerd control plane comes with its own
 minimally privileged Pod Security Policy and the associated RBAC resources which
 can be optionally created by setting the `--set enablePSP=true` flag during

--- a/linkerd.io/content/2.17/tasks/using-psp.md
+++ b/linkerd.io/content/2.17/tasks/using-psp.md
@@ -1,10 +1,10 @@
 ---
 title: Linkerd and Pod Security Policies (PSP)
-description: Using Linkerd with a pod security policies enabled.
+description: Using Linkerd with pod security policies enabled.
 ---
 
 [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)
-have been deprecated in Kuberenetes v1.21 and removed in v1.25. However, for
+have been deprecated in Kubernetes v1.21 and removed in v1.25. However, for
 users who still want them, the Linkerd control plane comes with its own
 minimally privileged Pod Security Policy and the associated RBAC resources which
 can be optionally created by setting the `--set enablePSP=true` flag during

--- a/linkerd.io/content/2.18/tasks/using-psp.md
+++ b/linkerd.io/content/2.18/tasks/using-psp.md
@@ -1,10 +1,10 @@
 ---
 title: Linkerd and Pod Security Policies (PSP)
-description: Using Linkerd with a pod security policies enabled.
+description: Using Linkerd with pod security policies enabled.
 ---
 
 [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)
-have been deprecated in Kuberenetes v1.21 and removed in v1.25. However, for
+have been deprecated in Kubernetes v1.21 and removed in v1.25. However, for
 users who still want them, the Linkerd control plane comes with its own
 minimally privileged Pod Security Policy and the associated RBAC resources which
 can be optionally created by setting the `--set enablePSP=true` flag during

--- a/linkerd.io/content/2.19/tasks/using-psp.md
+++ b/linkerd.io/content/2.19/tasks/using-psp.md
@@ -1,10 +1,10 @@
 ---
 title: Linkerd and Pod Security Policies (PSP)
-description: Using Linkerd with a pod security policies enabled.
+description: Using Linkerd with pod security policies enabled.
 ---
 
 [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)
-have been deprecated in Kuberenetes v1.21 and removed in v1.25. However, for
+have been deprecated in Kubernetes v1.21 and removed in v1.25. However, for
 users who still want them, the Linkerd control plane comes with its own
 minimally privileged Pod Security Policy and the associated RBAC resources which
 can be optionally created by setting the `--set enablePSP=true` flag during

--- a/linkerd.io/content/blog/2018/1023-a-linkerd-2-0-deep-dive-unboxing-debugging-and-monitoring-kubernetes-services-on-azure/index.md
+++ b/linkerd.io/content/blog/2018/1023-a-linkerd-2-0-deep-dive-unboxing-debugging-and-monitoring-kubernetes-services-on-azure/index.md
@@ -22,7 +22,7 @@ the install process, and extensive looks at Linkerd’s UNIX-style CLI, includin
 ‘stat’, ‘tap’ and ‘top’ commands to track service behaviors like inbound and
 outbound request performance.
 
-Lachie installs an Golang app with broken service in an Azure Kubernetes
+Lachie installs a Go app with a broken service in an Azure Kubernetes
 environment and then does some nifty live debugging the demo app. In the Linkerd
 2.0 dashboard UX, he looks at service topologies and then checks out different
 views of service behaviors to find failing services and identify the source of

--- a/linkerd.io/content/docs/tasks/using-psp.md
+++ b/linkerd.io/content/docs/tasks/using-psp.md
@@ -1,10 +1,10 @@
 ---
 title: Linkerd and Pod Security Policies (PSP)
-description: Using Linkerd with a pod security policies enabled.
+description: Using Linkerd with pod security policies enabled.
 ---
 
 [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)
-have been deprecated in Kuberenetes v1.21 and removed in v1.25. However, for
+have been deprecated in Kubernetes v1.21 and removed in v1.25. However, for
 users who still want them, the Linkerd control plane comes with its own
 minimally privileged Pod Security Policy and the associated RBAC resources which
 can be optionally created by setting the `--set enablePSP=true` flag during


### PR DESCRIPTION
small docs paper cut.

what broke
live docs text had a few obvious typos. the PSP pages repeated `Kuberenetes` and awkward `a pod security policies enabled` wording. `linkerd.io/README.md` had a couple spelling slips too.

what changed
cleaned up those typos across the maintained PSP pages, the contributor-facing README, one blog line, and one JS comment. no behavior change, just text cleanup.

how to repro
1. run `rg -n "Kuberenetes|a pod security policies enabled|please not use|automattically|highlighed|an Golang app with broken service" linkerd.io -S`
2. or just open the PSP docs intro and the typo jumps out, pretty quick.

checks
`make lint`
`make build-linkerd.io`
`bin/htmltest --conf .htmltest.yml` from `tmp/linkerd.io`
