### PR TITLE
fix(docs): correct troubleshooting checks hint URLs

### DIFF
--- a/linkerd.io/content/2-edge/tasks/troubleshooting.md
+++ b/linkerd.io/content/2-edge/tasks/troubleshooting.md
@@ -740,7 +740,7 @@ Example warning:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
         * emojivoto/vote-bot-588499c9f6-zpwz6
         * emojivoto/voting-8599548fdc-6v64k
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 Observing this warning indicates that some of your meshed pods have proxies that
@@ -759,7 +759,7 @@ components:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
         * linkerd-viz/tap-68d8bbf64-mpzgb
         * linkerd-viz/web-849f74b7c6-qlhwc
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 If that is the case, simply wait for the `upgrade` operation to complete. The

--- a/linkerd.io/content/2.10/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.10/tasks/troubleshooting.md
@@ -780,7 +780,7 @@ Example warning:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
         * emojivoto/vote-bot-588499c9f6-zpwz6
         * emojivoto/voting-8599548fdc-6v64k
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 Observing this warning indicates that some of your meshed pods have proxies that
@@ -799,7 +799,7 @@ components:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
         * linkerd-viz/tap-68d8bbf64-mpzgb
         * linkerd-viz/web-849f74b7c6-qlhwc
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 If that is the case, simply wait for the `upgrade` operation to complete. The

--- a/linkerd.io/content/2.11/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.11/tasks/troubleshooting.md
@@ -848,7 +848,7 @@ Example warning:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
         * emojivoto/vote-bot-588499c9f6-zpwz6
         * emojivoto/voting-8599548fdc-6v64k
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 Observing this warning indicates that some of your meshed pods have proxies that
@@ -867,7 +867,7 @@ components:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
         * linkerd-viz/tap-68d8bbf64-mpzgb
         * linkerd-viz/web-849f74b7c6-qlhwc
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 If that is the case, simply wait for the `upgrade` operation to complete. The

--- a/linkerd.io/content/2.12/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.12/tasks/troubleshooting.md
@@ -740,7 +740,7 @@ Example warning:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
         * emojivoto/vote-bot-588499c9f6-zpwz6
         * emojivoto/voting-8599548fdc-6v64k
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 Observing this warning indicates that some of your meshed pods have proxies that
@@ -759,7 +759,7 @@ components:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
         * linkerd-viz/tap-68d8bbf64-mpzgb
         * linkerd-viz/web-849f74b7c6-qlhwc
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 If that is the case, simply wait for the `upgrade` operation to complete. The

--- a/linkerd.io/content/2.13/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.13/tasks/troubleshooting.md
@@ -740,7 +740,7 @@ Example warning:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
         * emojivoto/vote-bot-588499c9f6-zpwz6
         * emojivoto/voting-8599548fdc-6v64k
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 Observing this warning indicates that some of your meshed pods have proxies that
@@ -759,7 +759,7 @@ components:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
         * linkerd-viz/tap-68d8bbf64-mpzgb
         * linkerd-viz/web-849f74b7c6-qlhwc
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 If that is the case, simply wait for the `upgrade` operation to complete. The

--- a/linkerd.io/content/2.14/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.14/tasks/troubleshooting.md
@@ -740,7 +740,7 @@ Example warning:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
         * emojivoto/vote-bot-588499c9f6-zpwz6
         * emojivoto/voting-8599548fdc-6v64k
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 Observing this warning indicates that some of your meshed pods have proxies that
@@ -759,7 +759,7 @@ components:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
         * linkerd-viz/tap-68d8bbf64-mpzgb
         * linkerd-viz/web-849f74b7c6-qlhwc
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 If that is the case, simply wait for the `upgrade` operation to complete. The

--- a/linkerd.io/content/2.15/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.15/tasks/troubleshooting.md
@@ -740,7 +740,7 @@ Example warning:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
         * emojivoto/vote-bot-588499c9f6-zpwz6
         * emojivoto/voting-8599548fdc-6v64k
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 Observing this warning indicates that some of your meshed pods have proxies that
@@ -759,7 +759,7 @@ components:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
         * linkerd-viz/tap-68d8bbf64-mpzgb
         * linkerd-viz/web-849f74b7c6-qlhwc
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 If that is the case, simply wait for the `upgrade` operation to complete. The

--- a/linkerd.io/content/2.16/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.16/tasks/troubleshooting.md
@@ -740,7 +740,7 @@ Example warning:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
         * emojivoto/vote-bot-588499c9f6-zpwz6
         * emojivoto/voting-8599548fdc-6v64k
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 Observing this warning indicates that some of your meshed pods have proxies that
@@ -759,7 +759,7 @@ components:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
         * linkerd-viz/tap-68d8bbf64-mpzgb
         * linkerd-viz/web-849f74b7c6-qlhwc
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 If that is the case, simply wait for the `upgrade` operation to complete. The

--- a/linkerd.io/content/2.17/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.17/tasks/troubleshooting.md
@@ -740,7 +740,7 @@ Example warning:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
         * emojivoto/vote-bot-588499c9f6-zpwz6
         * emojivoto/voting-8599548fdc-6v64k
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 Observing this warning indicates that some of your meshed pods have proxies that
@@ -759,7 +759,7 @@ components:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
         * linkerd-viz/tap-68d8bbf64-mpzgb
         * linkerd-viz/web-849f74b7c6-qlhwc
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 If that is the case, simply wait for the `upgrade` operation to complete. The

--- a/linkerd.io/content/2.18/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.18/tasks/troubleshooting.md
@@ -740,7 +740,7 @@ Example warning:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
         * emojivoto/vote-bot-588499c9f6-zpwz6
         * emojivoto/voting-8599548fdc-6v64k
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 Observing this warning indicates that some of your meshed pods have proxies that
@@ -759,7 +759,7 @@ components:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
         * linkerd-viz/tap-68d8bbf64-mpzgb
         * linkerd-viz/web-849f74b7c6-qlhwc
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 If that is the case, simply wait for the `upgrade` operation to complete. The

--- a/linkerd.io/content/2.19/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.19/tasks/troubleshooting.md
@@ -740,7 +740,7 @@ Example warning:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
         * emojivoto/vote-bot-588499c9f6-zpwz6
         * emojivoto/voting-8599548fdc-6v64k
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 Observing this warning indicates that some of your meshed pods have proxies that
@@ -759,7 +759,7 @@ components:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
         * linkerd-viz/tap-68d8bbf64-mpzgb
         * linkerd-viz/web-849f74b7c6-qlhwc
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 If that is the case, simply wait for the `upgrade` operation to complete. The

--- a/linkerd.io/content/docs/tasks/troubleshooting.md
+++ b/linkerd.io/content/docs/tasks/troubleshooting.md
@@ -740,7 +740,7 @@ Example warning:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
         * emojivoto/vote-bot-588499c9f6-zpwz6
         * emojivoto/voting-8599548fdc-6v64k
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 Observing this warning indicates that some of your meshed pods have proxies that
@@ -759,7 +759,7 @@ components:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
         * linkerd-viz/tap-68d8bbf64-mpzgb
         * linkerd-viz/web-849f74b7c6-qlhwc
-    see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints
+    see https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca for hints
 ```
 
 If that is the case, simply wait for the `upgrade` operation to complete. The


### PR DESCRIPTION
bad checks hint URLs slipped into the troubleshooting examples. the docs show `https://linkerd.io/2/checks/{#...`, so that hint is busted right now on the live page.

this swaps `/{#...` to `/#...` in the affected troubleshooting pages. tiny fix, but it makes the hint usable again.

repro:
1. open `https://linkerd.io/docs/tasks/troubleshooting/`
2. find `see https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca for hints`
3. run `curl -I 'https://linkerd.io/2/checks/{#l5d-identity-data-plane-proxies-certs-match-ca'`
4. `curl` bails with `unmatched brace in URL position 29`

after this PR:
`curl -I 'https://linkerd.io/2/checks/#l5d-identity-data-plane-proxies-certs-match-ca'`
returns a redirect, all good.

related: #1769, #1860
