### PR TITLE
fix: remove dead links from blog posts

### DIFF
--- a/linkerd.io/content/blog/2020/0723-under-the-hood-of-linkerd-s-state-of-the-art-rust-proxy-linkerd2-proxy/index.md
+++ b/linkerd.io/content/blog/2020/0723-under-the-hood-of-linkerd-s-state-of-the-art-rust-proxy-linkerd2-proxy/index.md
@@ -72,10 +72,9 @@ ran on the Java Virtual Machine, it had a pretty significant resource footprint.
 (The JVM is good at "scaling up", but not good at "scaling _down_", as William
 wrote in his InfoQ article on
 [the decision to reimplement Linkerd](https://www.infoq.com/articles/linkerd-v2-production-adoption/).)
-Even though the Linkerd community
-[got pretty good](/2016/06/17/small-memory-jvm-techniques-for-microservice-sidecars/)
-at tuning the JVM's memory use to minimize footprint, it was still too much to
-ask in a per-pod service mesh deployment model. So we knew we'd need a language
+Even though the Linkerd community got pretty good at tuning the JVM's memory use
+to minimize footprint, it was still too much to ask in a per-pod service mesh
+deployment model. So we knew we'd need a language
 that compiled to native binaries, like Rust, Go, and C++.
 
 Now, latency. Another lesson we learned from Linkerd 1.x that informed our

--- a/linkerd.io/content/blog/2021/0728-announcing-cncf-graduation/index.md
+++ b/linkerd.io/content/blog/2021/0728-announcing-cncf-graduation/index.md
@@ -14,10 +14,10 @@ at the foundation's highest level of project maturity.
 
 ## A victory for simplicity in a space notorious for complexity
 
-For a project that started out as
-[a small wrapper over some open source Twitter libraries](/2016/02/18/linkerd-twitter-style-operability-for-microservices/)
-and went on to face intense competition from some of the biggest companies in
-the world, graduation is a significant victory. But not just for Linkerd.
+For a project that started out as a small wrapper over some open source Twitter
+libraries and went on to face intense competition from some of the biggest
+companies in the world, graduation is a significant victory. But not just for
+Linkerd.
 
 This is a victory for everyone who has championed the virtues of simplicity and
 minimalism and rejected the narrative that service meshes must be complex and

--- a/linkerd.io/content/blog/2022/1228-service-mesh-2022-recap-ebpf-gateway-api/index.md
+++ b/linkerd.io/content/blog/2022/1228-service-mesh-2022-recap-ebpf-gateway-api/index.md
@@ -147,7 +147,7 @@ Although, rumors swirl about another KEP...
 {{< x user="La_Rainette" id="1591198130049257473" >}}
 
 Further reading:
-[What really happens at startup: Linkerd, init containers, the CNI, and more](/2022/12/01/what-really-happens-at-startup-linkerd-init-containers-the-cni-and-more/).
+[What really happens at startup: Linkerd, init containers, the CNI, and more](/2022/12/01/what-really-happens-at-startup-a-deep-dive-into-linkerd-init-containers-cni-plugins-and-more/).
 
 ## Non-surprise #2: Security continues to be a top driver of Linkerd adoption
 


### PR DESCRIPTION
Fixes 3 dead links in older blog posts.

Why
These source pages are live, but the links inside them send readers to 404s right now. Pretty easy to hit in practice, just click through.

Repro
`curl -s -o /dev/null -w '%{http_code}\n' https://linkerd.io/2020/07/23/under-the-hood-of-linkerds-state-of-the-art-rust-proxy-linkerd2-proxy/`
`curl -s -o /dev/null -w '%{http_code}\n' https://linkerd.io/2016/06/17/small-memory-jvm-techniques-for-microservice-sidecars/`

`curl -s -o /dev/null -w '%{http_code}\n' https://linkerd.io/2021/07/28/announcing-cncf-graduation/`
`curl -s -o /dev/null -w '%{http_code}\n' https://linkerd.io/2016/02/18/linkerd-twitter-style-operability-for-microservices/`

`curl -s -o /dev/null -w '%{http_code}\n' https://linkerd.io/2022/12/28/service-mesh-2022-recap-ebpf-gateway-api/`
`curl -s -o /dev/null -w '%{http_code}\n' https://linkerd.io/2022/12/01/what-really-happens-at-startup-linkerd-init-containers-the-cni-and-more/`

What changed
Removed 2 dead links where there is no matching in-repo target, and fixed 1 slug to the live 2022 post. nice and boring.

Checks
`make build-linkerd.io`
`make lint`
