### PR TITLE
Fix lang on command output examples

### DIFF
--- a/linkerd.io/content/2-edge/tasks/replacing_expired_certificates.md
+++ b/linkerd.io/content/2-edge/tasks/replacing_expired_certificates.md
@@ -16,7 +16,7 @@ replace the expired certificates with valid certificates.
 It might be the case that your issuer certificate is expired. If this it true
 running `linkerd check --proxy` will produce output similar to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -41,7 +41,7 @@ replace both your root and issuer certificates at the same time. If your root
 has expired `linkerd check` will indicate that by outputting an error similar
 to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -75,7 +75,7 @@ If you run `linkerd check --proxy` while pods are restarting after the trust
 bundle is updated, you will probably see warnings about pods not having the
 current trust bundle:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -107,7 +107,7 @@ These warnings will disappear as restarts complete. Once they do, you can use
 configuration up to date. After that is done, `linkerd check` should run with no
 warnings or errors:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid

--- a/linkerd.io/content/2-edge/tasks/troubleshooting.md
+++ b/linkerd.io/content/2-edge/tasks/troubleshooting.md
@@ -16,7 +16,7 @@ installation.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane namespace does not already exist
     The "linkerd" namespace already exists
 ```
@@ -34,7 +34,7 @@ linkerd check --pre --linkerd-namespace linkerd-test
 The subsequent checks in this section validate whether you have permission to
 create the Kubernetes resources required for Linkerd installation, specifically:
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -47,7 +47,7 @@ These checks only run when the `--pre` flag is set This flag is intended for use
 prior to running `linkerd install`, to verify you have the correct RBAC
 permissions to install Linkerd.
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -90,7 +90,7 @@ These checks only run when the `--pre` flag is set. This flag is intended for
 use prior to running `linkerd install`, to verify you have not already installed
 the Linkerd control plane.
 
-```bash
+```text {class=disable-copy}
 √ no ClusterRoles exist
 √ no ClusterRoleBindings exist
 √ no CustomResourceDefinitions exist
@@ -113,7 +113,7 @@ linkerd check --pre --single-namespace
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     error configuring Kubernetes API client: stat badconfig: no such file or directory
 × can query the Kubernetes API
@@ -139,8 +139,8 @@ kubectl version
 
 Another example failure:
 
-```bash
-✘ can query the Kubernetes API
+```text {class=disable-copy}
+× can query the Kubernetes API
     Get REDACTED/version: x509: certificate signed by unknown authority
 ```
 
@@ -157,7 +157,7 @@ kubectl config set-cluster ${KUBE_CONTEXT} --insecure-skip-tls-verify=true \
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum Kubernetes API version
     Kubernetes is on version [1.7.16], but version [1.13.0] or more recent is required
 ```
@@ -172,7 +172,7 @@ kubectl version
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum kubectl version
     kubectl is on version [1.9.1], but version [1.13.0] or more recent is required
     see https://linkerd.io/2/checks/#kubectl-version for hints
@@ -198,7 +198,7 @@ resources have been installed.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane Namespace exists
     The "foo" namespace does not exist
     see https://linkerd.io/2/checks/#l5d-existence-ns for hints
@@ -221,7 +221,7 @@ linkerd check --linkerd-namespace linkerdtest
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-cr for hints
@@ -248,7 +248,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-crb for hints
@@ -275,7 +275,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ServiceAccounts exist
     missing ServiceAccounts: linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-sa for hints
@@ -305,7 +305,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane CustomResourceDefinitions exist
     missing CustomResourceDefinitions: serviceprofiles.linkerd.io
     see https://linkerd.io/2/checks/#l5d-existence-crd for hints
@@ -330,7 +330,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane MutatingWebhookConfigurations exist
     missing MutatingWebhookConfigurations: linkerd-proxy-injector-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-mwc for hints
@@ -354,7 +354,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ValidatingWebhookConfigurations exist
     missing ValidatingWebhookConfigurations: linkerd-sp-validator-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-vwc for hints
@@ -378,7 +378,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × proxy-init container runs as root user if docker container runtime is used
     there are nodes using the docker container runtime and proxy-init container must run as root user.
 try installing linkerd via --set proxyInit.runAsRoot=true
@@ -409,7 +409,7 @@ further details.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × 'linkerd-config' config map exists
     missing ConfigMaps: linkerd-config
     see https://linkerd.io/2/checks/#l5d-existence-linkerd-config for hints
@@ -441,7 +441,7 @@ For more information, see the Kubernetes documentation on
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × no unschedulable pods
     linkerd-prometheus-6b668f774d-j8ncr: 0/1 nodes are available: 1 Insufficient cpu.
     see https://linkerd.io/2/checks/#l5d-existence-unschedulable-pods for hints
@@ -456,13 +456,13 @@ For more information, see the Kubernetes documentation on the
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key ca.crt containing the trust anchors needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=true
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
 ```
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key crt.pem containing the issuer certificate needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=false
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
@@ -478,7 +478,7 @@ keys are `crt.pem` and `key.pem`.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are using supported crypto algorithm
     Invalid roots:
         * 165223702412626077778653586125774349756 identity.linkerd.cluster.local must use P-256 curve for public key, instead P-521 was used
@@ -492,7 +492,7 @@ algorithm.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are within their validity period
     Invalid roots:
         * 199607941798581518463476688845828639279 identity.linkerd.cluster.local not valid anymore. Expired on 2019-12-19T13:08:18Z
@@ -509,7 +509,7 @@ cluster back to a stable state.
 
 Example warnings:
 
-```bash
+```text {class=disable-copy}
 ‼ trust roots are valid for at least 60 days
     Roots expiring soon:
         * 66509928892441932260491975092256847205 identity.linkerd.cluster.local will expire on 2019-12-19T13:30:57Z
@@ -525,7 +525,7 @@ process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is using supported crypto algorithm
     issuer certificate must use P-256 curve for public key, instead P-521 was used
     see https://linkerd.io/2/checks/#5d-identity-issuer-cert-uses-supported-crypto for hints
@@ -540,7 +540,7 @@ to see how you can generate certificates that will work with Linkerd.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is within its validity period
     issuer certificate is not valid anymore. Expired on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-is-time-valid
@@ -554,7 +554,7 @@ bring your cluster back to a valid state, follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ issuer cert is valid for at least 60 days
     issuer certificate will expire on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-not-expiring-soon for hints
@@ -569,7 +569,7 @@ follow the process outlined in
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is issued by the trust root
     x509: certificate signed by unknown authority (possibly because of "x509: ECDSA verification failure" while trying to verify candidate authority certificate "identity.linkerd.cluster.local")
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-issued-by-trust-anchor for hints
@@ -594,7 +594,7 @@ linkerd upgrade \
 Once the upgrade process is over, the output of `linkerd check --proxy` should
 be:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -617,7 +617,7 @@ linkerd-identity-data-plane
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     secrets "linkerd-proxy-injector-tls" not found
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -628,7 +628,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-proxy-injector-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-proxy-injector.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -641,7 +641,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ proxy-injector cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-not-expiring-soon for hints
@@ -656,7 +656,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     secrets "linkerd-sp-validator-tls" not found
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -667,7 +667,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-sp-validator-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-sp-validator.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -680,7 +680,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ sp-validator cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-not-expiring-soon for hints
@@ -695,7 +695,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × policy-validator webhook has valid cert
     secrets "linkerd-policy-validator-tls" not found
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-valid for hints
@@ -704,7 +704,7 @@ Example failure:
 Ensure that the `linkerd-policy-validator-k8s-tls` secret exists and contains
 the appropriate `tls.crt` and `tls.key` data entries.
 
-```bash
+```text {class=disable-copy}
 × policy-validator webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-policy-validator.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-valid for hints
@@ -717,7 +717,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ policy-validator cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-not-expiring-soon for hints
@@ -734,7 +734,7 @@ can follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
@@ -753,7 +753,7 @@ the Linkerd components are restarted. While this operation is in progress the
 `check --proxy` command may output a warning, pertaining to the Linkerd
 components:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
@@ -772,7 +772,7 @@ correct certificates.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane pods are ready
     No running pods for "linkerd-sp-validator"
 ```
@@ -791,7 +791,7 @@ linkerd-proxy-injector-67f8cf65f7-4tvt5   2/2     Running   1          12m
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cluster networks can be verified
     the following nodes do not expose a podCIDR:
         node-0
@@ -813,7 +813,7 @@ distribution being used.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × cluster networks contains all node podCIDRs
     node has podCIDR(s) [10.244.0.0/24] which are not contained in the Linkerd clusterNetworks.
     Try installing linkerd via --set clusterNetworks=10.244.0.0/24
@@ -830,12 +830,12 @@ this network may not be meshed properly. To remedy this, update the
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × the Linkerd clusterNetworks [10.244.0.0/24] do not include pod default/foo (104.21.63.202)
     see https://linkerd.io/2/checks/#l5d-cluster-networks-pods for hints
 ```
 
-```bash
+```text {class=disable-copy}
 × the Linkerd clusterNetworks [10.244.0.0/24] do not include svc default/bar (10.96.217.194)
     see https://linkerd.io/2/checks/#l5d-cluster-networks-pods for hints
 ```
@@ -853,7 +853,7 @@ networks in the cluster.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can determine the latest version
     Get https://versioncheck.linkerd.io/version.json?version=edge-19.1.2&uuid=test-uuid&source=cli: context deadline exceeded
 ```
@@ -872,7 +872,7 @@ Example failures:
 
 #### unsupported version channel
 
-```bash
+```text {class=disable-copy}
 ‼ cli is up-to-date
     unsupported version channel: stable-2.14.10
 ```
@@ -883,7 +883,7 @@ As of February 2024, the Linkerd project itself only produces
 
 #### is running version X but the latest version is Y
 
-```bash
+```text {class=disable-copy}
 ‼ cli is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ```
@@ -899,7 +899,7 @@ Example failures:
 
 #### unsupported version channel
 
-```bash
+```text {class=disable-copy}
 ‼ control plane is up-to-date
     unsupported version channel: stable-2.14.10
 ```
@@ -910,7 +910,7 @@ As of February 2024, the Linkerd project itself only produces
 
 #### is running version X but the latest version is Y
 
-```bash
+```text {class=disable-copy}
 ‼ control plane is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ```
@@ -922,7 +922,7 @@ There is a newer version of the control plane. See the page on
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ control plane and cli versions match
     mismatched channels: running stable-2.1.0 but retrieved edge-19.1.2
 ```
@@ -962,7 +962,9 @@ Example failure:
 
 ```bash
 $ linkerd check --proxy --namespace foo
-...
+```
+
+```text {class=disable-copy}
 × data plane namespace exists
     The "foo" namespace does not exist
 ```
@@ -974,7 +976,7 @@ namespaces.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxies are ready
     No "linkerd-proxy" containers found
 ```
@@ -990,7 +992,7 @@ in our [Getting Started](../getting-started/) guide.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane is up-to-date
     linkerd/linkerd-prometheus-74d66f86f6-6t6dh: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -999,7 +1001,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 ### √ data plane and cli versions match {#l5d-data-plane-cli-version}
 
-```bash
+```text {class=disable-copy}
 ‼ data plane and cli versions match
     linkerd/linkerd-identity-5f6c45d6d9-9hd9j: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -1010,7 +1012,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane pod labels are configured correctly
     Some labels on data plane pods should be annotations:
     * emojivoto/voting-ff4c54b8d-tv9pp
@@ -1024,7 +1026,7 @@ be annotations in order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service labels and annotations are configured correctly
     Some labels on data plane services should be annotations:
     * emojivoto/emoji-svc
@@ -1038,7 +1040,7 @@ order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service annotations are configured correctly
     Some annotations on data plane services should be labels:
     * emojivoto/emoji-svc
@@ -1051,7 +1053,7 @@ Example failure:
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × opaque ports are properly annotated
         * service emoji-svc targets the opaque port 8080 through 8080; add 8080 to its config.linkerd.io/opaque-ports annotation
     see https://linkerd.io/2/checks/#linkerd-opaque-ports-definition for hints
@@ -1075,7 +1077,7 @@ These checks are ran if Linkerd has been installed in HA mode.
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ multiple replicas of control plane pods
     not enough replicas available for [linkerd-identity]
     see https://linkerd.io/2/checks/#l5d-control-plane-replicas for hints
@@ -1117,7 +1119,7 @@ returns the healthchecks in the
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Linkerd command viz exists
 ```
 
@@ -1138,7 +1140,7 @@ resources are in place. If any of them are missing, you can use
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ConfigMap exists
     configmaps "linkerd-cni-config" not found
     see https://linkerd.io/2/checks/#cni-plugin-cm-exists for hints
@@ -1163,7 +1165,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRole exists
     missing ClusterRole: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-cr-exists for hints
@@ -1188,7 +1190,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRoleBinding exists
     missing ClusterRoleBinding: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-crb-exists for hints
@@ -1213,7 +1215,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ServiceAccount exists
     missing ServiceAccount: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-sa-exists for hints
@@ -1238,7 +1240,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin DaemonSet exists
     missing DaemonSet: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-ds-exists for hints
@@ -1263,7 +1265,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cni plugin pod is running on all nodes
     number ready: 2, number scheduled: 3
     see https://linkerd.io/2/checks/#cni-plugin-ready
@@ -1300,7 +1302,7 @@ possible between paired clusters.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link CRD exists
     multicluster.linkerd.io/Link CRD is missing
     see https://linkerd.io/2/checks/#l5d-multicluster-link-crd-exists for hints
@@ -1319,7 +1321,7 @@ links.multicluster.linkerd.io     2021-03-10T09:58:10Z
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link resources are valid
     failed to parse Link east
     see https://linkerd.io/2/checks/#l5d-multicluster-links-are-valid for hints
@@ -1342,7 +1344,7 @@ to do this.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × remote cluster access credentials are valid
     * secret [east/east-config]: could not find east-config secret
     see https://linkerd.io/2/checks/#l5d-smc-target-clusters-access for hints
@@ -1355,7 +1357,7 @@ target cluster is present as a secret correctly
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote
@@ -1366,7 +1368,7 @@ The error above indicates that your trust anchors are not compatible. In order
 to fix that you need to ensure that both your anchors contain identical sets of
 certificates.
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote: cannot parse trust anchors
@@ -1386,7 +1388,7 @@ linkerd --context=remote check
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controller has required permissions
     missing Service mirror ClusterRole linkerd-service-mirror-access-local-resources: unexpected verbs expected create,delete,get,list,update,watch, got create,delete,get,update,watch
     see https://linkerd.io/2/checks/#l5d-multicluster-source-rbac-correct for hints
@@ -1455,7 +1457,7 @@ metadata:
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controllers are running
     Service mirror controller is not present
     see https://linkerd.io/2/checks/#l5d-multicluster-service-mirror-running for hints
@@ -1475,7 +1477,7 @@ linkerd-service-mirror-7bb8ff5967-zg265   2/2       Running   0          50m
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 ‼ extension is managing controllers
             * using legacy service mirror controller for Link: target
     see https://linkerd.io/2/checks/#l5d-multicluster-managed-controllers for hints
@@ -1503,7 +1505,7 @@ grab the Lease object allowing them to take over service mirroring.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all gateway mirrors are healthy
     Some gateway mirrors do not have endpoints:
   linkerd-gateway-gke.linkerd-multicluster mirrored from cluster [gke]
@@ -1523,7 +1525,7 @@ service in target cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all mirror services have endpoints
     Some mirror services do not have endpoints:
   voting-svc-gke.emojivoto mirrored from cluster [gke] (gateway: [linkerd-multicluster/linkerd-gateway])
@@ -1544,7 +1546,7 @@ cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼  all mirror services are part of a Link
     mirror service voting-east.emojivoto is not part of any Link
     see https://linkerd.io/2/checks/#l5d-multicluster-orphaned-services for hints
@@ -1603,7 +1605,7 @@ for a full list of configurable fields.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1631,7 +1633,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-crb-exists for hints
@@ -1677,7 +1679,7 @@ sync by updating either the CLI or linkerd-viz as necessary.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     secrets "tap-k8s-tls" not found
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1688,7 +1690,7 @@ Ensure that the `tap-k8s-tls` secret exists and contains the appropriate
 named `linkerd-tap-tls` and it should contain the `crt.pem` and `key.pem` data
 entries.
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not tap.linkerd-viz.svc
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1701,7 +1703,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ tap API server cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-webhook-cert-not-expiring-soon for hints
@@ -1716,7 +1718,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × FailedDiscoveryCheck: no response from https://10.233.31.133:443: Get https://10.233.31.133:443: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
 ```
 
@@ -1732,7 +1734,7 @@ requirements in the cluster:
 
 ### √ linkerd-viz pods are injected {#l5d-viz-pods-injection}
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz extension pods are injected
     could not find proxy container for tap-59f5595fc7-ttndp pod
     see https://linkerd.io/2/checks/#l5d-viz-pods-injection for hints
@@ -1756,7 +1758,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ viz extension pods are running {#l5d-viz-pods-running}
 
-```bash
+```text {class=disable-copy}
 × viz extension pods are running
     container linkerd-proxy in pod tap-59f5595fc7-ttndp is not ready
     see https://linkerd.io/2/checks/#l5d-viz-pods-running for hints
@@ -1780,7 +1782,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ prometheus is installed and configured correctly {#l5d-viz-prometheus}
 
-```bash
+```text {class=disable-copy}
 × prometheus is installed and configured correctly
     missing ClusterRoles: linkerd-linkerd-viz-prometheus
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1789,12 +1791,12 @@ Make sure that the `proxy-injector` is working correctly by running
 Ensure all the prometheus related resources are present and running correctly.
 
 ```bash
-❯ kubectl -n linkerd-viz get deploy,cm | grep prometheus
+$ kubectl -n linkerd-viz get deploy,cm | grep prometheus
 deployment.apps/prometheus     1/1     1            1           3m18s
 configmap/prometheus-config   1      3m18s
-❯ kubectl get clusterRoleBindings | grep prometheus
+$ kubectl get clusterRoleBindings | grep prometheus
 linkerd-linkerd-viz-prometheus                         ClusterRole/linkerd-linkerd-viz-prometheus                         3m37s
-❯ kubectl get clusterRoles | grep prometheus
+$ kubectl get clusterRoles | grep prometheus
 linkerd-linkerd-viz-prometheus                                         2021-02-26T06:03:11Zh
 ```
 
@@ -1802,7 +1804,7 @@ linkerd-linkerd-viz-prometheus                                         2021-02-2
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     Failed to get deploy for pod metrics-api-77f684f7c7-hnw8r: not running
 ```
@@ -1810,7 +1812,7 @@ Example failure:
 Verify that the metrics API pod is running correctly
 
 ```bash
-❯ kubectl -n linkerd-viz get pods
+$ kubectl -n linkerd-viz get pods
 NAME                           READY   STATUS    RESTARTS   AGE
 metrics-api-7bb8cb8489-cbq4m   2/2     Running   0          4m58s
 tap-injector-6b9bc6fc4-cgbr4   2/2     Running   0          4m56s
@@ -1824,7 +1826,7 @@ prometheus-7c5c48c466-jc27g    2/2     Running   0          4m58s
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × viz extension self-check
     No results returned
 ```
@@ -1876,7 +1878,7 @@ be safely disregarded.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxy metrics are present in Prometheus
     Data plane metrics not found for linkerd/linkerd-identity-b8c4c48c8-pflc9.
 ```
@@ -1906,7 +1908,7 @@ comprises `linkerd-buoyant` CLI, the `buoyant-cloud-agent` Deployment, and the
 
 ### √ Linkerd extension command linkerd-buoyant exists
 
-```bash
+```text {class=disable-copy}
 ‼ Linkerd extension command linkerd-buoyant exists
     exec: "linkerd-buoyant": executable file not found in $PATH
     see https://linkerd.io/2/checks/#extensions for hints
@@ -1926,7 +1928,7 @@ curl https://buoyant.cloud/install | sh
 
 ### √ linkerd-buoyant can determine the latest version
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant can determine the latest version
     Get "https://buoyant.cloud/version.json": dial tcp: lookup buoyant.cloud: no such host
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1942,7 +1944,7 @@ $ curl https://buoyant.cloud/version.json
 
 ### √ linkerd-buoyant cli is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant cli is up-to-date
     CLI version is v0.4.3 but the latest is v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1956,7 +1958,7 @@ curl https://buoyant.cloud/install | sh
 
 ### √ buoyant-cloud Namespace exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace exists
     namespaces "buoyant-cloud" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1977,7 +1979,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud Namespace has correct labels
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace has correct labels
     missing app.kubernetes.io/part-of label
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1992,7 +1994,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent ClusterRole exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRole exists
     missing ClusterRole: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2015,7 +2017,7 @@ yes
 
 ### √ buoyant-cloud-agent ClusterRoleBinding exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRoleBinding exists
     missing ClusterRoleBinding: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2038,7 +2040,7 @@ yes
 
 ### √ buoyant-cloud-agent ServiceAccount exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ServiceAccount exists
     missing ServiceAccount: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2061,7 +2063,7 @@ yes
 
 ### √ buoyant-cloud-id Secret exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-id Secret exists
     missing Secret: buoyant-cloud-id
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2084,7 +2086,7 @@ yes
 
 ### √ buoyant-cloud-agent Deployment exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment exists
     deployments.apps "buoyant-cloud-agent" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2105,7 +2107,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running
     no running pods for buoyant-cloud-agent Deployment
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2129,7 +2131,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-agent-6b8c6888d7-htr7d buoyant-cloud
 
 ### √ buoyant-cloud-agent Deployment is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2149,7 +2151,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-agent Deployment is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-agent Deployment is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2171,7 +2173,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running a single pod
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running a single pod
     expected 1 buoyant-cloud-agent pod, found 2
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2185,7 +2187,7 @@ kubectl get po -A --selector app=buoyant-cloud-agent
 
 ### √ buoyant-cloud-metrics DaemonSet exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet exists
     deployments.apps "buoyant-cloud-metrics" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2206,7 +2208,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-metrics DaemonSet is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is running
     no running pods for buoyant-cloud-metrics DaemonSet
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2233,7 +2235,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-metrics-kt9mv buoyant-cloud-metrics
 
 ### √ buoyant-cloud-metrics DaemonSet is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2256,7 +2258,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-metrics DaemonSet is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-metrics DaemonSet is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints

--- a/linkerd.io/content/2-edge/tasks/troubleshooting.md
+++ b/linkerd.io/content/2-edge/tasks/troubleshooting.md
@@ -961,7 +961,7 @@ normally.
 Example failure:
 
 ```bash
-$ linkerd check --proxy --namespace foo
+linkerd check --proxy --namespace foo
 ```
 
 ```text {class=disable-copy}

--- a/linkerd.io/content/2.10/tasks/replacing_expired_certificates.md
+++ b/linkerd.io/content/2.10/tasks/replacing_expired_certificates.md
@@ -16,7 +16,7 @@ is best to proceed with replacing the certificates with valid ones.
 It might be the case that your issuer certificate is expired. If this it true
 running `linkerd check --proxy` will produce output similar to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -41,7 +41,7 @@ replace both your root and issuer certificates at the same time. If your root
 has expired `linkerd check` will indicate that by outputting an error similar
 to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -74,7 +74,7 @@ Therefore we use the `--force` flag to ignore this error.
 If you run `linkerd check --proxy` you might see some warning, while the upgrade
 process is being performed:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -106,7 +106,7 @@ Additionally you can use the `kubectl rollout restart` command to bring the
 configuration of your other injected resources up to date, and then the `check`
 command should stop producing warning or errors:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid

--- a/linkerd.io/content/2.10/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.10/tasks/troubleshooting.md
@@ -16,7 +16,7 @@ installation.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane namespace does not already exist
     The "linkerd" namespace already exists
 ```
@@ -34,7 +34,7 @@ linkerd check --pre --linkerd-namespace linkerd-test
 The subsequent checks in this section validate whether you have permission to
 create the Kubernetes resources required for Linkerd installation, specifically:
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -47,7 +47,7 @@ These checks only run when the `--pre` flag is set This flag is intended for use
 prior to running `linkerd install`, to verify you have the correct RBAC
 permissions to install Linkerd.
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -88,7 +88,7 @@ Kubernetes capability permissions to install Linkerd.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × has NET_ADMIN capability
     found 3 PodSecurityPolicies, but none provide NET_ADMIN
     see https://linkerd.io/2/checks/#pre-k8s-cluster-net-admin for hints
@@ -107,7 +107,7 @@ and the
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × has NET_RAW capability
     found 3 PodSecurityPolicies, but none provide NET_RAW
     see https://linkerd.io/2/checks/#pre-k8s-cluster-net-raw for hints
@@ -128,7 +128,7 @@ These checks only run when the `--pre` flag is set. This flag is intended for
 use prior to running `linkerd install`, to verify you have not already installed
 the Linkerd control plane.
 
-```bash
+```text {class=disable-copy}
 √ no ClusterRoles exist
 √ no ClusterRoleBindings exist
 √ no CustomResourceDefinitions exist
@@ -149,7 +149,7 @@ linkerd check --pre --single-namespace
 
 ### √ control plane namespace exists {#pre-single-ns}
 
-```bash
+```text {class=disable-copy}
 × control plane namespace exists
     The "linkerd" namespace does not exist
 ```
@@ -170,7 +170,7 @@ The subsequent checks in this section validate whether you have permission to
 create the Kubernetes resources required for Linkerd `--single-namespace`
 installation, specifically:
 
-```bash
+```text {class=disable-copy}
 √ can create Roles
 √ can create RoleBindings
 ```
@@ -182,7 +182,7 @@ section above.
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     error configuring Kubernetes API client: stat badconfig: no such file or directory
 × can query the Kubernetes API
@@ -208,8 +208,8 @@ kubectl version
 
 Another example failure:
 
-```bash
-✘ can query the Kubernetes API
+```text {class=disable-copy}
+× can query the Kubernetes API
     Get REDACTED/version: x509: certificate signed by unknown authority
 ```
 
@@ -226,7 +226,7 @@ kubectl config set-cluster ${KUBE_CONTEXT} --insecure-skip-tls-verify=true \
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum Kubernetes API version
     Kubernetes is on version [1.7.16], but version [1.13.0] or more recent is required
 ```
@@ -241,7 +241,7 @@ kubectl version
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum kubectl version
     kubectl is on version [1.9.1], but version [1.13.0] or more recent is required
     see https://linkerd.io/2/checks/#kubectl-version for hints
@@ -282,7 +282,7 @@ linkerd check
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane Namespace exists
     The "foo" namespace does not exist
     see https://linkerd.io/2/checks/#l5d-existence-ns for hints
@@ -305,7 +305,7 @@ linkerd check --linkerd-namespace linkerdtest
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-cr for hints
@@ -331,7 +331,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-crb for hints
@@ -357,7 +357,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ServiceAccounts exist
     missing ServiceAccounts: linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-sa for hints
@@ -387,7 +387,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane CustomResourceDefinitions exist
     missing CustomResourceDefinitions: serviceprofiles.linkerd.io
     see https://linkerd.io/2/checks/#l5d-existence-crd for hints
@@ -412,7 +412,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane MutatingWebhookConfigurations exist
     missing MutatingWebhookConfigurations: linkerd-proxy-injector-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-mwc for hints
@@ -436,7 +436,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ValidatingWebhookConfigurations exist
     missing ValidatingWebhookConfigurations: linkerd-sp-validator-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-vwc for hints
@@ -460,7 +460,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane PodSecurityPolicies exist
     missing PodSecurityPolicies: linkerd-linkerd-control-plane
     see https://linkerd.io/2/checks/#l5d-existence-psp for hints
@@ -486,7 +486,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × 'linkerd-config' config map exists
     missing ConfigMaps: linkerd-config
     see https://linkerd.io/2/checks/#l5d-existence-linkerd-config for hints
@@ -518,7 +518,7 @@ For more information, see the Kubernetes documentation on
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × no unschedulable pods
     linkerd-prometheus-6b668f774d-j8ncr: 0/1 nodes are available: 1 Insufficient cpu.
     see https://linkerd.io/2/checks/#l5d-existence-unschedulable-pods for hints
@@ -533,13 +533,13 @@ For more information, see the Kubernetes documentation on the
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key ca.crt containing the trust anchors needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=true
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
 ```
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key crt.pem containing the issuer certificate needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=false
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
@@ -555,7 +555,7 @@ keys are `crt.pem` and `key.pem`.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are using supported crypto algorithm
     Invalid roots:
         * 165223702412626077778653586125774349756 identity.linkerd.cluster.local must use P-256 curve for public key, instead P-521 was used
@@ -569,7 +569,7 @@ algorithm.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are within their validity period
     Invalid roots:
         * 199607941798581518463476688845828639279 identity.linkerd.cluster.local not valid anymore. Expired on 2019-12-19T13:08:18Z
@@ -586,7 +586,7 @@ cluster back to a stable state.
 
 Example warnings:
 
-```bash
+```text {class=disable-copy}
 ‼ trust roots are valid for at least 60 days
     Roots expiring soon:
         * 66509928892441932260491975092256847205 identity.linkerd.cluster.local will expire on 2019-12-19T13:30:57Z
@@ -602,7 +602,7 @@ process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is using supported crypto algorithm
     issuer certificate must use P-256 curve for public key, instead P-521 was used
     see https://linkerd.io/2/checks/#5d-identity-issuer-cert-uses-supported-crypto for hints
@@ -617,7 +617,7 @@ to see how you can generate certificates that will work with Linkerd.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is within its validity period
     issuer certificate is not valid anymore. Expired on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-is-time-valid
@@ -631,7 +631,7 @@ bring your cluster back to a valid state, follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ issuer cert is valid for at least 60 days
     issuer certificate will expire on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-not-expiring-soon for hints
@@ -646,7 +646,7 @@ follow the process outlined in
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is issued by the trust root
     x509: certificate signed by unknown authority (possibly because of "x509: ECDSA verification failure" while trying to verify candidate authority certificate "identity.linkerd.cluster.local")
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-issued-by-trust-anchor for hints
@@ -671,7 +671,7 @@ linkerd upgrade \
 Once the upgrade process is over, the output of `linkerd check --proxy` should
 be:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -694,7 +694,7 @@ linkerd-identity-data-plane
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     secrets "linkerd-proxy-injector-tls" not found
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -705,7 +705,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-proxy-injector-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-proxy-injector.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -718,7 +718,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ proxy-injector cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-webhook-cert-not-expiring-soon for hints
@@ -733,7 +733,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     secrets "linkerd-sp-validator-tls" not found
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -744,7 +744,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-sp-validator-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-sp-validator.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -757,7 +757,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ sp-validator cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-webhook-cert-not-expiring-soon for hints
@@ -774,7 +774,7 @@ can follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
@@ -793,7 +793,7 @@ the Linkerd components are restarted. While this operation is in progress the
 `check --proxy` command may output a warning, pertaining to the Linkerd
 components:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
@@ -812,7 +812,7 @@ correct certificates.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane pods are ready
     No running pods for "linkerd-sp-validator"
 ```
@@ -831,7 +831,7 @@ linkerd-proxy-injector-67f8cf65f7-4tvt5   2/2     Running   1          12m
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     parse http:// bad/: invalid character " " in host name
 ```
@@ -846,7 +846,7 @@ linkerd check --api-addr " bad"
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can query the control plane API
     Post http://8.8.8.8/api/v1/Version: context deadline exceeded
 ```
@@ -874,7 +874,7 @@ curl localhost:9995/metrics
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can determine the latest version
     Get https://versioncheck.linkerd.io/version.json?version=edge-19.1.2&uuid=test-uuid&source=cli: context deadline exceeded
 ```
@@ -891,7 +891,7 @@ $ curl "https://versioncheck.linkerd.io/version.json?version=edge-19.1.2&uuid=te
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cli is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ```
@@ -902,7 +902,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 ‼ control plane is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ‼ control plane and cli versions match
@@ -923,7 +923,9 @@ Example failure:
 
 ```bash
 $ linkerd check --proxy --namespace foo
-...
+```
+
+```text {class=disable-copy}
 × data plane namespace exists
     The "foo" namespace does not exist
 ```
@@ -935,7 +937,7 @@ namespaces.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxies are ready
     No "linkerd-proxy" containers found
 ```
@@ -951,7 +953,7 @@ in our [Getting Started](../getting-started/) guide.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxy metrics are present in Prometheus
     Data plane metrics not found for linkerd/linkerd-identity-b8c4c48c8-pflc9.
 ```
@@ -976,7 +978,7 @@ You should see all your pods here. If they are not:
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane is up-to-date
     linkerd/linkerd-prometheus-74d66f86f6-6t6dh: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -985,7 +987,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 ### √ data plane and cli versions match {#l5d-data-plane-cli-version}
 
-```bash
+```text {class=disable-copy}
 ‼ data plane and cli versions match
     linkerd/linkerd-identity-5f6c45d6d9-9hd9j: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -996,7 +998,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane pod labels are configured correctly
     Some labels on data plane pods should be annotations:
     * emojivoto/voting-ff4c54b8d-tv9pp
@@ -1010,7 +1012,7 @@ be annotations in order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service labels and annotations are configured correctly
     Some labels on data plane services should be annotations:
     * emojivoto/emoji-svc
@@ -1024,7 +1026,7 @@ order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service annotations are configured correctly
     Some annotations on data plane services should be labels:
     * emojivoto/emoji-svc
@@ -1041,7 +1043,7 @@ These checks are ran if Linkerd has been installed in HA mode.
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ pod injection disabled on kube-system
     kube-system namespace needs to have the label config.linkerd.io/admission-webhooks: disabled if HA mode is enabled
     see https://linkerd.io/2/checks/#l5d-injection-disabled for hints
@@ -1066,7 +1068,7 @@ metadata:
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ multiple replicas of control plane pods
     not enough replicas available for [linkerd-identity]
     see https://linkerd.io/2/checks/#l5d-control-plane-replicas for hints
@@ -1094,7 +1096,7 @@ returns the healthchecks in the
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Linkerd command jaeger exists
 ```
 
@@ -1115,7 +1117,7 @@ resources are in place. If any of them are missing, you can use
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ConfigMap exists
     configmaps "linkerd-cni-config" not found
     see https://linkerd.io/2/checks/#cni-plugin-cm-exists for hints
@@ -1140,7 +1142,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin PodSecurityPolicy exists
     missing PodSecurityPolicy: linkerd-linkerd-cni-cni
     see https://linkerd.io/2/checks/#cni-plugin-psp-exists for hint
@@ -1165,7 +1167,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRole exists
     missing ClusterRole: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-cr-exists for hints
@@ -1190,7 +1192,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRoleBinding exists
     missing ClusterRoleBinding: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-crb-exists for hints
@@ -1215,7 +1217,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin Role exists
     missing Role: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-r-exists for hints
@@ -1240,7 +1242,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin RoleBinding exists
     missing RoleBinding: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-rb-exists for hints
@@ -1265,7 +1267,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ServiceAccount exists
     missing ServiceAccount: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-sa-exists for hints
@@ -1290,7 +1292,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin DaemonSet exists
     missing DaemonSet: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-ds-exists for hints
@@ -1315,7 +1317,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cni plugin pod is running on all nodes
     number ready: 2, number scheduled: 3
     see https://linkerd.io/2/checks/#cni-plugin-ready
@@ -1352,7 +1354,7 @@ possible between paired clusters.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link CRD exists
     multicluster.linkerd.io/Link CRD is missing
     see https://linkerd.io/2/checks/#l5d-multicluster-link-crd-exists for hints
@@ -1371,7 +1373,7 @@ links.multicluster.linkerd.io     2021-03-10T09:58:10Z
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link resources are valid
     failed to parse Link east
     see https://linkerd.io/2/checks/#l5d-multicluster-links-are-valid for hints
@@ -1383,7 +1385,7 @@ Make sure all the link objects are specified in the expected format.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × remote cluster access credentials are valid
     * secret [east/east-config]: could not find east-config secret
     see https://linkerd.io/2/checks/#l5d-smc-target-clusters-access for hints
@@ -1396,7 +1398,7 @@ target cluster is present as a secret correctly
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote
@@ -1407,7 +1409,7 @@ The error above indicates that your trust anchors are not compatible. In order
 to fix that you need to ensure that both your anchors contain identical sets of
 certificates.
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote: cannot parse trust anchors
@@ -1427,7 +1429,7 @@ linkerd --context=remote check
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controller has required permissions
     missing Service mirror ClusterRole linkerd-service-mirror-access-local-resources: unexpected verbs expected create,delete,get,list,update,watch, got create,delete,get,update,watch
     see https://linkerd.io/2/checks/#l5d-multicluster-source-rbac-correct for hints
@@ -1496,7 +1498,7 @@ metadata:
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controllers are running
     Service mirror controller is not present
     see https://linkerd.io/2/checks/#l5d-multicluster-service-mirror-running for hints
@@ -1516,7 +1518,7 @@ linkerd-service-mirror-7bb8ff5967-zg265   2/2       Running   0          50m
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all gateway mirrors are healthy
     Some gateway mirrors do not have endpoints:
   linkerd-gateway-gke.linkerd-multicluster mirrored from cluster [gke]
@@ -1536,7 +1538,7 @@ service in target cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all mirror services have endpoints
     Some mirror services do not have endpoints:
   voting-svc-gke.emojivoto mirrored from cluster [gke] (gateway: [linkerd-multicluster/linkerd-gateway])
@@ -1557,7 +1559,7 @@ cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼  all mirror services are part of a Link
     mirror service voting-east.emojivoto is not part of any Link
     see https://linkerd.io/2/checks/#l5d-multicluster-orphaned-services for hints
@@ -1597,7 +1599,7 @@ for a full list of configurable fields.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1625,7 +1627,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-crb-exists for hints
@@ -1654,7 +1656,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     secrets "tap-k8s-tls" not found
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1665,7 +1667,7 @@ Ensure that the `tap-k8s-tls` secret exists and contains the appropriate
 named `linkerd-tap-tls` and it should contain the `crt.pem` and `key.pem` data
 entries.
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not tap.linkerd-viz.svc
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1678,7 +1680,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ tap API server cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-webhook-cert-not-expiring-soon for hints
@@ -1693,7 +1695,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × FailedDiscoveryCheck: no response from https://10.233.31.133:443: Get https://10.233.31.133:443: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
 ```
 
@@ -1709,7 +1711,7 @@ requirements in the cluster:
 
 ### √ linkerd-viz pods are injected {#l5d-viz-pods-injection}
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz extension pods are injected
     could not find proxy container for tap-59f5595fc7-ttndp pod
     see https://linkerd.io/2/checks/#l5d-viz-pods-injection for hints
@@ -1733,7 +1735,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ viz extension pods are running {#l5d-viz-pods-running}
 
-```bash
+```text {class=disable-copy}
 × viz extension pods are running
     container linkerd-proxy in pod tap-59f5595fc7-ttndp is not ready
     see https://linkerd.io/2/checks/#l5d-viz-pods-running for hints
@@ -1757,7 +1759,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ prometheus is installed and configured correctly {#l5d-viz-prometheus}
 
-```bash
+```text {class=disable-copy}
 × prometheus is installed and configured correctly
     missing ClusterRoles: linkerd-linkerd-viz-prometheus
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1766,12 +1768,12 @@ Make sure that the `proxy-injector` is working correctly by running
 Ensure all the prometheus related resources are present and running correctly.
 
 ```bash
-❯ kubectl -n linkerd-viz get deploy,cm | grep prometheus
+$ kubectl -n linkerd-viz get deploy,cm | grep prometheus
 deployment.apps/prometheus     1/1     1            1           3m18s
 configmap/prometheus-config   1      3m18s
-❯ kubectl get clusterRoleBindings | grep prometheus
+$ kubectl get clusterRoleBindings | grep prometheus
 linkerd-linkerd-viz-prometheus                         ClusterRole/linkerd-linkerd-viz-prometheus                         3m37s
-❯ kubectl get clusterRoles | grep prometheus
+$ kubectl get clusterRoles | grep prometheus
 linkerd-linkerd-viz-prometheus                                         2021-02-26T06:03:11Zh
 ```
 
@@ -1779,7 +1781,7 @@ linkerd-linkerd-viz-prometheus                                         2021-02-2
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     Failed to get deploy for pod metrics-api-77f684f7c7-hnw8r: not running
 ```
@@ -1787,7 +1789,7 @@ Example failure:
 Verify that the metrics API pod is running correctly
 
 ```bash
-❯ kubectl -n linkerd-viz get pods
+$ kubectl -n linkerd-viz get pods
 NAME                           READY   STATUS    RESTARTS   AGE
 metrics-api-7bb8cb8489-cbq4m   2/2     Running   0          4m58s
 tap-injector-6b9bc6fc4-cgbr4   2/2     Running   0          4m56s
@@ -1801,7 +1803,7 @@ prometheus-7c5c48c466-jc27g    2/2     Running   0          4m58s
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × viz extension self-check
     No results returned
 ```
@@ -1838,7 +1840,7 @@ for a full list of configurable fields.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × collector and jaeger service account exists
     missing ServiceAccounts: collector
     see https://linkerd.io/2/checks/#l5d-jaeger-sc-exists for hints
@@ -1865,7 +1867,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × collector config map exists
     missing ConfigMaps: collector-config
     see https://linkerd.io/2/checks/#l5d-jaeger-oc-cm-exists for hints
@@ -1888,7 +1890,7 @@ yes
 
 ### √ jaeger extension pods are injected {#l5d-jaeger-pods-injection}
 
-```bash
+```text {class=disable-copy}
 × jaeger extension pods are injected
     could not find proxy container for jaeger-6f98d5c979-scqlq pod
     see https://linkerd.io/2/checks/#l5d-jaeger-pods-injections for hints
@@ -1909,7 +1911,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ jaeger extension pods are running {#l5d-jaeger-pods-running}
 
-```bash
+```text {class=disable-copy}
 × jaeger extension pods are running
     container linkerd-proxy in pod jaeger-59f5595fc7-ttndp is not ready
     see https://linkerd.io/2/checks/#l5d-jaeger-pods-running for hints
@@ -1937,7 +1939,7 @@ comprises `linkerd-buoyant` CLI, the `buoyant-cloud-agent` Deployment, and the
 
 ### √ Linkerd extension command linkerd-buoyant exists
 
-```bash
+```text {class=disable-copy}
 ‼ Linkerd extension command linkerd-buoyant exists
     exec: "linkerd-buoyant": executable file not found in $PATH
     see https://linkerd.io/2/checks/#extensions for hints
@@ -1957,7 +1959,7 @@ curl --proto '=https' --tlsv1.2 -sSfL https://buoyant.cloud/install | sh
 
 ### √ linkerd-buoyant can determine the latest version
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant can determine the latest version
     Get "https://buoyant.cloud/version.json": dial tcp: lookup buoyant.cloud: no such host
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1973,7 +1975,7 @@ $ curl --proto '=https' --tlsv1.2 -sSfL https://buoyant.cloud/version.json
 
 ### √ linkerd-buoyant cli is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant cli is up-to-date
     CLI version is v0.4.3 but the latest is v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1987,7 +1989,7 @@ curl --proto '=https' --tlsv1.2 -sSfL https://buoyant.cloud/install | sh
 
 ### √ buoyant-cloud Namespace exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace exists
     namespaces "buoyant-cloud" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2008,7 +2010,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud Namespace has correct labels
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace has correct labels
     missing app.kubernetes.io/part-of label
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2023,7 +2025,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent ClusterRole exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRole exists
     missing ClusterRole: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2046,7 +2048,7 @@ yes
 
 ### √ buoyant-cloud-agent ClusterRoleBinding exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRoleBinding exists
     missing ClusterRoleBinding: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2069,7 +2071,7 @@ yes
 
 ### √ buoyant-cloud-agent ServiceAccount exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ServiceAccount exists
     missing ServiceAccount: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2092,7 +2094,7 @@ yes
 
 ### √ buoyant-cloud-id Secret exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-id Secret exists
     missing Secret: buoyant-cloud-id
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2115,7 +2117,7 @@ yes
 
 ### √ buoyant-cloud-agent Deployment exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment exists
     deployments.apps "buoyant-cloud-agent" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2136,7 +2138,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running
     no running pods for buoyant-cloud-agent Deployment
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2160,7 +2162,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-agent-6b8c6888d7-htr7d buoyant-cloud
 
 ### √ buoyant-cloud-agent Deployment is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2180,7 +2182,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-agent Deployment is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-agent Deployment is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2202,7 +2204,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running a single pod
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running a single pod
     expected 1 buoyant-cloud-agent pod, found 2
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2216,7 +2218,7 @@ kubectl get po -A --selector app=buoyant-cloud-agent
 
 ### √ buoyant-cloud-metrics DaemonSet exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet exists
     deployments.apps "buoyant-cloud-metrics" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2237,7 +2239,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-metrics DaemonSet is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is running
     no running pods for buoyant-cloud-metrics DaemonSet
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2264,7 +2266,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-metrics-kt9mv buoyant-cloud-metrics
 
 ### √ buoyant-cloud-metrics DaemonSet is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2287,7 +2289,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-metrics DaemonSet is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-metrics DaemonSet is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints

--- a/linkerd.io/content/2.10/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.10/tasks/troubleshooting.md
@@ -922,7 +922,7 @@ normally.
 Example failure:
 
 ```bash
-$ linkerd check --proxy --namespace foo
+linkerd check --proxy --namespace foo
 ```
 
 ```text {class=disable-copy}

--- a/linkerd.io/content/2.11/tasks/replacing_expired_certificates.md
+++ b/linkerd.io/content/2.11/tasks/replacing_expired_certificates.md
@@ -16,7 +16,7 @@ replace the expired certificates with valid certificates.
 It might be the case that your issuer certificate is expired. If this it true
 running `linkerd check --proxy` will produce output similar to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -41,7 +41,7 @@ replace both your root and issuer certificates at the same time. If your root
 has expired `linkerd check` will indicate that by outputting an error similar
 to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -81,7 +81,7 @@ kubectl rollout restart -n linkerd deploy
 If you run `linkerd check --proxy` before the restart is completed, you will
 probably see warnings about pods not having the current trust bundle:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -114,7 +114,7 @@ can use `kubectl rollout restart` to restart your meshed workloads to bring
 their configuration up to date. After that is done, `linkerd check` should run
 with no warnings or errors:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid

--- a/linkerd.io/content/2.11/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.11/tasks/troubleshooting.md
@@ -1049,7 +1049,7 @@ normally.
 Example failure:
 
 ```bash
-$ linkerd check --proxy --namespace foo
+linkerd check --proxy --namespace foo
 ```
 
 ```text {class=disable-copy}

--- a/linkerd.io/content/2.11/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.11/tasks/troubleshooting.md
@@ -16,7 +16,7 @@ installation.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane namespace does not already exist
     The "linkerd" namespace already exists
 ```
@@ -34,7 +34,7 @@ linkerd check --pre --linkerd-namespace linkerd-test
 The subsequent checks in this section validate whether you have permission to
 create the Kubernetes resources required for Linkerd installation, specifically:
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -47,7 +47,7 @@ These checks only run when the `--pre` flag is set This flag is intended for use
 prior to running `linkerd install`, to verify you have the correct RBAC
 permissions to install Linkerd.
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -88,7 +88,7 @@ Kubernetes capability permissions to install Linkerd.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × has NET_ADMIN capability
     found 3 PodSecurityPolicies, but none provide NET_ADMIN
     see https://linkerd.io/2/checks/#pre-k8s-cluster-net-admin for hints
@@ -107,7 +107,7 @@ and the
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × has NET_RAW capability
     found 3 PodSecurityPolicies, but none provide NET_RAW
     see https://linkerd.io/2/checks/#pre-k8s-cluster-net-raw for hints
@@ -128,7 +128,7 @@ These checks only run when the `--pre` flag is set. This flag is intended for
 use prior to running `linkerd install`, to verify you have not already installed
 the Linkerd control plane.
 
-```bash
+```text {class=disable-copy}
 √ no ClusterRoles exist
 √ no ClusterRoleBindings exist
 √ no CustomResourceDefinitions exist
@@ -149,7 +149,7 @@ linkerd check --pre --single-namespace
 
 ### √ control plane namespace exists {#pre-single-ns}
 
-```bash
+```text {class=disable-copy}
 × control plane namespace exists
     The "linkerd" namespace does not exist
 ```
@@ -170,7 +170,7 @@ The subsequent checks in this section validate whether you have permission to
 create the Kubernetes resources required for Linkerd `--single-namespace`
 installation, specifically:
 
-```bash
+```text {class=disable-copy}
 √ can create Roles
 √ can create RoleBindings
 ```
@@ -182,7 +182,7 @@ section above.
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     error configuring Kubernetes API client: stat badconfig: no such file or directory
 × can query the Kubernetes API
@@ -208,8 +208,8 @@ kubectl version
 
 Another example failure:
 
-```bash
-✘ can query the Kubernetes API
+```text {class=disable-copy}
+× can query the Kubernetes API
     Get REDACTED/version: x509: certificate signed by unknown authority
 ```
 
@@ -226,7 +226,7 @@ kubectl config set-cluster ${KUBE_CONTEXT} --insecure-skip-tls-verify=true \
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum Kubernetes API version
     Kubernetes is on version [1.7.16], but version [1.13.0] or more recent is required
 ```
@@ -241,7 +241,7 @@ kubectl version
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum kubectl version
     kubectl is on version [1.9.1], but version [1.13.0] or more recent is required
     see https://linkerd.io/2/checks/#kubectl-version for hints
@@ -282,7 +282,7 @@ linkerd check
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane Namespace exists
     The "foo" namespace does not exist
     see https://linkerd.io/2/checks/#l5d-existence-ns for hints
@@ -305,7 +305,7 @@ linkerd check --linkerd-namespace linkerdtest
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-cr for hints
@@ -332,7 +332,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-crb for hints
@@ -359,7 +359,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ServiceAccounts exist
     missing ServiceAccounts: linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-sa for hints
@@ -389,7 +389,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane CustomResourceDefinitions exist
     missing CustomResourceDefinitions: serviceprofiles.linkerd.io
     see https://linkerd.io/2/checks/#l5d-existence-crd for hints
@@ -414,7 +414,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane MutatingWebhookConfigurations exist
     missing MutatingWebhookConfigurations: linkerd-proxy-injector-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-mwc for hints
@@ -438,7 +438,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ValidatingWebhookConfigurations exist
     missing ValidatingWebhookConfigurations: linkerd-sp-validator-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-vwc for hints
@@ -462,7 +462,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane PodSecurityPolicies exist
     missing PodSecurityPolicies: linkerd-linkerd-control-plane
     see https://linkerd.io/2/checks/#l5d-existence-psp for hints
@@ -486,7 +486,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × proxy-init container runs as root user if docker container runtime is used
     there are nodes using the docker container runtime and proxy-init container must run as root user.
 try installing linkerd via --set proxyInit.runAsRoot=true
@@ -517,7 +517,7 @@ further details.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × 'linkerd-config' config map exists
     missing ConfigMaps: linkerd-config
     see https://linkerd.io/2/checks/#l5d-existence-linkerd-config for hints
@@ -549,7 +549,7 @@ For more information, see the Kubernetes documentation on
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × no unschedulable pods
     linkerd-prometheus-6b668f774d-j8ncr: 0/1 nodes are available: 1 Insufficient cpu.
     see https://linkerd.io/2/checks/#l5d-existence-unschedulable-pods for hints
@@ -564,13 +564,13 @@ For more information, see the Kubernetes documentation on the
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key ca.crt containing the trust anchors needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=true
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
 ```
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key crt.pem containing the issuer certificate needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=false
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
@@ -586,7 +586,7 @@ keys are `crt.pem` and `key.pem`.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are using supported crypto algorithm
     Invalid roots:
         * 165223702412626077778653586125774349756 identity.linkerd.cluster.local must use P-256 curve for public key, instead P-521 was used
@@ -600,7 +600,7 @@ algorithm.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are within their validity period
     Invalid roots:
         * 199607941798581518463476688845828639279 identity.linkerd.cluster.local not valid anymore. Expired on 2019-12-19T13:08:18Z
@@ -617,7 +617,7 @@ cluster back to a stable state.
 
 Example warnings:
 
-```bash
+```text {class=disable-copy}
 ‼ trust roots are valid for at least 60 days
     Roots expiring soon:
         * 66509928892441932260491975092256847205 identity.linkerd.cluster.local will expire on 2019-12-19T13:30:57Z
@@ -633,7 +633,7 @@ process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is using supported crypto algorithm
     issuer certificate must use P-256 curve for public key, instead P-521 was used
     see https://linkerd.io/2/checks/#5d-identity-issuer-cert-uses-supported-crypto for hints
@@ -648,7 +648,7 @@ to see how you can generate certificates that will work with Linkerd.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is within its validity period
     issuer certificate is not valid anymore. Expired on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-is-time-valid
@@ -662,7 +662,7 @@ bring your cluster back to a valid state, follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ issuer cert is valid for at least 60 days
     issuer certificate will expire on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-not-expiring-soon for hints
@@ -677,7 +677,7 @@ follow the process outlined in
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is issued by the trust root
     x509: certificate signed by unknown authority (possibly because of "x509: ECDSA verification failure" while trying to verify candidate authority certificate "identity.linkerd.cluster.local")
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-issued-by-trust-anchor for hints
@@ -702,7 +702,7 @@ linkerd upgrade \
 Once the upgrade process is over, the output of `linkerd check --proxy` should
 be:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -725,7 +725,7 @@ linkerd-identity-data-plane
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     secrets "linkerd-proxy-injector-tls" not found
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -736,7 +736,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-proxy-injector-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-proxy-injector.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -749,7 +749,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ proxy-injector cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-not-expiring-soon for hints
@@ -764,7 +764,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     secrets "linkerd-sp-validator-tls" not found
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -775,7 +775,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-sp-validator-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-sp-validator.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -788,7 +788,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ sp-validator cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-not-expiring-soon for hints
@@ -803,7 +803,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × policy-validator webhook has valid cert
     secrets "linkerd-policy-validator-tls" not found
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-valid for hints
@@ -812,7 +812,7 @@ Example failure:
 Ensure that the `linkerd-policy-validator-k8s-tls` secret exists and contains
 the appropriate `tls.crt` and `tls.key` data entries.
 
-```bash
+```text {class=disable-copy}
 × policy-validator webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-policy-validator.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-valid for hints
@@ -825,7 +825,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ policy-validator cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-not-expiring-soon for hints
@@ -842,7 +842,7 @@ can follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
@@ -861,7 +861,7 @@ the Linkerd components are restarted. While this operation is in progress the
 `check --proxy` command may output a warning, pertaining to the Linkerd
 components:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
@@ -880,7 +880,7 @@ correct certificates.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane pods are ready
     No running pods for "linkerd-sp-validator"
 ```
@@ -899,7 +899,7 @@ linkerd-proxy-injector-67f8cf65f7-4tvt5   2/2     Running   1          12m
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cluster networks can be verified
     the following nodes do not expose a podCIDR:
         node-0
@@ -921,7 +921,7 @@ distribution being used.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × cluster networks contains all node podCIDRs
     node has podCIDR(s) [10.244.0.0/24] which are not contained in the Linkerd clusterNetworks.
     Try installing linkerd via --set clusterNetworks=10.244.0.0/24
@@ -938,7 +938,7 @@ this network may not be meshed properly. To remedy this, update the
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     parse http:// bad/: invalid character " " in host name
 ```
@@ -953,7 +953,7 @@ linkerd check --api-addr " bad"
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can query the control plane API
     Post http://8.8.8.8/api/v1/Version: context deadline exceeded
 ```
@@ -981,7 +981,7 @@ curl localhost:9995/metrics
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can determine the latest version
     Get https://versioncheck.linkerd.io/version.json?version=edge-19.1.2&uuid=test-uuid&source=cli: context deadline exceeded
 ```
@@ -998,7 +998,7 @@ $ curl "https://versioncheck.linkerd.io/version.json?version=edge-19.1.2&uuid=te
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cli is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ```
@@ -1009,7 +1009,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 ‼ control plane is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ‼ control plane and cli versions match
@@ -1050,7 +1050,9 @@ Example failure:
 
 ```bash
 $ linkerd check --proxy --namespace foo
-...
+```
+
+```text {class=disable-copy}
 × data plane namespace exists
     The "foo" namespace does not exist
 ```
@@ -1062,7 +1064,7 @@ namespaces.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxies are ready
     No "linkerd-proxy" containers found
 ```
@@ -1078,7 +1080,7 @@ in our [Getting Started](../getting-started/) guide.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxy metrics are present in Prometheus
     Data plane metrics not found for linkerd/linkerd-identity-b8c4c48c8-pflc9.
 ```
@@ -1103,7 +1105,7 @@ You should see all your pods here. If they are not:
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane is up-to-date
     linkerd/linkerd-prometheus-74d66f86f6-6t6dh: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -1112,7 +1114,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 ### √ data plane and cli versions match {#l5d-data-plane-cli-version}
 
-```bash
+```text {class=disable-copy}
 ‼ data plane and cli versions match
     linkerd/linkerd-identity-5f6c45d6d9-9hd9j: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -1123,7 +1125,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane pod labels are configured correctly
     Some labels on data plane pods should be annotations:
     * emojivoto/voting-ff4c54b8d-tv9pp
@@ -1137,7 +1139,7 @@ be annotations in order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service labels and annotations are configured correctly
     Some labels on data plane services should be annotations:
     * emojivoto/emoji-svc
@@ -1151,7 +1153,7 @@ order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service annotations are configured correctly
     Some annotations on data plane services should be labels:
     * emojivoto/emoji-svc
@@ -1164,7 +1166,7 @@ Example failure:
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × opaque ports are properly annotated
         * service emoji-svc targets the opaque port 8080 through 8080; add 8080 to its config.linkerd.io/opaque-ports annotation
     see https://linkerd.io/2/checks/#linkerd-opaque-ports-definition for hints
@@ -1188,7 +1190,7 @@ These checks are ran if Linkerd has been installed in HA mode.
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ pod injection disabled on kube-system
     kube-system namespace needs to have the label config.linkerd.io/admission-webhooks: disabled if HA mode is enabled
     see https://linkerd.io/2/checks/#l5d-injection-disabled for hints
@@ -1213,7 +1215,7 @@ metadata:
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ multiple replicas of control plane pods
     not enough replicas available for [linkerd-identity]
     see https://linkerd.io/2/checks/#l5d-control-plane-replicas for hints
@@ -1241,7 +1243,7 @@ returns the healthchecks in the
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Linkerd command jaeger exists
 ```
 
@@ -1262,7 +1264,7 @@ resources are in place. If any of them are missing, you can use
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ConfigMap exists
     configmaps "linkerd-cni-config" not found
     see https://linkerd.io/2/checks/#cni-plugin-cm-exists for hints
@@ -1287,7 +1289,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin PodSecurityPolicy exists
     missing PodSecurityPolicy: linkerd-linkerd-cni-cni
     see https://linkerd.io/2/checks/#cni-plugin-psp-exists for hint
@@ -1312,7 +1314,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRole exists
     missing ClusterRole: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-cr-exists for hints
@@ -1337,7 +1339,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRoleBinding exists
     missing ClusterRoleBinding: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-crb-exists for hints
@@ -1362,7 +1364,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin Role exists
     missing Role: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-r-exists for hints
@@ -1387,7 +1389,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin RoleBinding exists
     missing RoleBinding: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-rb-exists for hints
@@ -1412,7 +1414,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ServiceAccount exists
     missing ServiceAccount: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-sa-exists for hints
@@ -1437,7 +1439,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin DaemonSet exists
     missing DaemonSet: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-ds-exists for hints
@@ -1462,7 +1464,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cni plugin pod is running on all nodes
     number ready: 2, number scheduled: 3
     see https://linkerd.io/2/checks/#cni-plugin-ready
@@ -1499,7 +1501,7 @@ possible between paired clusters.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link CRD exists
     multicluster.linkerd.io/Link CRD is missing
     see https://linkerd.io/2/checks/#l5d-multicluster-link-crd-exists for hints
@@ -1518,7 +1520,7 @@ links.multicluster.linkerd.io     2021-03-10T09:58:10Z
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link resources are valid
     failed to parse Link east
     see https://linkerd.io/2/checks/#l5d-multicluster-links-are-valid for hints
@@ -1530,7 +1532,7 @@ Make sure all the link objects are specified in the expected format.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × remote cluster access credentials are valid
     * secret [east/east-config]: could not find east-config secret
     see https://linkerd.io/2/checks/#l5d-smc-target-clusters-access for hints
@@ -1543,7 +1545,7 @@ target cluster is present as a secret correctly
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote
@@ -1554,7 +1556,7 @@ The error above indicates that your trust anchors are not compatible. In order
 to fix that you need to ensure that both your anchors contain identical sets of
 certificates.
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote: cannot parse trust anchors
@@ -1574,7 +1576,7 @@ linkerd --context=remote check
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controller has required permissions
     missing Service mirror ClusterRole linkerd-service-mirror-access-local-resources: unexpected verbs expected create,delete,get,list,update,watch, got create,delete,get,update,watch
     see https://linkerd.io/2/checks/#l5d-multicluster-source-rbac-correct for hints
@@ -1643,7 +1645,7 @@ metadata:
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controllers are running
     Service mirror controller is not present
     see https://linkerd.io/2/checks/#l5d-multicluster-service-mirror-running for hints
@@ -1663,7 +1665,7 @@ linkerd-service-mirror-7bb8ff5967-zg265   2/2       Running   0          50m
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all gateway mirrors are healthy
     Some gateway mirrors do not have endpoints:
   linkerd-gateway-gke.linkerd-multicluster mirrored from cluster [gke]
@@ -1683,7 +1685,7 @@ service in target cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all mirror services have endpoints
     Some mirror services do not have endpoints:
   voting-svc-gke.emojivoto mirrored from cluster [gke] (gateway: [linkerd-multicluster/linkerd-gateway])
@@ -1704,7 +1706,7 @@ cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼  all mirror services are part of a Link
     mirror service voting-east.emojivoto is not part of any Link
     see https://linkerd.io/2/checks/#l5d-multicluster-orphaned-services for hints
@@ -1744,7 +1746,7 @@ for a full list of configurable fields.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1772,7 +1774,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-crb-exists for hints
@@ -1801,7 +1803,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     secrets "tap-k8s-tls" not found
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1812,7 +1814,7 @@ Ensure that the `tap-k8s-tls` secret exists and contains the appropriate
 named `linkerd-tap-tls` and it should contain the `crt.pem` and `key.pem` data
 entries.
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not tap.linkerd-viz.svc
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1825,7 +1827,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ tap API server cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-webhook-cert-not-expiring-soon for hints
@@ -1840,7 +1842,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × FailedDiscoveryCheck: no response from https://10.233.31.133:443: Get https://10.233.31.133:443: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
 ```
 
@@ -1856,7 +1858,7 @@ requirements in the cluster:
 
 ### √ linkerd-viz pods are injected {#l5d-viz-pods-injection}
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz extension pods are injected
     could not find proxy container for tap-59f5595fc7-ttndp pod
     see https://linkerd.io/2/checks/#l5d-viz-pods-injection for hints
@@ -1880,7 +1882,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ viz extension pods are running {#l5d-viz-pods-running}
 
-```bash
+```text {class=disable-copy}
 × viz extension pods are running
     container linkerd-proxy in pod tap-59f5595fc7-ttndp is not ready
     see https://linkerd.io/2/checks/#l5d-viz-pods-running for hints
@@ -1904,7 +1906,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ prometheus is installed and configured correctly {#l5d-viz-prometheus}
 
-```bash
+```text {class=disable-copy}
 × prometheus is installed and configured correctly
     missing ClusterRoles: linkerd-linkerd-viz-prometheus
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1913,12 +1915,12 @@ Make sure that the `proxy-injector` is working correctly by running
 Ensure all the prometheus related resources are present and running correctly.
 
 ```bash
-❯ kubectl -n linkerd-viz get deploy,cm | grep prometheus
+$ kubectl -n linkerd-viz get deploy,cm | grep prometheus
 deployment.apps/prometheus     1/1     1            1           3m18s
 configmap/prometheus-config   1      3m18s
-❯ kubectl get clusterRoleBindings | grep prometheus
+$ kubectl get clusterRoleBindings | grep prometheus
 linkerd-linkerd-viz-prometheus                         ClusterRole/linkerd-linkerd-viz-prometheus                         3m37s
-❯ kubectl get clusterRoles | grep prometheus
+$ kubectl get clusterRoles | grep prometheus
 linkerd-linkerd-viz-prometheus                                         2021-02-26T06:03:11Zh
 ```
 
@@ -1926,7 +1928,7 @@ linkerd-linkerd-viz-prometheus                                         2021-02-2
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     Failed to get deploy for pod metrics-api-77f684f7c7-hnw8r: not running
 ```
@@ -1934,7 +1936,7 @@ Example failure:
 Verify that the metrics API pod is running correctly
 
 ```bash
-❯ kubectl -n linkerd-viz get pods
+$ kubectl -n linkerd-viz get pods
 NAME                           READY   STATUS    RESTARTS   AGE
 metrics-api-7bb8cb8489-cbq4m   2/2     Running   0          4m58s
 tap-injector-6b9bc6fc4-cgbr4   2/2     Running   0          4m56s
@@ -1948,7 +1950,7 @@ prometheus-7c5c48c466-jc27g    2/2     Running   0          4m58s
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × viz extension self-check
     No results returned
 ```
@@ -1985,7 +1987,7 @@ for a full list of configurable fields.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × collector and jaeger service account exists
     missing ServiceAccounts: collector
     see https://linkerd.io/2/checks/#l5d-jaeger-sc-exists for hints
@@ -2012,7 +2014,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × collector config map exists
     missing ConfigMaps: collector-config
     see https://linkerd.io/2/checks/#l5d-jaeger-oc-cm-exists for hints
@@ -2035,7 +2037,7 @@ yes
 
 ### √ jaeger extension pods are injected {#l5d-jaeger-pods-injection}
 
-```bash
+```text {class=disable-copy}
 × jaeger extension pods are injected
     could not find proxy container for jaeger-6f98d5c979-scqlq pod
     see https://linkerd.io/2/checks/#l5d-jaeger-pods-injections for hints
@@ -2056,7 +2058,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ jaeger extension pods are running {#l5d-jaeger-pods-running}
 
-```bash
+```text {class=disable-copy}
 × jaeger extension pods are running
     container linkerd-proxy in pod jaeger-59f5595fc7-ttndp is not ready
     see https://linkerd.io/2/checks/#l5d-jaeger-pods-running for hints
@@ -2084,7 +2086,7 @@ comprises `linkerd-buoyant` CLI, the `buoyant-cloud-agent` Deployment, and the
 
 ### √ Linkerd extension command linkerd-buoyant exists
 
-```bash
+```text {class=disable-copy}
 ‼ Linkerd extension command linkerd-buoyant exists
     exec: "linkerd-buoyant": executable file not found in $PATH
     see https://linkerd.io/2/checks/#extensions for hints
@@ -2104,7 +2106,7 @@ curl https://buoyant.cloud/install | sh
 
 ### √ linkerd-buoyant can determine the latest version
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant can determine the latest version
     Get "https://buoyant.cloud/version.json": dial tcp: lookup buoyant.cloud: no such host
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2120,7 +2122,7 @@ $ curl https://buoyant.cloud/version.json
 
 ### √ linkerd-buoyant cli is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant cli is up-to-date
     CLI version is v0.4.3 but the latest is v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2134,7 +2136,7 @@ curl https://buoyant.cloud/install | sh
 
 ### √ buoyant-cloud Namespace exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace exists
     namespaces "buoyant-cloud" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2155,7 +2157,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud Namespace has correct labels
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace has correct labels
     missing app.kubernetes.io/part-of label
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2170,7 +2172,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent ClusterRole exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRole exists
     missing ClusterRole: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2193,7 +2195,7 @@ yes
 
 ### √ buoyant-cloud-agent ClusterRoleBinding exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRoleBinding exists
     missing ClusterRoleBinding: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2216,7 +2218,7 @@ yes
 
 ### √ buoyant-cloud-agent ServiceAccount exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ServiceAccount exists
     missing ServiceAccount: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2239,7 +2241,7 @@ yes
 
 ### √ buoyant-cloud-id Secret exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-id Secret exists
     missing Secret: buoyant-cloud-id
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2262,7 +2264,7 @@ yes
 
 ### √ buoyant-cloud-agent Deployment exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment exists
     deployments.apps "buoyant-cloud-agent" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2283,7 +2285,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running
     no running pods for buoyant-cloud-agent Deployment
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2307,7 +2309,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-agent-6b8c6888d7-htr7d buoyant-cloud
 
 ### √ buoyant-cloud-agent Deployment is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2327,7 +2329,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-agent Deployment is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-agent Deployment is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2349,7 +2351,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running a single pod
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running a single pod
     expected 1 buoyant-cloud-agent pod, found 2
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2363,7 +2365,7 @@ kubectl get po -A --selector app=buoyant-cloud-agent
 
 ### √ buoyant-cloud-metrics DaemonSet exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet exists
     deployments.apps "buoyant-cloud-metrics" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2384,7 +2386,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-metrics DaemonSet is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is running
     no running pods for buoyant-cloud-metrics DaemonSet
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2411,7 +2413,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-metrics-kt9mv buoyant-cloud-metrics
 
 ### √ buoyant-cloud-metrics DaemonSet is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2434,7 +2436,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-metrics DaemonSet is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-metrics DaemonSet is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints

--- a/linkerd.io/content/2.12/tasks/replacing_expired_certificates.md
+++ b/linkerd.io/content/2.12/tasks/replacing_expired_certificates.md
@@ -16,7 +16,7 @@ replace the expired certificates with valid certificates.
 It might be the case that your issuer certificate is expired. If this it true
 running `linkerd check --proxy` will produce output similar to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -41,7 +41,7 @@ replace both your root and issuer certificates at the same time. If your root
 has expired `linkerd check` will indicate that by outputting an error similar
 to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -75,7 +75,7 @@ If you run `linkerd check --proxy` while pods are restarting after the trust
 bundle is updated, you will probably see warnings about pods not having the
 current trust bundle:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -107,7 +107,7 @@ These warnings will disappear as restarts complete. Once they do, you can use
 configuration up to date. After that is done, `linkerd check` should run with no
 warnings or errors:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid

--- a/linkerd.io/content/2.12/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.12/tasks/troubleshooting.md
@@ -921,7 +921,7 @@ normally.
 Example failure:
 
 ```bash
-$ linkerd check --proxy --namespace foo
+linkerd check --proxy --namespace foo
 ```
 
 ```text {class=disable-copy}

--- a/linkerd.io/content/2.12/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.12/tasks/troubleshooting.md
@@ -16,7 +16,7 @@ installation.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane namespace does not already exist
     The "linkerd" namespace already exists
 ```
@@ -34,7 +34,7 @@ linkerd check --pre --linkerd-namespace linkerd-test
 The subsequent checks in this section validate whether you have permission to
 create the Kubernetes resources required for Linkerd installation, specifically:
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -47,7 +47,7 @@ These checks only run when the `--pre` flag is set This flag is intended for use
 prior to running `linkerd install`, to verify you have the correct RBAC
 permissions to install Linkerd.
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -90,7 +90,7 @@ These checks only run when the `--pre` flag is set. This flag is intended for
 use prior to running `linkerd install`, to verify you have not already installed
 the Linkerd control plane.
 
-```bash
+```text {class=disable-copy}
 √ no ClusterRoles exist
 √ no ClusterRoleBindings exist
 √ no CustomResourceDefinitions exist
@@ -113,7 +113,7 @@ linkerd check --pre --single-namespace
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     error configuring Kubernetes API client: stat badconfig: no such file or directory
 × can query the Kubernetes API
@@ -139,8 +139,8 @@ kubectl version
 
 Another example failure:
 
-```bash
-✘ can query the Kubernetes API
+```text {class=disable-copy}
+× can query the Kubernetes API
     Get REDACTED/version: x509: certificate signed by unknown authority
 ```
 
@@ -157,7 +157,7 @@ kubectl config set-cluster ${KUBE_CONTEXT} --insecure-skip-tls-verify=true \
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum Kubernetes API version
     Kubernetes is on version [1.7.16], but version [1.13.0] or more recent is required
 ```
@@ -172,7 +172,7 @@ kubectl version
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum kubectl version
     kubectl is on version [1.9.1], but version [1.13.0] or more recent is required
     see https://linkerd.io/2/checks/#kubectl-version for hints
@@ -198,7 +198,7 @@ resources have been installed.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane Namespace exists
     The "foo" namespace does not exist
     see https://linkerd.io/2/checks/#l5d-existence-ns for hints
@@ -221,7 +221,7 @@ linkerd check --linkerd-namespace linkerdtest
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-cr for hints
@@ -248,7 +248,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-crb for hints
@@ -275,7 +275,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ServiceAccounts exist
     missing ServiceAccounts: linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-sa for hints
@@ -305,7 +305,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane CustomResourceDefinitions exist
     missing CustomResourceDefinitions: serviceprofiles.linkerd.io
     see https://linkerd.io/2/checks/#l5d-existence-crd for hints
@@ -330,7 +330,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane MutatingWebhookConfigurations exist
     missing MutatingWebhookConfigurations: linkerd-proxy-injector-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-mwc for hints
@@ -354,7 +354,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ValidatingWebhookConfigurations exist
     missing ValidatingWebhookConfigurations: linkerd-sp-validator-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-vwc for hints
@@ -378,7 +378,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × proxy-init container runs as root user if docker container runtime is used
     there are nodes using the docker container runtime and proxy-init container must run as root user.
 try installing linkerd via --set proxyInit.runAsRoot=true
@@ -409,7 +409,7 @@ further details.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × 'linkerd-config' config map exists
     missing ConfigMaps: linkerd-config
     see https://linkerd.io/2/checks/#l5d-existence-linkerd-config for hints
@@ -441,7 +441,7 @@ For more information, see the Kubernetes documentation on
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × no unschedulable pods
     linkerd-prometheus-6b668f774d-j8ncr: 0/1 nodes are available: 1 Insufficient cpu.
     see https://linkerd.io/2/checks/#l5d-existence-unschedulable-pods for hints
@@ -456,13 +456,13 @@ For more information, see the Kubernetes documentation on the
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key ca.crt containing the trust anchors needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=true
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
 ```
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key crt.pem containing the issuer certificate needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=false
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
@@ -478,7 +478,7 @@ keys are `crt.pem` and `key.pem`.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are using supported crypto algorithm
     Invalid roots:
         * 165223702412626077778653586125774349756 identity.linkerd.cluster.local must use P-256 curve for public key, instead P-521 was used
@@ -492,7 +492,7 @@ algorithm.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are within their validity period
     Invalid roots:
         * 199607941798581518463476688845828639279 identity.linkerd.cluster.local not valid anymore. Expired on 2019-12-19T13:08:18Z
@@ -509,7 +509,7 @@ cluster back to a stable state.
 
 Example warnings:
 
-```bash
+```text {class=disable-copy}
 ‼ trust roots are valid for at least 60 days
     Roots expiring soon:
         * 66509928892441932260491975092256847205 identity.linkerd.cluster.local will expire on 2019-12-19T13:30:57Z
@@ -525,7 +525,7 @@ process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is using supported crypto algorithm
     issuer certificate must use P-256 curve for public key, instead P-521 was used
     see https://linkerd.io/2/checks/#5d-identity-issuer-cert-uses-supported-crypto for hints
@@ -540,7 +540,7 @@ to see how you can generate certificates that will work with Linkerd.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is within its validity period
     issuer certificate is not valid anymore. Expired on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-is-time-valid
@@ -554,7 +554,7 @@ bring your cluster back to a valid state, follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ issuer cert is valid for at least 60 days
     issuer certificate will expire on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-not-expiring-soon for hints
@@ -569,7 +569,7 @@ follow the process outlined in
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is issued by the trust root
     x509: certificate signed by unknown authority (possibly because of "x509: ECDSA verification failure" while trying to verify candidate authority certificate "identity.linkerd.cluster.local")
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-issued-by-trust-anchor for hints
@@ -594,7 +594,7 @@ linkerd upgrade \
 Once the upgrade process is over, the output of `linkerd check --proxy` should
 be:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -617,7 +617,7 @@ linkerd-identity-data-plane
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     secrets "linkerd-proxy-injector-tls" not found
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -628,7 +628,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-proxy-injector-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-proxy-injector.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -641,7 +641,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ proxy-injector cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-not-expiring-soon for hints
@@ -656,7 +656,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     secrets "linkerd-sp-validator-tls" not found
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -667,7 +667,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-sp-validator-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-sp-validator.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -680,7 +680,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ sp-validator cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-not-expiring-soon for hints
@@ -695,7 +695,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × policy-validator webhook has valid cert
     secrets "linkerd-policy-validator-tls" not found
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-valid for hints
@@ -704,7 +704,7 @@ Example failure:
 Ensure that the `linkerd-policy-validator-k8s-tls` secret exists and contains
 the appropriate `tls.crt` and `tls.key` data entries.
 
-```bash
+```text {class=disable-copy}
 × policy-validator webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-policy-validator.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-valid for hints
@@ -717,7 +717,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ policy-validator cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-not-expiring-soon for hints
@@ -734,7 +734,7 @@ can follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
@@ -753,7 +753,7 @@ the Linkerd components are restarted. While this operation is in progress the
 `check --proxy` command may output a warning, pertaining to the Linkerd
 components:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
@@ -772,7 +772,7 @@ correct certificates.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane pods are ready
     No running pods for "linkerd-sp-validator"
 ```
@@ -791,7 +791,7 @@ linkerd-proxy-injector-67f8cf65f7-4tvt5   2/2     Running   1          12m
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cluster networks can be verified
     the following nodes do not expose a podCIDR:
         node-0
@@ -813,7 +813,7 @@ distribution being used.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × cluster networks contains all node podCIDRs
     node has podCIDR(s) [10.244.0.0/24] which are not contained in the Linkerd clusterNetworks.
     Try installing linkerd via --set clusterNetworks=10.244.0.0/24
@@ -830,12 +830,12 @@ this network may not be meshed properly. To remedy this, update the
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × the Linkerd clusterNetworks [10.244.0.0/24] do not include pod default/foo (104.21.63.202)
     see https://linkerd.io/2/checks/#l5d-cluster-networks-pods for hints
 ```
 
-```bash
+```text {class=disable-copy}
 × the Linkerd clusterNetworks [10.244.0.0/24] do not include svc default/bar (10.96.217.194)
     see https://linkerd.io/2/checks/#l5d-cluster-networks-pods for hints
 ```
@@ -853,7 +853,7 @@ networks in the cluster.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can determine the latest version
     Get https://versioncheck.linkerd.io/version.json?version=edge-19.1.2&uuid=test-uuid&source=cli: context deadline exceeded
 ```
@@ -870,7 +870,7 @@ $ curl "https://versioncheck.linkerd.io/version.json?version=edge-19.1.2&uuid=te
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cli is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ```
@@ -881,7 +881,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 ‼ control plane is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ‼ control plane and cli versions match
@@ -922,7 +922,9 @@ Example failure:
 
 ```bash
 $ linkerd check --proxy --namespace foo
-...
+```
+
+```text {class=disable-copy}
 × data plane namespace exists
     The "foo" namespace does not exist
 ```
@@ -934,7 +936,7 @@ namespaces.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxies are ready
     No "linkerd-proxy" containers found
 ```
@@ -950,7 +952,7 @@ in our [Getting Started](../getting-started/) guide.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane is up-to-date
     linkerd/linkerd-prometheus-74d66f86f6-6t6dh: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -959,7 +961,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 ### √ data plane and cli versions match {#l5d-data-plane-cli-version}
 
-```bash
+```text {class=disable-copy}
 ‼ data plane and cli versions match
     linkerd/linkerd-identity-5f6c45d6d9-9hd9j: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -970,7 +972,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane pod labels are configured correctly
     Some labels on data plane pods should be annotations:
     * emojivoto/voting-ff4c54b8d-tv9pp
@@ -984,7 +986,7 @@ be annotations in order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service labels and annotations are configured correctly
     Some labels on data plane services should be annotations:
     * emojivoto/emoji-svc
@@ -998,7 +1000,7 @@ order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service annotations are configured correctly
     Some annotations on data plane services should be labels:
     * emojivoto/emoji-svc
@@ -1011,7 +1013,7 @@ Example failure:
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × opaque ports are properly annotated
         * service emoji-svc targets the opaque port 8080 through 8080; add 8080 to its config.linkerd.io/opaque-ports annotation
     see https://linkerd.io/2/checks/#linkerd-opaque-ports-definition for hints
@@ -1035,7 +1037,7 @@ These checks are ran if Linkerd has been installed in HA mode.
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ pod injection disabled on kube-system
     kube-system namespace needs to have the label config.linkerd.io/admission-webhooks: disabled if HA mode is enabled
     see https://linkerd.io/2/checks/#l5d-injection-disabled for hints
@@ -1060,7 +1062,7 @@ metadata:
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ multiple replicas of control plane pods
     not enough replicas available for [linkerd-identity]
     see https://linkerd.io/2/checks/#l5d-control-plane-replicas for hints
@@ -1088,7 +1090,7 @@ returns the healthchecks in the
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Linkerd command jaeger exists
 ```
 
@@ -1109,7 +1111,7 @@ resources are in place. If any of them are missing, you can use
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ConfigMap exists
     configmaps "linkerd-cni-config" not found
     see https://linkerd.io/2/checks/#cni-plugin-cm-exists for hints
@@ -1134,7 +1136,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRole exists
     missing ClusterRole: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-cr-exists for hints
@@ -1159,7 +1161,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRoleBinding exists
     missing ClusterRoleBinding: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-crb-exists for hints
@@ -1184,7 +1186,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ServiceAccount exists
     missing ServiceAccount: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-sa-exists for hints
@@ -1209,7 +1211,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin DaemonSet exists
     missing DaemonSet: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-ds-exists for hints
@@ -1234,7 +1236,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cni plugin pod is running on all nodes
     number ready: 2, number scheduled: 3
     see https://linkerd.io/2/checks/#cni-plugin-ready
@@ -1271,7 +1273,7 @@ possible between paired clusters.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link CRD exists
     multicluster.linkerd.io/Link CRD is missing
     see https://linkerd.io/2/checks/#l5d-multicluster-link-crd-exists for hints
@@ -1290,7 +1292,7 @@ links.multicluster.linkerd.io     2021-03-10T09:58:10Z
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link resources are valid
     failed to parse Link east
     see https://linkerd.io/2/checks/#l5d-multicluster-links-are-valid for hints
@@ -1302,7 +1304,7 @@ Make sure all the link objects are specified in the expected format.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × remote cluster access credentials are valid
     * secret [east/east-config]: could not find east-config secret
     see https://linkerd.io/2/checks/#l5d-smc-target-clusters-access for hints
@@ -1315,7 +1317,7 @@ target cluster is present as a secret correctly
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote
@@ -1326,7 +1328,7 @@ The error above indicates that your trust anchors are not compatible. In order
 to fix that you need to ensure that both your anchors contain identical sets of
 certificates.
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote: cannot parse trust anchors
@@ -1346,7 +1348,7 @@ linkerd --context=remote check
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controller has required permissions
     missing Service mirror ClusterRole linkerd-service-mirror-access-local-resources: unexpected verbs expected create,delete,get,list,update,watch, got create,delete,get,update,watch
     see https://linkerd.io/2/checks/#l5d-multicluster-source-rbac-correct for hints
@@ -1415,7 +1417,7 @@ metadata:
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controllers are running
     Service mirror controller is not present
     see https://linkerd.io/2/checks/#l5d-multicluster-service-mirror-running for hints
@@ -1435,7 +1437,7 @@ linkerd-service-mirror-7bb8ff5967-zg265   2/2       Running   0          50m
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all gateway mirrors are healthy
     Some gateway mirrors do not have endpoints:
   linkerd-gateway-gke.linkerd-multicluster mirrored from cluster [gke]
@@ -1455,7 +1457,7 @@ service in target cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all mirror services have endpoints
     Some mirror services do not have endpoints:
   voting-svc-gke.emojivoto mirrored from cluster [gke] (gateway: [linkerd-multicluster/linkerd-gateway])
@@ -1476,7 +1478,7 @@ cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼  all mirror services are part of a Link
     mirror service voting-east.emojivoto is not part of any Link
     see https://linkerd.io/2/checks/#l5d-multicluster-orphaned-services for hints
@@ -1535,7 +1537,7 @@ for a full list of configurable fields.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1563,7 +1565,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-crb-exists for hints
@@ -1609,7 +1611,7 @@ sync by updating either the CLI or linkerd-viz as necessary.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     secrets "tap-k8s-tls" not found
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1620,7 +1622,7 @@ Ensure that the `tap-k8s-tls` secret exists and contains the appropriate
 named `linkerd-tap-tls` and it should contain the `crt.pem` and `key.pem` data
 entries.
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not tap.linkerd-viz.svc
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1633,7 +1635,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ tap API server cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-webhook-cert-not-expiring-soon for hints
@@ -1648,7 +1650,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × FailedDiscoveryCheck: no response from https://10.233.31.133:443: Get https://10.233.31.133:443: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
 ```
 
@@ -1664,7 +1666,7 @@ requirements in the cluster:
 
 ### √ linkerd-viz pods are injected {#l5d-viz-pods-injection}
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz extension pods are injected
     could not find proxy container for tap-59f5595fc7-ttndp pod
     see https://linkerd.io/2/checks/#l5d-viz-pods-injection for hints
@@ -1688,7 +1690,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ viz extension pods are running {#l5d-viz-pods-running}
 
-```bash
+```text {class=disable-copy}
 × viz extension pods are running
     container linkerd-proxy in pod tap-59f5595fc7-ttndp is not ready
     see https://linkerd.io/2/checks/#l5d-viz-pods-running for hints
@@ -1712,7 +1714,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ prometheus is installed and configured correctly {#l5d-viz-prometheus}
 
-```bash
+```text {class=disable-copy}
 × prometheus is installed and configured correctly
     missing ClusterRoles: linkerd-linkerd-viz-prometheus
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1721,12 +1723,12 @@ Make sure that the `proxy-injector` is working correctly by running
 Ensure all the prometheus related resources are present and running correctly.
 
 ```bash
-❯ kubectl -n linkerd-viz get deploy,cm | grep prometheus
+$ kubectl -n linkerd-viz get deploy,cm | grep prometheus
 deployment.apps/prometheus     1/1     1            1           3m18s
 configmap/prometheus-config   1      3m18s
-❯ kubectl get clusterRoleBindings | grep prometheus
+$ kubectl get clusterRoleBindings | grep prometheus
 linkerd-linkerd-viz-prometheus                         ClusterRole/linkerd-linkerd-viz-prometheus                         3m37s
-❯ kubectl get clusterRoles | grep prometheus
+$ kubectl get clusterRoles | grep prometheus
 linkerd-linkerd-viz-prometheus                                         2021-02-26T06:03:11Zh
 ```
 
@@ -1734,7 +1736,7 @@ linkerd-linkerd-viz-prometheus                                         2021-02-2
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     Failed to get deploy for pod metrics-api-77f684f7c7-hnw8r: not running
 ```
@@ -1742,7 +1744,7 @@ Example failure:
 Verify that the metrics API pod is running correctly
 
 ```bash
-❯ kubectl -n linkerd-viz get pods
+$ kubectl -n linkerd-viz get pods
 NAME                           READY   STATUS    RESTARTS   AGE
 metrics-api-7bb8cb8489-cbq4m   2/2     Running   0          4m58s
 tap-injector-6b9bc6fc4-cgbr4   2/2     Running   0          4m56s
@@ -1756,7 +1758,7 @@ prometheus-7c5c48c466-jc27g    2/2     Running   0          4m58s
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × viz extension self-check
     No results returned
 ```
@@ -1808,7 +1810,7 @@ be safely disregarded.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxy metrics are present in Prometheus
     Data plane metrics not found for linkerd/linkerd-identity-b8c4c48c8-pflc9.
 ```
@@ -1871,7 +1873,7 @@ versions in sync by updating either the CLI or linkerd-jaeger as necessary.
 
 ### √ jaeger extension pods are injected {#l5d-jaeger-pods-injection}
 
-```bash
+```text {class=disable-copy}
 × jaeger extension pods are injected
     could not find proxy container for jaeger-6f98d5c979-scqlq pod
     see https://linkerd.io/2/checks/#l5d-jaeger-pods-injections for hints
@@ -1892,7 +1894,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ jaeger extension pods are running {#l5d-jaeger-pods-running}
 
-```bash
+```text {class=disable-copy}
 × jaeger extension pods are running
     container linkerd-proxy in pod jaeger-59f5595fc7-ttndp is not ready
     see https://linkerd.io/2/checks/#l5d-jaeger-pods-running for hints
@@ -1920,7 +1922,7 @@ comprises `linkerd-buoyant` CLI, the `buoyant-cloud-agent` Deployment, and the
 
 ### √ Linkerd extension command linkerd-buoyant exists
 
-```bash
+```text {class=disable-copy}
 ‼ Linkerd extension command linkerd-buoyant exists
     exec: "linkerd-buoyant": executable file not found in $PATH
     see https://linkerd.io/2/checks/#extensions for hints
@@ -1940,7 +1942,7 @@ curl https://buoyant.cloud/install | sh
 
 ### √ linkerd-buoyant can determine the latest version
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant can determine the latest version
     Get "https://buoyant.cloud/version.json": dial tcp: lookup buoyant.cloud: no such host
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1956,7 +1958,7 @@ $ curl https://buoyant.cloud/version.json
 
 ### √ linkerd-buoyant cli is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant cli is up-to-date
     CLI version is v0.4.3 but the latest is v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1970,7 +1972,7 @@ curl https://buoyant.cloud/install | sh
 
 ### √ buoyant-cloud Namespace exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace exists
     namespaces "buoyant-cloud" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1991,7 +1993,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud Namespace has correct labels
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace has correct labels
     missing app.kubernetes.io/part-of label
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2006,7 +2008,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent ClusterRole exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRole exists
     missing ClusterRole: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2029,7 +2031,7 @@ yes
 
 ### √ buoyant-cloud-agent ClusterRoleBinding exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRoleBinding exists
     missing ClusterRoleBinding: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2052,7 +2054,7 @@ yes
 
 ### √ buoyant-cloud-agent ServiceAccount exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ServiceAccount exists
     missing ServiceAccount: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2075,7 +2077,7 @@ yes
 
 ### √ buoyant-cloud-id Secret exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-id Secret exists
     missing Secret: buoyant-cloud-id
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2098,7 +2100,7 @@ yes
 
 ### √ buoyant-cloud-agent Deployment exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment exists
     deployments.apps "buoyant-cloud-agent" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2119,7 +2121,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running
     no running pods for buoyant-cloud-agent Deployment
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2143,7 +2145,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-agent-6b8c6888d7-htr7d buoyant-cloud
 
 ### √ buoyant-cloud-agent Deployment is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2163,7 +2165,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-agent Deployment is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-agent Deployment is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2185,7 +2187,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running a single pod
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running a single pod
     expected 1 buoyant-cloud-agent pod, found 2
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2199,7 +2201,7 @@ kubectl get po -A --selector app=buoyant-cloud-agent
 
 ### √ buoyant-cloud-metrics DaemonSet exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet exists
     deployments.apps "buoyant-cloud-metrics" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2220,7 +2222,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-metrics DaemonSet is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is running
     no running pods for buoyant-cloud-metrics DaemonSet
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2247,7 +2249,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-metrics-kt9mv buoyant-cloud-metrics
 
 ### √ buoyant-cloud-metrics DaemonSet is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2270,7 +2272,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-metrics DaemonSet is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-metrics DaemonSet is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints

--- a/linkerd.io/content/2.13/tasks/replacing_expired_certificates.md
+++ b/linkerd.io/content/2.13/tasks/replacing_expired_certificates.md
@@ -16,7 +16,7 @@ replace the expired certificates with valid certificates.
 It might be the case that your issuer certificate is expired. If this it true
 running `linkerd check --proxy` will produce output similar to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -41,7 +41,7 @@ replace both your root and issuer certificates at the same time. If your root
 has expired `linkerd check` will indicate that by outputting an error similar
 to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -75,7 +75,7 @@ If you run `linkerd check --proxy` while pods are restarting after the trust
 bundle is updated, you will probably see warnings about pods not having the
 current trust bundle:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -107,7 +107,7 @@ These warnings will disappear as restarts complete. Once they do, you can use
 configuration up to date. After that is done, `linkerd check` should run with no
 warnings or errors:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid

--- a/linkerd.io/content/2.13/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.13/tasks/troubleshooting.md
@@ -921,7 +921,7 @@ normally.
 Example failure:
 
 ```bash
-$ linkerd check --proxy --namespace foo
+linkerd check --proxy --namespace foo
 ```
 
 ```text {class=disable-copy}

--- a/linkerd.io/content/2.13/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.13/tasks/troubleshooting.md
@@ -16,7 +16,7 @@ installation.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane namespace does not already exist
     The "linkerd" namespace already exists
 ```
@@ -34,7 +34,7 @@ linkerd check --pre --linkerd-namespace linkerd-test
 The subsequent checks in this section validate whether you have permission to
 create the Kubernetes resources required for Linkerd installation, specifically:
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -47,7 +47,7 @@ These checks only run when the `--pre` flag is set This flag is intended for use
 prior to running `linkerd install`, to verify you have the correct RBAC
 permissions to install Linkerd.
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -90,7 +90,7 @@ These checks only run when the `--pre` flag is set. This flag is intended for
 use prior to running `linkerd install`, to verify you have not already installed
 the Linkerd control plane.
 
-```bash
+```text {class=disable-copy}
 √ no ClusterRoles exist
 √ no ClusterRoleBindings exist
 √ no CustomResourceDefinitions exist
@@ -113,7 +113,7 @@ linkerd check --pre --single-namespace
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     error configuring Kubernetes API client: stat badconfig: no such file or directory
 × can query the Kubernetes API
@@ -139,8 +139,8 @@ kubectl version
 
 Another example failure:
 
-```bash
-✘ can query the Kubernetes API
+```text {class=disable-copy}
+× can query the Kubernetes API
     Get REDACTED/version: x509: certificate signed by unknown authority
 ```
 
@@ -157,7 +157,7 @@ kubectl config set-cluster ${KUBE_CONTEXT} --insecure-skip-tls-verify=true \
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum Kubernetes API version
     Kubernetes is on version [1.7.16], but version [1.13.0] or more recent is required
 ```
@@ -172,7 +172,7 @@ kubectl version
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum kubectl version
     kubectl is on version [1.9.1], but version [1.13.0] or more recent is required
     see https://linkerd.io/2/checks/#kubectl-version for hints
@@ -198,7 +198,7 @@ resources have been installed.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane Namespace exists
     The "foo" namespace does not exist
     see https://linkerd.io/2/checks/#l5d-existence-ns for hints
@@ -221,7 +221,7 @@ linkerd check --linkerd-namespace linkerdtest
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-cr for hints
@@ -248,7 +248,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-crb for hints
@@ -275,7 +275,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ServiceAccounts exist
     missing ServiceAccounts: linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-sa for hints
@@ -305,7 +305,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane CustomResourceDefinitions exist
     missing CustomResourceDefinitions: serviceprofiles.linkerd.io
     see https://linkerd.io/2/checks/#l5d-existence-crd for hints
@@ -330,7 +330,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane MutatingWebhookConfigurations exist
     missing MutatingWebhookConfigurations: linkerd-proxy-injector-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-mwc for hints
@@ -354,7 +354,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ValidatingWebhookConfigurations exist
     missing ValidatingWebhookConfigurations: linkerd-sp-validator-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-vwc for hints
@@ -378,7 +378,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × proxy-init container runs as root user if docker container runtime is used
     there are nodes using the docker container runtime and proxy-init container must run as root user.
 try installing linkerd via --set proxyInit.runAsRoot=true
@@ -409,7 +409,7 @@ further details.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × 'linkerd-config' config map exists
     missing ConfigMaps: linkerd-config
     see https://linkerd.io/2/checks/#l5d-existence-linkerd-config for hints
@@ -441,7 +441,7 @@ For more information, see the Kubernetes documentation on
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × no unschedulable pods
     linkerd-prometheus-6b668f774d-j8ncr: 0/1 nodes are available: 1 Insufficient cpu.
     see https://linkerd.io/2/checks/#l5d-existence-unschedulable-pods for hints
@@ -456,13 +456,13 @@ For more information, see the Kubernetes documentation on the
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key ca.crt containing the trust anchors needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=true
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
 ```
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key crt.pem containing the issuer certificate needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=false
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
@@ -478,7 +478,7 @@ keys are `crt.pem` and `key.pem`.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are using supported crypto algorithm
     Invalid roots:
         * 165223702412626077778653586125774349756 identity.linkerd.cluster.local must use P-256 curve for public key, instead P-521 was used
@@ -492,7 +492,7 @@ algorithm.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are within their validity period
     Invalid roots:
         * 199607941798581518463476688845828639279 identity.linkerd.cluster.local not valid anymore. Expired on 2019-12-19T13:08:18Z
@@ -509,7 +509,7 @@ cluster back to a stable state.
 
 Example warnings:
 
-```bash
+```text {class=disable-copy}
 ‼ trust roots are valid for at least 60 days
     Roots expiring soon:
         * 66509928892441932260491975092256847205 identity.linkerd.cluster.local will expire on 2019-12-19T13:30:57Z
@@ -525,7 +525,7 @@ process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is using supported crypto algorithm
     issuer certificate must use P-256 curve for public key, instead P-521 was used
     see https://linkerd.io/2/checks/#5d-identity-issuer-cert-uses-supported-crypto for hints
@@ -540,7 +540,7 @@ to see how you can generate certificates that will work with Linkerd.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is within its validity period
     issuer certificate is not valid anymore. Expired on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-is-time-valid
@@ -554,7 +554,7 @@ bring your cluster back to a valid state, follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ issuer cert is valid for at least 60 days
     issuer certificate will expire on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-not-expiring-soon for hints
@@ -569,7 +569,7 @@ follow the process outlined in
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is issued by the trust root
     x509: certificate signed by unknown authority (possibly because of "x509: ECDSA verification failure" while trying to verify candidate authority certificate "identity.linkerd.cluster.local")
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-issued-by-trust-anchor for hints
@@ -594,7 +594,7 @@ linkerd upgrade \
 Once the upgrade process is over, the output of `linkerd check --proxy` should
 be:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -617,7 +617,7 @@ linkerd-identity-data-plane
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     secrets "linkerd-proxy-injector-tls" not found
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -628,7 +628,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-proxy-injector-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-proxy-injector.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -641,7 +641,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ proxy-injector cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-not-expiring-soon for hints
@@ -656,7 +656,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     secrets "linkerd-sp-validator-tls" not found
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -667,7 +667,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-sp-validator-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-sp-validator.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -680,7 +680,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ sp-validator cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-not-expiring-soon for hints
@@ -695,7 +695,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × policy-validator webhook has valid cert
     secrets "linkerd-policy-validator-tls" not found
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-valid for hints
@@ -704,7 +704,7 @@ Example failure:
 Ensure that the `linkerd-policy-validator-k8s-tls` secret exists and contains
 the appropriate `tls.crt` and `tls.key` data entries.
 
-```bash
+```text {class=disable-copy}
 × policy-validator webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-policy-validator.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-valid for hints
@@ -717,7 +717,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ policy-validator cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-not-expiring-soon for hints
@@ -734,7 +734,7 @@ can follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
@@ -753,7 +753,7 @@ the Linkerd components are restarted. While this operation is in progress the
 `check --proxy` command may output a warning, pertaining to the Linkerd
 components:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
@@ -772,7 +772,7 @@ correct certificates.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane pods are ready
     No running pods for "linkerd-sp-validator"
 ```
@@ -791,7 +791,7 @@ linkerd-proxy-injector-67f8cf65f7-4tvt5   2/2     Running   1          12m
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cluster networks can be verified
     the following nodes do not expose a podCIDR:
         node-0
@@ -813,7 +813,7 @@ distribution being used.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × cluster networks contains all node podCIDRs
     node has podCIDR(s) [10.244.0.0/24] which are not contained in the Linkerd clusterNetworks.
     Try installing linkerd via --set clusterNetworks=10.244.0.0/24
@@ -830,12 +830,12 @@ this network may not be meshed properly. To remedy this, update the
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × the Linkerd clusterNetworks [10.244.0.0/24] do not include pod default/foo (104.21.63.202)
     see https://linkerd.io/2/checks/#l5d-cluster-networks-pods for hints
 ```
 
-```bash
+```text {class=disable-copy}
 × the Linkerd clusterNetworks [10.244.0.0/24] do not include svc default/bar (10.96.217.194)
     see https://linkerd.io/2/checks/#l5d-cluster-networks-pods for hints
 ```
@@ -853,7 +853,7 @@ networks in the cluster.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can determine the latest version
     Get https://versioncheck.linkerd.io/version.json?version=edge-19.1.2&uuid=test-uuid&source=cli: context deadline exceeded
 ```
@@ -870,7 +870,7 @@ $ curl "https://versioncheck.linkerd.io/version.json?version=edge-19.1.2&uuid=te
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cli is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ```
@@ -881,7 +881,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 ‼ control plane is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ‼ control plane and cli versions match
@@ -922,7 +922,9 @@ Example failure:
 
 ```bash
 $ linkerd check --proxy --namespace foo
-...
+```
+
+```text {class=disable-copy}
 × data plane namespace exists
     The "foo" namespace does not exist
 ```
@@ -934,7 +936,7 @@ namespaces.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxies are ready
     No "linkerd-proxy" containers found
 ```
@@ -950,7 +952,7 @@ in our [Getting Started](../getting-started/) guide.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane is up-to-date
     linkerd/linkerd-prometheus-74d66f86f6-6t6dh: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -959,7 +961,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 ### √ data plane and cli versions match {#l5d-data-plane-cli-version}
 
-```bash
+```text {class=disable-copy}
 ‼ data plane and cli versions match
     linkerd/linkerd-identity-5f6c45d6d9-9hd9j: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -970,7 +972,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane pod labels are configured correctly
     Some labels on data plane pods should be annotations:
     * emojivoto/voting-ff4c54b8d-tv9pp
@@ -984,7 +986,7 @@ be annotations in order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service labels and annotations are configured correctly
     Some labels on data plane services should be annotations:
     * emojivoto/emoji-svc
@@ -998,7 +1000,7 @@ order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service annotations are configured correctly
     Some annotations on data plane services should be labels:
     * emojivoto/emoji-svc
@@ -1011,7 +1013,7 @@ Example failure:
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × opaque ports are properly annotated
         * service emoji-svc targets the opaque port 8080 through 8080; add 8080 to its config.linkerd.io/opaque-ports annotation
     see https://linkerd.io/2/checks/#linkerd-opaque-ports-definition for hints
@@ -1035,7 +1037,7 @@ These checks are ran if Linkerd has been installed in HA mode.
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ pod injection disabled on kube-system
     kube-system namespace needs to have the label config.linkerd.io/admission-webhooks: disabled if HA mode is enabled
     see https://linkerd.io/2/checks/#l5d-injection-disabled for hints
@@ -1060,7 +1062,7 @@ metadata:
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ multiple replicas of control plane pods
     not enough replicas available for [linkerd-identity]
     see https://linkerd.io/2/checks/#l5d-control-plane-replicas for hints
@@ -1088,7 +1090,7 @@ returns the healthchecks in the
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Linkerd command jaeger exists
 ```
 
@@ -1109,7 +1111,7 @@ resources are in place. If any of them are missing, you can use
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ConfigMap exists
     configmaps "linkerd-cni-config" not found
     see https://linkerd.io/2/checks/#cni-plugin-cm-exists for hints
@@ -1134,7 +1136,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRole exists
     missing ClusterRole: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-cr-exists for hints
@@ -1159,7 +1161,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRoleBinding exists
     missing ClusterRoleBinding: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-crb-exists for hints
@@ -1184,7 +1186,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ServiceAccount exists
     missing ServiceAccount: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-sa-exists for hints
@@ -1209,7 +1211,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin DaemonSet exists
     missing DaemonSet: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-ds-exists for hints
@@ -1234,7 +1236,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cni plugin pod is running on all nodes
     number ready: 2, number scheduled: 3
     see https://linkerd.io/2/checks/#cni-plugin-ready
@@ -1271,7 +1273,7 @@ possible between paired clusters.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link CRD exists
     multicluster.linkerd.io/Link CRD is missing
     see https://linkerd.io/2/checks/#l5d-multicluster-link-crd-exists for hints
@@ -1290,7 +1292,7 @@ links.multicluster.linkerd.io     2021-03-10T09:58:10Z
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link resources are valid
     failed to parse Link east
     see https://linkerd.io/2/checks/#l5d-multicluster-links-are-valid for hints
@@ -1302,7 +1304,7 @@ Make sure all the link objects are specified in the expected format.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × remote cluster access credentials are valid
     * secret [east/east-config]: could not find east-config secret
     see https://linkerd.io/2/checks/#l5d-smc-target-clusters-access for hints
@@ -1315,7 +1317,7 @@ target cluster is present as a secret correctly
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote
@@ -1326,7 +1328,7 @@ The error above indicates that your trust anchors are not compatible. In order
 to fix that you need to ensure that both your anchors contain identical sets of
 certificates.
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote: cannot parse trust anchors
@@ -1346,7 +1348,7 @@ linkerd --context=remote check
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controller has required permissions
     missing Service mirror ClusterRole linkerd-service-mirror-access-local-resources: unexpected verbs expected create,delete,get,list,update,watch, got create,delete,get,update,watch
     see https://linkerd.io/2/checks/#l5d-multicluster-source-rbac-correct for hints
@@ -1415,7 +1417,7 @@ metadata:
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controllers are running
     Service mirror controller is not present
     see https://linkerd.io/2/checks/#l5d-multicluster-service-mirror-running for hints
@@ -1435,7 +1437,7 @@ linkerd-service-mirror-7bb8ff5967-zg265   2/2       Running   0          50m
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all gateway mirrors are healthy
     Some gateway mirrors do not have endpoints:
   linkerd-gateway-gke.linkerd-multicluster mirrored from cluster [gke]
@@ -1455,7 +1457,7 @@ service in target cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all mirror services have endpoints
     Some mirror services do not have endpoints:
   voting-svc-gke.emojivoto mirrored from cluster [gke] (gateway: [linkerd-multicluster/linkerd-gateway])
@@ -1476,7 +1478,7 @@ cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼  all mirror services are part of a Link
     mirror service voting-east.emojivoto is not part of any Link
     see https://linkerd.io/2/checks/#l5d-multicluster-orphaned-services for hints
@@ -1535,7 +1537,7 @@ for a full list of configurable fields.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1563,7 +1565,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-crb-exists for hints
@@ -1609,7 +1611,7 @@ sync by updating either the CLI or linkerd-viz as necessary.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     secrets "tap-k8s-tls" not found
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1620,7 +1622,7 @@ Ensure that the `tap-k8s-tls` secret exists and contains the appropriate
 named `linkerd-tap-tls` and it should contain the `crt.pem` and `key.pem` data
 entries.
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not tap.linkerd-viz.svc
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1633,7 +1635,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ tap API server cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-webhook-cert-not-expiring-soon for hints
@@ -1648,7 +1650,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × FailedDiscoveryCheck: no response from https://10.233.31.133:443: Get https://10.233.31.133:443: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
 ```
 
@@ -1664,7 +1666,7 @@ requirements in the cluster:
 
 ### √ linkerd-viz pods are injected {#l5d-viz-pods-injection}
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz extension pods are injected
     could not find proxy container for tap-59f5595fc7-ttndp pod
     see https://linkerd.io/2/checks/#l5d-viz-pods-injection for hints
@@ -1688,7 +1690,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ viz extension pods are running {#l5d-viz-pods-running}
 
-```bash
+```text {class=disable-copy}
 × viz extension pods are running
     container linkerd-proxy in pod tap-59f5595fc7-ttndp is not ready
     see https://linkerd.io/2/checks/#l5d-viz-pods-running for hints
@@ -1712,7 +1714,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ prometheus is installed and configured correctly {#l5d-viz-prometheus}
 
-```bash
+```text {class=disable-copy}
 × prometheus is installed and configured correctly
     missing ClusterRoles: linkerd-linkerd-viz-prometheus
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1721,12 +1723,12 @@ Make sure that the `proxy-injector` is working correctly by running
 Ensure all the prometheus related resources are present and running correctly.
 
 ```bash
-❯ kubectl -n linkerd-viz get deploy,cm | grep prometheus
+$ kubectl -n linkerd-viz get deploy,cm | grep prometheus
 deployment.apps/prometheus     1/1     1            1           3m18s
 configmap/prometheus-config   1      3m18s
-❯ kubectl get clusterRoleBindings | grep prometheus
+$ kubectl get clusterRoleBindings | grep prometheus
 linkerd-linkerd-viz-prometheus                         ClusterRole/linkerd-linkerd-viz-prometheus                         3m37s
-❯ kubectl get clusterRoles | grep prometheus
+$ kubectl get clusterRoles | grep prometheus
 linkerd-linkerd-viz-prometheus                                         2021-02-26T06:03:11Zh
 ```
 
@@ -1734,7 +1736,7 @@ linkerd-linkerd-viz-prometheus                                         2021-02-2
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     Failed to get deploy for pod metrics-api-77f684f7c7-hnw8r: not running
 ```
@@ -1742,7 +1744,7 @@ Example failure:
 Verify that the metrics API pod is running correctly
 
 ```bash
-❯ kubectl -n linkerd-viz get pods
+$ kubectl -n linkerd-viz get pods
 NAME                           READY   STATUS    RESTARTS   AGE
 metrics-api-7bb8cb8489-cbq4m   2/2     Running   0          4m58s
 tap-injector-6b9bc6fc4-cgbr4   2/2     Running   0          4m56s
@@ -1756,7 +1758,7 @@ prometheus-7c5c48c466-jc27g    2/2     Running   0          4m58s
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × viz extension self-check
     No results returned
 ```
@@ -1808,7 +1810,7 @@ be safely disregarded.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxy metrics are present in Prometheus
     Data plane metrics not found for linkerd/linkerd-identity-b8c4c48c8-pflc9.
 ```
@@ -1871,7 +1873,7 @@ versions in sync by updating either the CLI or linkerd-jaeger as necessary.
 
 ### √ jaeger extension pods are injected {#l5d-jaeger-pods-injection}
 
-```bash
+```text {class=disable-copy}
 × jaeger extension pods are injected
     could not find proxy container for jaeger-6f98d5c979-scqlq pod
     see https://linkerd.io/2/checks/#l5d-jaeger-pods-injections for hints
@@ -1892,7 +1894,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ jaeger extension pods are running {#l5d-jaeger-pods-running}
 
-```bash
+```text {class=disable-copy}
 × jaeger extension pods are running
     container linkerd-proxy in pod jaeger-59f5595fc7-ttndp is not ready
     see https://linkerd.io/2/checks/#l5d-jaeger-pods-running for hints
@@ -1920,7 +1922,7 @@ comprises `linkerd-buoyant` CLI, the `buoyant-cloud-agent` Deployment, and the
 
 ### √ Linkerd extension command linkerd-buoyant exists
 
-```bash
+```text {class=disable-copy}
 ‼ Linkerd extension command linkerd-buoyant exists
     exec: "linkerd-buoyant": executable file not found in $PATH
     see https://linkerd.io/2/checks/#extensions for hints
@@ -1940,7 +1942,7 @@ curl https://buoyant.cloud/install | sh
 
 ### √ linkerd-buoyant can determine the latest version
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant can determine the latest version
     Get "https://buoyant.cloud/version.json": dial tcp: lookup buoyant.cloud: no such host
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1956,7 +1958,7 @@ $ curl https://buoyant.cloud/version.json
 
 ### √ linkerd-buoyant cli is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant cli is up-to-date
     CLI version is v0.4.3 but the latest is v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1970,7 +1972,7 @@ curl https://buoyant.cloud/install | sh
 
 ### √ buoyant-cloud Namespace exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace exists
     namespaces "buoyant-cloud" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1991,7 +1993,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud Namespace has correct labels
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace has correct labels
     missing app.kubernetes.io/part-of label
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2006,7 +2008,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent ClusterRole exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRole exists
     missing ClusterRole: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2029,7 +2031,7 @@ yes
 
 ### √ buoyant-cloud-agent ClusterRoleBinding exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRoleBinding exists
     missing ClusterRoleBinding: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2052,7 +2054,7 @@ yes
 
 ### √ buoyant-cloud-agent ServiceAccount exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ServiceAccount exists
     missing ServiceAccount: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2075,7 +2077,7 @@ yes
 
 ### √ buoyant-cloud-id Secret exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-id Secret exists
     missing Secret: buoyant-cloud-id
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2098,7 +2100,7 @@ yes
 
 ### √ buoyant-cloud-agent Deployment exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment exists
     deployments.apps "buoyant-cloud-agent" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2119,7 +2121,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running
     no running pods for buoyant-cloud-agent Deployment
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2143,7 +2145,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-agent-6b8c6888d7-htr7d buoyant-cloud
 
 ### √ buoyant-cloud-agent Deployment is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2163,7 +2165,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-agent Deployment is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-agent Deployment is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2185,7 +2187,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running a single pod
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running a single pod
     expected 1 buoyant-cloud-agent pod, found 2
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2199,7 +2201,7 @@ kubectl get po -A --selector app=buoyant-cloud-agent
 
 ### √ buoyant-cloud-metrics DaemonSet exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet exists
     deployments.apps "buoyant-cloud-metrics" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2220,7 +2222,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-metrics DaemonSet is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is running
     no running pods for buoyant-cloud-metrics DaemonSet
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2247,7 +2249,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-metrics-kt9mv buoyant-cloud-metrics
 
 ### √ buoyant-cloud-metrics DaemonSet is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2270,7 +2272,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-metrics DaemonSet is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-metrics DaemonSet is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints

--- a/linkerd.io/content/2.14/tasks/replacing_expired_certificates.md
+++ b/linkerd.io/content/2.14/tasks/replacing_expired_certificates.md
@@ -16,7 +16,7 @@ replace the expired certificates with valid certificates.
 It might be the case that your issuer certificate is expired. If this it true
 running `linkerd check --proxy` will produce output similar to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -41,7 +41,7 @@ replace both your root and issuer certificates at the same time. If your root
 has expired `linkerd check` will indicate that by outputting an error similar
 to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -75,7 +75,7 @@ If you run `linkerd check --proxy` while pods are restarting after the trust
 bundle is updated, you will probably see warnings about pods not having the
 current trust bundle:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -107,7 +107,7 @@ These warnings will disappear as restarts complete. Once they do, you can use
 configuration up to date. After that is done, `linkerd check` should run with no
 warnings or errors:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid

--- a/linkerd.io/content/2.14/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.14/tasks/troubleshooting.md
@@ -921,7 +921,7 @@ normally.
 Example failure:
 
 ```bash
-$ linkerd check --proxy --namespace foo
+linkerd check --proxy --namespace foo
 ```
 
 ```text {class=disable-copy}

--- a/linkerd.io/content/2.14/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.14/tasks/troubleshooting.md
@@ -16,7 +16,7 @@ installation.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane namespace does not already exist
     The "linkerd" namespace already exists
 ```
@@ -34,7 +34,7 @@ linkerd check --pre --linkerd-namespace linkerd-test
 The subsequent checks in this section validate whether you have permission to
 create the Kubernetes resources required for Linkerd installation, specifically:
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -47,7 +47,7 @@ These checks only run when the `--pre` flag is set This flag is intended for use
 prior to running `linkerd install`, to verify you have the correct RBAC
 permissions to install Linkerd.
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -90,7 +90,7 @@ These checks only run when the `--pre` flag is set. This flag is intended for
 use prior to running `linkerd install`, to verify you have not already installed
 the Linkerd control plane.
 
-```bash
+```text {class=disable-copy}
 √ no ClusterRoles exist
 √ no ClusterRoleBindings exist
 √ no CustomResourceDefinitions exist
@@ -113,7 +113,7 @@ linkerd check --pre --single-namespace
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     error configuring Kubernetes API client: stat badconfig: no such file or directory
 × can query the Kubernetes API
@@ -139,8 +139,8 @@ kubectl version
 
 Another example failure:
 
-```bash
-✘ can query the Kubernetes API
+```text {class=disable-copy}
+× can query the Kubernetes API
     Get REDACTED/version: x509: certificate signed by unknown authority
 ```
 
@@ -157,7 +157,7 @@ kubectl config set-cluster ${KUBE_CONTEXT} --insecure-skip-tls-verify=true \
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum Kubernetes API version
     Kubernetes is on version [1.7.16], but version [1.13.0] or more recent is required
 ```
@@ -172,7 +172,7 @@ kubectl version
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum kubectl version
     kubectl is on version [1.9.1], but version [1.13.0] or more recent is required
     see https://linkerd.io/2/checks/#kubectl-version for hints
@@ -198,7 +198,7 @@ resources have been installed.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane Namespace exists
     The "foo" namespace does not exist
     see https://linkerd.io/2/checks/#l5d-existence-ns for hints
@@ -221,7 +221,7 @@ linkerd check --linkerd-namespace linkerdtest
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-cr for hints
@@ -248,7 +248,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-crb for hints
@@ -275,7 +275,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ServiceAccounts exist
     missing ServiceAccounts: linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-sa for hints
@@ -305,7 +305,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane CustomResourceDefinitions exist
     missing CustomResourceDefinitions: serviceprofiles.linkerd.io
     see https://linkerd.io/2/checks/#l5d-existence-crd for hints
@@ -330,7 +330,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane MutatingWebhookConfigurations exist
     missing MutatingWebhookConfigurations: linkerd-proxy-injector-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-mwc for hints
@@ -354,7 +354,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ValidatingWebhookConfigurations exist
     missing ValidatingWebhookConfigurations: linkerd-sp-validator-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-vwc for hints
@@ -378,7 +378,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × proxy-init container runs as root user if docker container runtime is used
     there are nodes using the docker container runtime and proxy-init container must run as root user.
 try installing linkerd via --set proxyInit.runAsRoot=true
@@ -409,7 +409,7 @@ further details.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × 'linkerd-config' config map exists
     missing ConfigMaps: linkerd-config
     see https://linkerd.io/2/checks/#l5d-existence-linkerd-config for hints
@@ -441,7 +441,7 @@ For more information, see the Kubernetes documentation on
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × no unschedulable pods
     linkerd-prometheus-6b668f774d-j8ncr: 0/1 nodes are available: 1 Insufficient cpu.
     see https://linkerd.io/2/checks/#l5d-existence-unschedulable-pods for hints
@@ -456,13 +456,13 @@ For more information, see the Kubernetes documentation on the
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key ca.crt containing the trust anchors needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=true
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
 ```
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key crt.pem containing the issuer certificate needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=false
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
@@ -478,7 +478,7 @@ keys are `crt.pem` and `key.pem`.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are using supported crypto algorithm
     Invalid roots:
         * 165223702412626077778653586125774349756 identity.linkerd.cluster.local must use P-256 curve for public key, instead P-521 was used
@@ -492,7 +492,7 @@ algorithm.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are within their validity period
     Invalid roots:
         * 199607941798581518463476688845828639279 identity.linkerd.cluster.local not valid anymore. Expired on 2019-12-19T13:08:18Z
@@ -509,7 +509,7 @@ cluster back to a stable state.
 
 Example warnings:
 
-```bash
+```text {class=disable-copy}
 ‼ trust roots are valid for at least 60 days
     Roots expiring soon:
         * 66509928892441932260491975092256847205 identity.linkerd.cluster.local will expire on 2019-12-19T13:30:57Z
@@ -525,7 +525,7 @@ process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is using supported crypto algorithm
     issuer certificate must use P-256 curve for public key, instead P-521 was used
     see https://linkerd.io/2/checks/#5d-identity-issuer-cert-uses-supported-crypto for hints
@@ -540,7 +540,7 @@ to see how you can generate certificates that will work with Linkerd.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is within its validity period
     issuer certificate is not valid anymore. Expired on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-is-time-valid
@@ -554,7 +554,7 @@ bring your cluster back to a valid state, follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ issuer cert is valid for at least 60 days
     issuer certificate will expire on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-not-expiring-soon for hints
@@ -569,7 +569,7 @@ follow the process outlined in
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is issued by the trust root
     x509: certificate signed by unknown authority (possibly because of "x509: ECDSA verification failure" while trying to verify candidate authority certificate "identity.linkerd.cluster.local")
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-issued-by-trust-anchor for hints
@@ -594,7 +594,7 @@ linkerd upgrade \
 Once the upgrade process is over, the output of `linkerd check --proxy` should
 be:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -617,7 +617,7 @@ linkerd-identity-data-plane
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     secrets "linkerd-proxy-injector-tls" not found
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -628,7 +628,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-proxy-injector-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-proxy-injector.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -641,7 +641,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ proxy-injector cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-not-expiring-soon for hints
@@ -656,7 +656,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     secrets "linkerd-sp-validator-tls" not found
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -667,7 +667,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-sp-validator-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-sp-validator.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -680,7 +680,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ sp-validator cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-not-expiring-soon for hints
@@ -695,7 +695,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × policy-validator webhook has valid cert
     secrets "linkerd-policy-validator-tls" not found
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-valid for hints
@@ -704,7 +704,7 @@ Example failure:
 Ensure that the `linkerd-policy-validator-k8s-tls` secret exists and contains
 the appropriate `tls.crt` and `tls.key` data entries.
 
-```bash
+```text {class=disable-copy}
 × policy-validator webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-policy-validator.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-valid for hints
@@ -717,7 +717,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ policy-validator cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-not-expiring-soon for hints
@@ -734,7 +734,7 @@ can follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
@@ -753,7 +753,7 @@ the Linkerd components are restarted. While this operation is in progress the
 `check --proxy` command may output a warning, pertaining to the Linkerd
 components:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
@@ -772,7 +772,7 @@ correct certificates.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane pods are ready
     No running pods for "linkerd-sp-validator"
 ```
@@ -791,7 +791,7 @@ linkerd-proxy-injector-67f8cf65f7-4tvt5   2/2     Running   1          12m
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cluster networks can be verified
     the following nodes do not expose a podCIDR:
         node-0
@@ -813,7 +813,7 @@ distribution being used.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × cluster networks contains all node podCIDRs
     node has podCIDR(s) [10.244.0.0/24] which are not contained in the Linkerd clusterNetworks.
     Try installing linkerd via --set clusterNetworks=10.244.0.0/24
@@ -830,12 +830,12 @@ this network may not be meshed properly. To remedy this, update the
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × the Linkerd clusterNetworks [10.244.0.0/24] do not include pod default/foo (104.21.63.202)
     see https://linkerd.io/2/checks/#l5d-cluster-networks-pods for hints
 ```
 
-```bash
+```text {class=disable-copy}
 × the Linkerd clusterNetworks [10.244.0.0/24] do not include svc default/bar (10.96.217.194)
     see https://linkerd.io/2/checks/#l5d-cluster-networks-pods for hints
 ```
@@ -853,7 +853,7 @@ networks in the cluster.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can determine the latest version
     Get https://versioncheck.linkerd.io/version.json?version=edge-19.1.2&uuid=test-uuid&source=cli: context deadline exceeded
 ```
@@ -870,7 +870,7 @@ $ curl "https://versioncheck.linkerd.io/version.json?version=edge-19.1.2&uuid=te
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cli is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ```
@@ -881,7 +881,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 ‼ control plane is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ‼ control plane and cli versions match
@@ -922,7 +922,9 @@ Example failure:
 
 ```bash
 $ linkerd check --proxy --namespace foo
-...
+```
+
+```text {class=disable-copy}
 × data plane namespace exists
     The "foo" namespace does not exist
 ```
@@ -934,7 +936,7 @@ namespaces.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxies are ready
     No "linkerd-proxy" containers found
 ```
@@ -950,7 +952,7 @@ in our [Getting Started](../getting-started/) guide.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane is up-to-date
     linkerd/linkerd-prometheus-74d66f86f6-6t6dh: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -959,7 +961,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 ### √ data plane and cli versions match {#l5d-data-plane-cli-version}
 
-```bash
+```text {class=disable-copy}
 ‼ data plane and cli versions match
     linkerd/linkerd-identity-5f6c45d6d9-9hd9j: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -970,7 +972,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane pod labels are configured correctly
     Some labels on data plane pods should be annotations:
     * emojivoto/voting-ff4c54b8d-tv9pp
@@ -984,7 +986,7 @@ be annotations in order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service labels and annotations are configured correctly
     Some labels on data plane services should be annotations:
     * emojivoto/emoji-svc
@@ -998,7 +1000,7 @@ order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service annotations are configured correctly
     Some annotations on data plane services should be labels:
     * emojivoto/emoji-svc
@@ -1011,7 +1013,7 @@ Example failure:
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × opaque ports are properly annotated
         * service emoji-svc targets the opaque port 8080 through 8080; add 8080 to its config.linkerd.io/opaque-ports annotation
     see https://linkerd.io/2/checks/#linkerd-opaque-ports-definition for hints
@@ -1035,7 +1037,7 @@ These checks are ran if Linkerd has been installed in HA mode.
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ pod injection disabled on kube-system
     kube-system namespace needs to have the label config.linkerd.io/admission-webhooks: disabled if HA mode is enabled
     see https://linkerd.io/2/checks/#l5d-injection-disabled for hints
@@ -1060,7 +1062,7 @@ metadata:
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ multiple replicas of control plane pods
     not enough replicas available for [linkerd-identity]
     see https://linkerd.io/2/checks/#l5d-control-plane-replicas for hints
@@ -1088,7 +1090,7 @@ returns the healthchecks in the
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Linkerd command jaeger exists
 ```
 
@@ -1109,7 +1111,7 @@ resources are in place. If any of them are missing, you can use
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ConfigMap exists
     configmaps "linkerd-cni-config" not found
     see https://linkerd.io/2/checks/#cni-plugin-cm-exists for hints
@@ -1134,7 +1136,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRole exists
     missing ClusterRole: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-cr-exists for hints
@@ -1159,7 +1161,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRoleBinding exists
     missing ClusterRoleBinding: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-crb-exists for hints
@@ -1184,7 +1186,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ServiceAccount exists
     missing ServiceAccount: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-sa-exists for hints
@@ -1209,7 +1211,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin DaemonSet exists
     missing DaemonSet: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-ds-exists for hints
@@ -1234,7 +1236,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cni plugin pod is running on all nodes
     number ready: 2, number scheduled: 3
     see https://linkerd.io/2/checks/#cni-plugin-ready
@@ -1271,7 +1273,7 @@ possible between paired clusters.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link CRD exists
     multicluster.linkerd.io/Link CRD is missing
     see https://linkerd.io/2/checks/#l5d-multicluster-link-crd-exists for hints
@@ -1290,7 +1292,7 @@ links.multicluster.linkerd.io     2021-03-10T09:58:10Z
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link resources are valid
     failed to parse Link east
     see https://linkerd.io/2/checks/#l5d-multicluster-links-are-valid for hints
@@ -1302,7 +1304,7 @@ Make sure all the link objects are specified in the expected format.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × remote cluster access credentials are valid
     * secret [east/east-config]: could not find east-config secret
     see https://linkerd.io/2/checks/#l5d-smc-target-clusters-access for hints
@@ -1315,7 +1317,7 @@ target cluster is present as a secret correctly
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote
@@ -1326,7 +1328,7 @@ The error above indicates that your trust anchors are not compatible. In order
 to fix that you need to ensure that both your anchors contain identical sets of
 certificates.
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote: cannot parse trust anchors
@@ -1346,7 +1348,7 @@ linkerd --context=remote check
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controller has required permissions
     missing Service mirror ClusterRole linkerd-service-mirror-access-local-resources: unexpected verbs expected create,delete,get,list,update,watch, got create,delete,get,update,watch
     see https://linkerd.io/2/checks/#l5d-multicluster-source-rbac-correct for hints
@@ -1415,7 +1417,7 @@ metadata:
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controllers are running
     Service mirror controller is not present
     see https://linkerd.io/2/checks/#l5d-multicluster-service-mirror-running for hints
@@ -1435,7 +1437,7 @@ linkerd-service-mirror-7bb8ff5967-zg265   2/2       Running   0          50m
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all gateway mirrors are healthy
     Some gateway mirrors do not have endpoints:
   linkerd-gateway-gke.linkerd-multicluster mirrored from cluster [gke]
@@ -1455,7 +1457,7 @@ service in target cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all mirror services have endpoints
     Some mirror services do not have endpoints:
   voting-svc-gke.emojivoto mirrored from cluster [gke] (gateway: [linkerd-multicluster/linkerd-gateway])
@@ -1476,7 +1478,7 @@ cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼  all mirror services are part of a Link
     mirror service voting-east.emojivoto is not part of any Link
     see https://linkerd.io/2/checks/#l5d-multicluster-orphaned-services for hints
@@ -1535,7 +1537,7 @@ for a full list of configurable fields.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1563,7 +1565,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-crb-exists for hints
@@ -1609,7 +1611,7 @@ sync by updating either the CLI or linkerd-viz as necessary.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     secrets "tap-k8s-tls" not found
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1620,7 +1622,7 @@ Ensure that the `tap-k8s-tls` secret exists and contains the appropriate
 named `linkerd-tap-tls` and it should contain the `crt.pem` and `key.pem` data
 entries.
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not tap.linkerd-viz.svc
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1633,7 +1635,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ tap API server cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-webhook-cert-not-expiring-soon for hints
@@ -1648,7 +1650,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × FailedDiscoveryCheck: no response from https://10.233.31.133:443: Get https://10.233.31.133:443: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
 ```
 
@@ -1664,7 +1666,7 @@ requirements in the cluster:
 
 ### √ linkerd-viz pods are injected {#l5d-viz-pods-injection}
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz extension pods are injected
     could not find proxy container for tap-59f5595fc7-ttndp pod
     see https://linkerd.io/2/checks/#l5d-viz-pods-injection for hints
@@ -1688,7 +1690,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ viz extension pods are running {#l5d-viz-pods-running}
 
-```bash
+```text {class=disable-copy}
 × viz extension pods are running
     container linkerd-proxy in pod tap-59f5595fc7-ttndp is not ready
     see https://linkerd.io/2/checks/#l5d-viz-pods-running for hints
@@ -1712,7 +1714,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ prometheus is installed and configured correctly {#l5d-viz-prometheus}
 
-```bash
+```text {class=disable-copy}
 × prometheus is installed and configured correctly
     missing ClusterRoles: linkerd-linkerd-viz-prometheus
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1721,12 +1723,12 @@ Make sure that the `proxy-injector` is working correctly by running
 Ensure all the prometheus related resources are present and running correctly.
 
 ```bash
-❯ kubectl -n linkerd-viz get deploy,cm | grep prometheus
+$ kubectl -n linkerd-viz get deploy,cm | grep prometheus
 deployment.apps/prometheus     1/1     1            1           3m18s
 configmap/prometheus-config   1      3m18s
-❯ kubectl get clusterRoleBindings | grep prometheus
+$ kubectl get clusterRoleBindings | grep prometheus
 linkerd-linkerd-viz-prometheus                         ClusterRole/linkerd-linkerd-viz-prometheus                         3m37s
-❯ kubectl get clusterRoles | grep prometheus
+$ kubectl get clusterRoles | grep prometheus
 linkerd-linkerd-viz-prometheus                                         2021-02-26T06:03:11Zh
 ```
 
@@ -1734,7 +1736,7 @@ linkerd-linkerd-viz-prometheus                                         2021-02-2
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     Failed to get deploy for pod metrics-api-77f684f7c7-hnw8r: not running
 ```
@@ -1742,7 +1744,7 @@ Example failure:
 Verify that the metrics API pod is running correctly
 
 ```bash
-❯ kubectl -n linkerd-viz get pods
+$ kubectl -n linkerd-viz get pods
 NAME                           READY   STATUS    RESTARTS   AGE
 metrics-api-7bb8cb8489-cbq4m   2/2     Running   0          4m58s
 tap-injector-6b9bc6fc4-cgbr4   2/2     Running   0          4m56s
@@ -1756,7 +1758,7 @@ prometheus-7c5c48c466-jc27g    2/2     Running   0          4m58s
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × viz extension self-check
     No results returned
 ```
@@ -1808,7 +1810,7 @@ be safely disregarded.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxy metrics are present in Prometheus
     Data plane metrics not found for linkerd/linkerd-identity-b8c4c48c8-pflc9.
 ```
@@ -1871,7 +1873,7 @@ versions in sync by updating either the CLI or linkerd-jaeger as necessary.
 
 ### √ jaeger extension pods are injected {#l5d-jaeger-pods-injection}
 
-```bash
+```text {class=disable-copy}
 × jaeger extension pods are injected
     could not find proxy container for jaeger-6f98d5c979-scqlq pod
     see https://linkerd.io/2/checks/#l5d-jaeger-pods-injections for hints
@@ -1892,7 +1894,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ jaeger extension pods are running {#l5d-jaeger-pods-running}
 
-```bash
+```text {class=disable-copy}
 × jaeger extension pods are running
     container linkerd-proxy in pod jaeger-59f5595fc7-ttndp is not ready
     see https://linkerd.io/2/checks/#l5d-jaeger-pods-running for hints
@@ -1920,7 +1922,7 @@ comprises `linkerd-buoyant` CLI, the `buoyant-cloud-agent` Deployment, and the
 
 ### √ Linkerd extension command linkerd-buoyant exists
 
-```bash
+```text {class=disable-copy}
 ‼ Linkerd extension command linkerd-buoyant exists
     exec: "linkerd-buoyant": executable file not found in $PATH
     see https://linkerd.io/2/checks/#extensions for hints
@@ -1940,7 +1942,7 @@ curl https://buoyant.cloud/install | sh
 
 ### √ linkerd-buoyant can determine the latest version
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant can determine the latest version
     Get "https://buoyant.cloud/version.json": dial tcp: lookup buoyant.cloud: no such host
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1956,7 +1958,7 @@ $ curl https://buoyant.cloud/version.json
 
 ### √ linkerd-buoyant cli is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant cli is up-to-date
     CLI version is v0.4.3 but the latest is v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1970,7 +1972,7 @@ curl https://buoyant.cloud/install | sh
 
 ### √ buoyant-cloud Namespace exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace exists
     namespaces "buoyant-cloud" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1991,7 +1993,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud Namespace has correct labels
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace has correct labels
     missing app.kubernetes.io/part-of label
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2006,7 +2008,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent ClusterRole exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRole exists
     missing ClusterRole: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2029,7 +2031,7 @@ yes
 
 ### √ buoyant-cloud-agent ClusterRoleBinding exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRoleBinding exists
     missing ClusterRoleBinding: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2052,7 +2054,7 @@ yes
 
 ### √ buoyant-cloud-agent ServiceAccount exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ServiceAccount exists
     missing ServiceAccount: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2075,7 +2077,7 @@ yes
 
 ### √ buoyant-cloud-id Secret exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-id Secret exists
     missing Secret: buoyant-cloud-id
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2098,7 +2100,7 @@ yes
 
 ### √ buoyant-cloud-agent Deployment exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment exists
     deployments.apps "buoyant-cloud-agent" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2119,7 +2121,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running
     no running pods for buoyant-cloud-agent Deployment
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2143,7 +2145,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-agent-6b8c6888d7-htr7d buoyant-cloud
 
 ### √ buoyant-cloud-agent Deployment is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2163,7 +2165,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-agent Deployment is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-agent Deployment is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2185,7 +2187,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running a single pod
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running a single pod
     expected 1 buoyant-cloud-agent pod, found 2
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2199,7 +2201,7 @@ kubectl get po -A --selector app=buoyant-cloud-agent
 
 ### √ buoyant-cloud-metrics DaemonSet exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet exists
     deployments.apps "buoyant-cloud-metrics" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2220,7 +2222,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-metrics DaemonSet is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is running
     no running pods for buoyant-cloud-metrics DaemonSet
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2247,7 +2249,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-metrics-kt9mv buoyant-cloud-metrics
 
 ### √ buoyant-cloud-metrics DaemonSet is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2270,7 +2272,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-metrics DaemonSet is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-metrics DaemonSet is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints

--- a/linkerd.io/content/2.15/tasks/replacing_expired_certificates.md
+++ b/linkerd.io/content/2.15/tasks/replacing_expired_certificates.md
@@ -16,7 +16,7 @@ replace the expired certificates with valid certificates.
 It might be the case that your issuer certificate is expired. If this it true
 running `linkerd check --proxy` will produce output similar to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -41,7 +41,7 @@ replace both your root and issuer certificates at the same time. If your root
 has expired `linkerd check` will indicate that by outputting an error similar
 to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -75,7 +75,7 @@ If you run `linkerd check --proxy` while pods are restarting after the trust
 bundle is updated, you will probably see warnings about pods not having the
 current trust bundle:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -107,7 +107,7 @@ These warnings will disappear as restarts complete. Once they do, you can use
 configuration up to date. After that is done, `linkerd check` should run with no
 warnings or errors:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid

--- a/linkerd.io/content/2.15/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.15/tasks/troubleshooting.md
@@ -16,7 +16,7 @@ installation.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane namespace does not already exist
     The "linkerd" namespace already exists
 ```
@@ -34,7 +34,7 @@ linkerd check --pre --linkerd-namespace linkerd-test
 The subsequent checks in this section validate whether you have permission to
 create the Kubernetes resources required for Linkerd installation, specifically:
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -47,7 +47,7 @@ These checks only run when the `--pre` flag is set This flag is intended for use
 prior to running `linkerd install`, to verify you have the correct RBAC
 permissions to install Linkerd.
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -90,7 +90,7 @@ These checks only run when the `--pre` flag is set. This flag is intended for
 use prior to running `linkerd install`, to verify you have not already installed
 the Linkerd control plane.
 
-```bash
+```text {class=disable-copy}
 √ no ClusterRoles exist
 √ no ClusterRoleBindings exist
 √ no CustomResourceDefinitions exist
@@ -113,7 +113,7 @@ linkerd check --pre --single-namespace
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     error configuring Kubernetes API client: stat badconfig: no such file or directory
 × can query the Kubernetes API
@@ -139,8 +139,8 @@ kubectl version
 
 Another example failure:
 
-```bash
-✘ can query the Kubernetes API
+```text {class=disable-copy}
+× can query the Kubernetes API
     Get REDACTED/version: x509: certificate signed by unknown authority
 ```
 
@@ -157,7 +157,7 @@ kubectl config set-cluster ${KUBE_CONTEXT} --insecure-skip-tls-verify=true \
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum Kubernetes API version
     Kubernetes is on version [1.7.16], but version [1.13.0] or more recent is required
 ```
@@ -172,7 +172,7 @@ kubectl version
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum kubectl version
     kubectl is on version [1.9.1], but version [1.13.0] or more recent is required
     see https://linkerd.io/2/checks/#kubectl-version for hints
@@ -198,7 +198,7 @@ resources have been installed.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane Namespace exists
     The "foo" namespace does not exist
     see https://linkerd.io/2/checks/#l5d-existence-ns for hints
@@ -221,7 +221,7 @@ linkerd check --linkerd-namespace linkerdtest
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-cr for hints
@@ -248,7 +248,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-crb for hints
@@ -275,7 +275,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ServiceAccounts exist
     missing ServiceAccounts: linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-sa for hints
@@ -305,7 +305,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane CustomResourceDefinitions exist
     missing CustomResourceDefinitions: serviceprofiles.linkerd.io
     see https://linkerd.io/2/checks/#l5d-existence-crd for hints
@@ -330,7 +330,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane MutatingWebhookConfigurations exist
     missing MutatingWebhookConfigurations: linkerd-proxy-injector-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-mwc for hints
@@ -354,7 +354,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ValidatingWebhookConfigurations exist
     missing ValidatingWebhookConfigurations: linkerd-sp-validator-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-vwc for hints
@@ -378,7 +378,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × proxy-init container runs as root user if docker container runtime is used
     there are nodes using the docker container runtime and proxy-init container must run as root user.
 try installing linkerd via --set proxyInit.runAsRoot=true
@@ -409,7 +409,7 @@ further details.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × 'linkerd-config' config map exists
     missing ConfigMaps: linkerd-config
     see https://linkerd.io/2/checks/#l5d-existence-linkerd-config for hints
@@ -441,7 +441,7 @@ For more information, see the Kubernetes documentation on
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × no unschedulable pods
     linkerd-prometheus-6b668f774d-j8ncr: 0/1 nodes are available: 1 Insufficient cpu.
     see https://linkerd.io/2/checks/#l5d-existence-unschedulable-pods for hints
@@ -456,13 +456,13 @@ For more information, see the Kubernetes documentation on the
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key ca.crt containing the trust anchors needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=true
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
 ```
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key crt.pem containing the issuer certificate needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=false
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
@@ -478,7 +478,7 @@ keys are `crt.pem` and `key.pem`.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are using supported crypto algorithm
     Invalid roots:
         * 165223702412626077778653586125774349756 identity.linkerd.cluster.local must use P-256 curve for public key, instead P-521 was used
@@ -492,7 +492,7 @@ algorithm.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are within their validity period
     Invalid roots:
         * 199607941798581518463476688845828639279 identity.linkerd.cluster.local not valid anymore. Expired on 2019-12-19T13:08:18Z
@@ -509,7 +509,7 @@ cluster back to a stable state.
 
 Example warnings:
 
-```bash
+```text {class=disable-copy}
 ‼ trust roots are valid for at least 60 days
     Roots expiring soon:
         * 66509928892441932260491975092256847205 identity.linkerd.cluster.local will expire on 2019-12-19T13:30:57Z
@@ -525,7 +525,7 @@ process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is using supported crypto algorithm
     issuer certificate must use P-256 curve for public key, instead P-521 was used
     see https://linkerd.io/2/checks/#5d-identity-issuer-cert-uses-supported-crypto for hints
@@ -540,7 +540,7 @@ to see how you can generate certificates that will work with Linkerd.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is within its validity period
     issuer certificate is not valid anymore. Expired on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-is-time-valid
@@ -554,7 +554,7 @@ bring your cluster back to a valid state, follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ issuer cert is valid for at least 60 days
     issuer certificate will expire on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-not-expiring-soon for hints
@@ -569,7 +569,7 @@ follow the process outlined in
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is issued by the trust root
     x509: certificate signed by unknown authority (possibly because of "x509: ECDSA verification failure" while trying to verify candidate authority certificate "identity.linkerd.cluster.local")
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-issued-by-trust-anchor for hints
@@ -594,7 +594,7 @@ linkerd upgrade \
 Once the upgrade process is over, the output of `linkerd check --proxy` should
 be:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -617,7 +617,7 @@ linkerd-identity-data-plane
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     secrets "linkerd-proxy-injector-tls" not found
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -628,7 +628,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-proxy-injector-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-proxy-injector.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -641,7 +641,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ proxy-injector cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-not-expiring-soon for hints
@@ -656,7 +656,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     secrets "linkerd-sp-validator-tls" not found
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -667,7 +667,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-sp-validator-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-sp-validator.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -680,7 +680,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ sp-validator cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-not-expiring-soon for hints
@@ -695,7 +695,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × policy-validator webhook has valid cert
     secrets "linkerd-policy-validator-tls" not found
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-valid for hints
@@ -704,7 +704,7 @@ Example failure:
 Ensure that the `linkerd-policy-validator-k8s-tls` secret exists and contains
 the appropriate `tls.crt` and `tls.key` data entries.
 
-```bash
+```text {class=disable-copy}
 × policy-validator webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-policy-validator.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-valid for hints
@@ -717,7 +717,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ policy-validator cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-not-expiring-soon for hints
@@ -734,7 +734,7 @@ can follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
@@ -753,7 +753,7 @@ the Linkerd components are restarted. While this operation is in progress the
 `check --proxy` command may output a warning, pertaining to the Linkerd
 components:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
@@ -772,7 +772,7 @@ correct certificates.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane pods are ready
     No running pods for "linkerd-sp-validator"
 ```
@@ -791,7 +791,7 @@ linkerd-proxy-injector-67f8cf65f7-4tvt5   2/2     Running   1          12m
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cluster networks can be verified
     the following nodes do not expose a podCIDR:
         node-0
@@ -813,7 +813,7 @@ distribution being used.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × cluster networks contains all node podCIDRs
     node has podCIDR(s) [10.244.0.0/24] which are not contained in the Linkerd clusterNetworks.
     Try installing linkerd via --set clusterNetworks=10.244.0.0/24
@@ -830,12 +830,12 @@ this network may not be meshed properly. To remedy this, update the
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × the Linkerd clusterNetworks [10.244.0.0/24] do not include pod default/foo (104.21.63.202)
     see https://linkerd.io/2/checks/#l5d-cluster-networks-pods for hints
 ```
 
-```bash
+```text {class=disable-copy}
 × the Linkerd clusterNetworks [10.244.0.0/24] do not include svc default/bar (10.96.217.194)
     see https://linkerd.io/2/checks/#l5d-cluster-networks-pods for hints
 ```
@@ -853,7 +853,7 @@ networks in the cluster.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can determine the latest version
     Get https://versioncheck.linkerd.io/version.json?version=edge-19.1.2&uuid=test-uuid&source=cli: context deadline exceeded
 ```
@@ -872,7 +872,7 @@ Example failures:
 
 #### unsupported version channel
 
-```bash
+```text {class=disable-copy}
 ‼ cli is up-to-date
     unsupported version channel: stable-2.14.10
 ```
@@ -883,7 +883,7 @@ As of February 2024, the Linkerd project itself only produces
 
 #### is running version X but the latest version is Y
 
-```bash
+```text {class=disable-copy}
 ‼ cli is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ```
@@ -899,7 +899,7 @@ Example failures:
 
 #### unsupported version channel
 
-```bash
+```text {class=disable-copy}
 ‼ control plane is up-to-date
     unsupported version channel: stable-2.14.10
 ```
@@ -910,7 +910,7 @@ As of February 2024, the Linkerd project itself only produces
 
 #### is running version X but the latest version is Y
 
-```bash
+```text {class=disable-copy}
 ‼ control plane is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ```
@@ -922,7 +922,7 @@ There is a newer version of the control plane. See the page on
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ control plane and cli versions match
     mismatched channels: running stable-2.1.0 but retrieved edge-19.1.2
 ```
@@ -962,7 +962,9 @@ Example failure:
 
 ```bash
 $ linkerd check --proxy --namespace foo
-...
+```
+
+```text {class=disable-copy}
 × data plane namespace exists
     The "foo" namespace does not exist
 ```
@@ -974,7 +976,7 @@ namespaces.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxies are ready
     No "linkerd-proxy" containers found
 ```
@@ -990,7 +992,7 @@ in our [Getting Started](../getting-started/) guide.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane is up-to-date
     linkerd/linkerd-prometheus-74d66f86f6-6t6dh: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -999,7 +1001,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 ### √ data plane and cli versions match {#l5d-data-plane-cli-version}
 
-```bash
+```text {class=disable-copy}
 ‼ data plane and cli versions match
     linkerd/linkerd-identity-5f6c45d6d9-9hd9j: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -1010,7 +1012,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane pod labels are configured correctly
     Some labels on data plane pods should be annotations:
     * emojivoto/voting-ff4c54b8d-tv9pp
@@ -1024,7 +1026,7 @@ be annotations in order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service labels and annotations are configured correctly
     Some labels on data plane services should be annotations:
     * emojivoto/emoji-svc
@@ -1038,7 +1040,7 @@ order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service annotations are configured correctly
     Some annotations on data plane services should be labels:
     * emojivoto/emoji-svc
@@ -1051,7 +1053,7 @@ Example failure:
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × opaque ports are properly annotated
         * service emoji-svc targets the opaque port 8080 through 8080; add 8080 to its config.linkerd.io/opaque-ports annotation
     see https://linkerd.io/2/checks/#linkerd-opaque-ports-definition for hints
@@ -1075,7 +1077,7 @@ These checks are ran if Linkerd has been installed in HA mode.
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ multiple replicas of control plane pods
     not enough replicas available for [linkerd-identity]
     see https://linkerd.io/2/checks/#l5d-control-plane-replicas for hints
@@ -1103,7 +1105,7 @@ returns the healthchecks in the
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Linkerd command jaeger exists
 ```
 
@@ -1124,7 +1126,7 @@ resources are in place. If any of them are missing, you can use
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ConfigMap exists
     configmaps "linkerd-cni-config" not found
     see https://linkerd.io/2/checks/#cni-plugin-cm-exists for hints
@@ -1149,7 +1151,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRole exists
     missing ClusterRole: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-cr-exists for hints
@@ -1174,7 +1176,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRoleBinding exists
     missing ClusterRoleBinding: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-crb-exists for hints
@@ -1199,7 +1201,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ServiceAccount exists
     missing ServiceAccount: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-sa-exists for hints
@@ -1224,7 +1226,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin DaemonSet exists
     missing DaemonSet: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-ds-exists for hints
@@ -1249,7 +1251,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cni plugin pod is running on all nodes
     number ready: 2, number scheduled: 3
     see https://linkerd.io/2/checks/#cni-plugin-ready
@@ -1286,7 +1288,7 @@ possible between paired clusters.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link CRD exists
     multicluster.linkerd.io/Link CRD is missing
     see https://linkerd.io/2/checks/#l5d-multicluster-link-crd-exists for hints
@@ -1305,7 +1307,7 @@ links.multicluster.linkerd.io     2021-03-10T09:58:10Z
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link resources are valid
     failed to parse Link east
     see https://linkerd.io/2/checks/#l5d-multicluster-links-are-valid for hints
@@ -1317,7 +1319,7 @@ Make sure all the link objects are specified in the expected format.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × remote cluster access credentials are valid
     * secret [east/east-config]: could not find east-config secret
     see https://linkerd.io/2/checks/#l5d-smc-target-clusters-access for hints
@@ -1330,7 +1332,7 @@ target cluster is present as a secret correctly
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote
@@ -1341,7 +1343,7 @@ The error above indicates that your trust anchors are not compatible. In order
 to fix that you need to ensure that both your anchors contain identical sets of
 certificates.
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote: cannot parse trust anchors
@@ -1361,7 +1363,7 @@ linkerd --context=remote check
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controller has required permissions
     missing Service mirror ClusterRole linkerd-service-mirror-access-local-resources: unexpected verbs expected create,delete,get,list,update,watch, got create,delete,get,update,watch
     see https://linkerd.io/2/checks/#l5d-multicluster-source-rbac-correct for hints
@@ -1430,7 +1432,7 @@ metadata:
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controllers are running
     Service mirror controller is not present
     see https://linkerd.io/2/checks/#l5d-multicluster-service-mirror-running for hints
@@ -1450,7 +1452,7 @@ linkerd-service-mirror-7bb8ff5967-zg265   2/2       Running   0          50m
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all gateway mirrors are healthy
     Some gateway mirrors do not have endpoints:
   linkerd-gateway-gke.linkerd-multicluster mirrored from cluster [gke]
@@ -1470,7 +1472,7 @@ service in target cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all mirror services have endpoints
     Some mirror services do not have endpoints:
   voting-svc-gke.emojivoto mirrored from cluster [gke] (gateway: [linkerd-multicluster/linkerd-gateway])
@@ -1491,7 +1493,7 @@ cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼  all mirror services are part of a Link
     mirror service voting-east.emojivoto is not part of any Link
     see https://linkerd.io/2/checks/#l5d-multicluster-orphaned-services for hints
@@ -1550,7 +1552,7 @@ for a full list of configurable fields.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1578,7 +1580,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-crb-exists for hints
@@ -1624,7 +1626,7 @@ sync by updating either the CLI or linkerd-viz as necessary.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     secrets "tap-k8s-tls" not found
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1635,7 +1637,7 @@ Ensure that the `tap-k8s-tls` secret exists and contains the appropriate
 named `linkerd-tap-tls` and it should contain the `crt.pem` and `key.pem` data
 entries.
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not tap.linkerd-viz.svc
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1648,7 +1650,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ tap API server cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-webhook-cert-not-expiring-soon for hints
@@ -1663,7 +1665,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × FailedDiscoveryCheck: no response from https://10.233.31.133:443: Get https://10.233.31.133:443: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
 ```
 
@@ -1679,7 +1681,7 @@ requirements in the cluster:
 
 ### √ linkerd-viz pods are injected {#l5d-viz-pods-injection}
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz extension pods are injected
     could not find proxy container for tap-59f5595fc7-ttndp pod
     see https://linkerd.io/2/checks/#l5d-viz-pods-injection for hints
@@ -1703,7 +1705,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ viz extension pods are running {#l5d-viz-pods-running}
 
-```bash
+```text {class=disable-copy}
 × viz extension pods are running
     container linkerd-proxy in pod tap-59f5595fc7-ttndp is not ready
     see https://linkerd.io/2/checks/#l5d-viz-pods-running for hints
@@ -1727,7 +1729,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ prometheus is installed and configured correctly {#l5d-viz-prometheus}
 
-```bash
+```text {class=disable-copy}
 × prometheus is installed and configured correctly
     missing ClusterRoles: linkerd-linkerd-viz-prometheus
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1736,12 +1738,12 @@ Make sure that the `proxy-injector` is working correctly by running
 Ensure all the prometheus related resources are present and running correctly.
 
 ```bash
-❯ kubectl -n linkerd-viz get deploy,cm | grep prometheus
+$ kubectl -n linkerd-viz get deploy,cm | grep prometheus
 deployment.apps/prometheus     1/1     1            1           3m18s
 configmap/prometheus-config   1      3m18s
-❯ kubectl get clusterRoleBindings | grep prometheus
+$ kubectl get clusterRoleBindings | grep prometheus
 linkerd-linkerd-viz-prometheus                         ClusterRole/linkerd-linkerd-viz-prometheus                         3m37s
-❯ kubectl get clusterRoles | grep prometheus
+$ kubectl get clusterRoles | grep prometheus
 linkerd-linkerd-viz-prometheus                                         2021-02-26T06:03:11Zh
 ```
 
@@ -1749,7 +1751,7 @@ linkerd-linkerd-viz-prometheus                                         2021-02-2
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     Failed to get deploy for pod metrics-api-77f684f7c7-hnw8r: not running
 ```
@@ -1757,7 +1759,7 @@ Example failure:
 Verify that the metrics API pod is running correctly
 
 ```bash
-❯ kubectl -n linkerd-viz get pods
+$ kubectl -n linkerd-viz get pods
 NAME                           READY   STATUS    RESTARTS   AGE
 metrics-api-7bb8cb8489-cbq4m   2/2     Running   0          4m58s
 tap-injector-6b9bc6fc4-cgbr4   2/2     Running   0          4m56s
@@ -1771,7 +1773,7 @@ prometheus-7c5c48c466-jc27g    2/2     Running   0          4m58s
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × viz extension self-check
     No results returned
 ```
@@ -1823,7 +1825,7 @@ be safely disregarded.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxy metrics are present in Prometheus
     Data plane metrics not found for linkerd/linkerd-identity-b8c4c48c8-pflc9.
 ```
@@ -1886,7 +1888,7 @@ versions in sync by updating either the CLI or linkerd-jaeger as necessary.
 
 ### √ jaeger extension pods are injected {#l5d-jaeger-pods-injection}
 
-```bash
+```text {class=disable-copy}
 × jaeger extension pods are injected
     could not find proxy container for jaeger-6f98d5c979-scqlq pod
     see https://linkerd.io/2/checks/#l5d-jaeger-pods-injections for hints
@@ -1907,7 +1909,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ jaeger extension pods are running {#l5d-jaeger-pods-running}
 
-```bash
+```text {class=disable-copy}
 × jaeger extension pods are running
     container linkerd-proxy in pod jaeger-59f5595fc7-ttndp is not ready
     see https://linkerd.io/2/checks/#l5d-jaeger-pods-running for hints
@@ -1935,7 +1937,7 @@ comprises `linkerd-buoyant` CLI, the `buoyant-cloud-agent` Deployment, and the
 
 ### √ Linkerd extension command linkerd-buoyant exists
 
-```bash
+```text {class=disable-copy}
 ‼ Linkerd extension command linkerd-buoyant exists
     exec: "linkerd-buoyant": executable file not found in $PATH
     see https://linkerd.io/2/checks/#extensions for hints
@@ -1955,7 +1957,7 @@ curl https://buoyant.cloud/install | sh
 
 ### √ linkerd-buoyant can determine the latest version
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant can determine the latest version
     Get "https://buoyant.cloud/version.json": dial tcp: lookup buoyant.cloud: no such host
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1971,7 +1973,7 @@ $ curl https://buoyant.cloud/version.json
 
 ### √ linkerd-buoyant cli is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant cli is up-to-date
     CLI version is v0.4.3 but the latest is v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1985,7 +1987,7 @@ curl https://buoyant.cloud/install | sh
 
 ### √ buoyant-cloud Namespace exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace exists
     namespaces "buoyant-cloud" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2006,7 +2008,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud Namespace has correct labels
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace has correct labels
     missing app.kubernetes.io/part-of label
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2021,7 +2023,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent ClusterRole exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRole exists
     missing ClusterRole: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2044,7 +2046,7 @@ yes
 
 ### √ buoyant-cloud-agent ClusterRoleBinding exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRoleBinding exists
     missing ClusterRoleBinding: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2067,7 +2069,7 @@ yes
 
 ### √ buoyant-cloud-agent ServiceAccount exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ServiceAccount exists
     missing ServiceAccount: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2090,7 +2092,7 @@ yes
 
 ### √ buoyant-cloud-id Secret exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-id Secret exists
     missing Secret: buoyant-cloud-id
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2113,7 +2115,7 @@ yes
 
 ### √ buoyant-cloud-agent Deployment exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment exists
     deployments.apps "buoyant-cloud-agent" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2134,7 +2136,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running
     no running pods for buoyant-cloud-agent Deployment
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2158,7 +2160,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-agent-6b8c6888d7-htr7d buoyant-cloud
 
 ### √ buoyant-cloud-agent Deployment is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2178,7 +2180,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-agent Deployment is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-agent Deployment is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2200,7 +2202,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running a single pod
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running a single pod
     expected 1 buoyant-cloud-agent pod, found 2
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2214,7 +2216,7 @@ kubectl get po -A --selector app=buoyant-cloud-agent
 
 ### √ buoyant-cloud-metrics DaemonSet exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet exists
     deployments.apps "buoyant-cloud-metrics" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2235,7 +2237,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-metrics DaemonSet is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is running
     no running pods for buoyant-cloud-metrics DaemonSet
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2262,7 +2264,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-metrics-kt9mv buoyant-cloud-metrics
 
 ### √ buoyant-cloud-metrics DaemonSet is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2285,7 +2287,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-metrics DaemonSet is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-metrics DaemonSet is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints

--- a/linkerd.io/content/2.15/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.15/tasks/troubleshooting.md
@@ -961,7 +961,7 @@ normally.
 Example failure:
 
 ```bash
-$ linkerd check --proxy --namespace foo
+linkerd check --proxy --namespace foo
 ```
 
 ```text {class=disable-copy}

--- a/linkerd.io/content/2.16/tasks/replacing_expired_certificates.md
+++ b/linkerd.io/content/2.16/tasks/replacing_expired_certificates.md
@@ -16,7 +16,7 @@ replace the expired certificates with valid certificates.
 It might be the case that your issuer certificate is expired. If this it true
 running `linkerd check --proxy` will produce output similar to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -41,7 +41,7 @@ replace both your root and issuer certificates at the same time. If your root
 has expired `linkerd check` will indicate that by outputting an error similar
 to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -75,7 +75,7 @@ If you run `linkerd check --proxy` while pods are restarting after the trust
 bundle is updated, you will probably see warnings about pods not having the
 current trust bundle:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -107,7 +107,7 @@ These warnings will disappear as restarts complete. Once they do, you can use
 configuration up to date. After that is done, `linkerd check` should run with no
 warnings or errors:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid

--- a/linkerd.io/content/2.16/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.16/tasks/troubleshooting.md
@@ -16,7 +16,7 @@ installation.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane namespace does not already exist
     The "linkerd" namespace already exists
 ```
@@ -34,7 +34,7 @@ linkerd check --pre --linkerd-namespace linkerd-test
 The subsequent checks in this section validate whether you have permission to
 create the Kubernetes resources required for Linkerd installation, specifically:
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -47,7 +47,7 @@ These checks only run when the `--pre` flag is set This flag is intended for use
 prior to running `linkerd install`, to verify you have the correct RBAC
 permissions to install Linkerd.
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -90,7 +90,7 @@ These checks only run when the `--pre` flag is set. This flag is intended for
 use prior to running `linkerd install`, to verify you have not already installed
 the Linkerd control plane.
 
-```bash
+```text {class=disable-copy}
 √ no ClusterRoles exist
 √ no ClusterRoleBindings exist
 √ no CustomResourceDefinitions exist
@@ -113,7 +113,7 @@ linkerd check --pre --single-namespace
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     error configuring Kubernetes API client: stat badconfig: no such file or directory
 × can query the Kubernetes API
@@ -139,8 +139,8 @@ kubectl version
 
 Another example failure:
 
-```bash
-✘ can query the Kubernetes API
+```text {class=disable-copy}
+× can query the Kubernetes API
     Get REDACTED/version: x509: certificate signed by unknown authority
 ```
 
@@ -157,7 +157,7 @@ kubectl config set-cluster ${KUBE_CONTEXT} --insecure-skip-tls-verify=true \
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum Kubernetes API version
     Kubernetes is on version [1.7.16], but version [1.13.0] or more recent is required
 ```
@@ -172,7 +172,7 @@ kubectl version
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum kubectl version
     kubectl is on version [1.9.1], but version [1.13.0] or more recent is required
     see https://linkerd.io/2/checks/#kubectl-version for hints
@@ -198,7 +198,7 @@ resources have been installed.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane Namespace exists
     The "foo" namespace does not exist
     see https://linkerd.io/2/checks/#l5d-existence-ns for hints
@@ -221,7 +221,7 @@ linkerd check --linkerd-namespace linkerdtest
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-cr for hints
@@ -248,7 +248,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-crb for hints
@@ -275,7 +275,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ServiceAccounts exist
     missing ServiceAccounts: linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-sa for hints
@@ -305,7 +305,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane CustomResourceDefinitions exist
     missing CustomResourceDefinitions: serviceprofiles.linkerd.io
     see https://linkerd.io/2/checks/#l5d-existence-crd for hints
@@ -330,7 +330,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane MutatingWebhookConfigurations exist
     missing MutatingWebhookConfigurations: linkerd-proxy-injector-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-mwc for hints
@@ -354,7 +354,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ValidatingWebhookConfigurations exist
     missing ValidatingWebhookConfigurations: linkerd-sp-validator-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-vwc for hints
@@ -378,7 +378,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × proxy-init container runs as root user if docker container runtime is used
     there are nodes using the docker container runtime and proxy-init container must run as root user.
 try installing linkerd via --set proxyInit.runAsRoot=true
@@ -409,7 +409,7 @@ further details.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × 'linkerd-config' config map exists
     missing ConfigMaps: linkerd-config
     see https://linkerd.io/2/checks/#l5d-existence-linkerd-config for hints
@@ -441,7 +441,7 @@ For more information, see the Kubernetes documentation on
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × no unschedulable pods
     linkerd-prometheus-6b668f774d-j8ncr: 0/1 nodes are available: 1 Insufficient cpu.
     see https://linkerd.io/2/checks/#l5d-existence-unschedulable-pods for hints
@@ -456,13 +456,13 @@ For more information, see the Kubernetes documentation on the
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key ca.crt containing the trust anchors needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=true
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
 ```
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key crt.pem containing the issuer certificate needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=false
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
@@ -478,7 +478,7 @@ keys are `crt.pem` and `key.pem`.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are using supported crypto algorithm
     Invalid roots:
         * 165223702412626077778653586125774349756 identity.linkerd.cluster.local must use P-256 curve for public key, instead P-521 was used
@@ -492,7 +492,7 @@ algorithm.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are within their validity period
     Invalid roots:
         * 199607941798581518463476688845828639279 identity.linkerd.cluster.local not valid anymore. Expired on 2019-12-19T13:08:18Z
@@ -509,7 +509,7 @@ cluster back to a stable state.
 
 Example warnings:
 
-```bash
+```text {class=disable-copy}
 ‼ trust roots are valid for at least 60 days
     Roots expiring soon:
         * 66509928892441932260491975092256847205 identity.linkerd.cluster.local will expire on 2019-12-19T13:30:57Z
@@ -525,7 +525,7 @@ process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is using supported crypto algorithm
     issuer certificate must use P-256 curve for public key, instead P-521 was used
     see https://linkerd.io/2/checks/#5d-identity-issuer-cert-uses-supported-crypto for hints
@@ -540,7 +540,7 @@ to see how you can generate certificates that will work with Linkerd.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is within its validity period
     issuer certificate is not valid anymore. Expired on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-is-time-valid
@@ -554,7 +554,7 @@ bring your cluster back to a valid state, follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ issuer cert is valid for at least 60 days
     issuer certificate will expire on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-not-expiring-soon for hints
@@ -569,7 +569,7 @@ follow the process outlined in
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is issued by the trust root
     x509: certificate signed by unknown authority (possibly because of "x509: ECDSA verification failure" while trying to verify candidate authority certificate "identity.linkerd.cluster.local")
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-issued-by-trust-anchor for hints
@@ -594,7 +594,7 @@ linkerd upgrade \
 Once the upgrade process is over, the output of `linkerd check --proxy` should
 be:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -617,7 +617,7 @@ linkerd-identity-data-plane
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     secrets "linkerd-proxy-injector-tls" not found
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -628,7 +628,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-proxy-injector-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-proxy-injector.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -641,7 +641,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ proxy-injector cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-not-expiring-soon for hints
@@ -656,7 +656,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     secrets "linkerd-sp-validator-tls" not found
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -667,7 +667,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-sp-validator-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-sp-validator.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -680,7 +680,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ sp-validator cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-not-expiring-soon for hints
@@ -695,7 +695,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × policy-validator webhook has valid cert
     secrets "linkerd-policy-validator-tls" not found
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-valid for hints
@@ -704,7 +704,7 @@ Example failure:
 Ensure that the `linkerd-policy-validator-k8s-tls` secret exists and contains
 the appropriate `tls.crt` and `tls.key` data entries.
 
-```bash
+```text {class=disable-copy}
 × policy-validator webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-policy-validator.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-valid for hints
@@ -717,7 +717,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ policy-validator cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-not-expiring-soon for hints
@@ -734,7 +734,7 @@ can follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
@@ -753,7 +753,7 @@ the Linkerd components are restarted. While this operation is in progress the
 `check --proxy` command may output a warning, pertaining to the Linkerd
 components:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
@@ -772,7 +772,7 @@ correct certificates.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane pods are ready
     No running pods for "linkerd-sp-validator"
 ```
@@ -791,7 +791,7 @@ linkerd-proxy-injector-67f8cf65f7-4tvt5   2/2     Running   1          12m
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cluster networks can be verified
     the following nodes do not expose a podCIDR:
         node-0
@@ -813,7 +813,7 @@ distribution being used.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × cluster networks contains all node podCIDRs
     node has podCIDR(s) [10.244.0.0/24] which are not contained in the Linkerd clusterNetworks.
     Try installing linkerd via --set clusterNetworks=10.244.0.0/24
@@ -830,12 +830,12 @@ this network may not be meshed properly. To remedy this, update the
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × the Linkerd clusterNetworks [10.244.0.0/24] do not include pod default/foo (104.21.63.202)
     see https://linkerd.io/2/checks/#l5d-cluster-networks-pods for hints
 ```
 
-```bash
+```text {class=disable-copy}
 × the Linkerd clusterNetworks [10.244.0.0/24] do not include svc default/bar (10.96.217.194)
     see https://linkerd.io/2/checks/#l5d-cluster-networks-pods for hints
 ```
@@ -853,7 +853,7 @@ networks in the cluster.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can determine the latest version
     Get https://versioncheck.linkerd.io/version.json?version=edge-19.1.2&uuid=test-uuid&source=cli: context deadline exceeded
 ```
@@ -872,7 +872,7 @@ Example failures:
 
 #### unsupported version channel
 
-```bash
+```text {class=disable-copy}
 ‼ cli is up-to-date
     unsupported version channel: stable-2.14.10
 ```
@@ -883,7 +883,7 @@ As of February 2024, the Linkerd project itself only produces
 
 #### is running version X but the latest version is Y
 
-```bash
+```text {class=disable-copy}
 ‼ cli is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ```
@@ -899,7 +899,7 @@ Example failures:
 
 #### unsupported version channel
 
-```bash
+```text {class=disable-copy}
 ‼ control plane is up-to-date
     unsupported version channel: stable-2.14.10
 ```
@@ -910,7 +910,7 @@ As of February 2024, the Linkerd project itself only produces
 
 #### is running version X but the latest version is Y
 
-```bash
+```text {class=disable-copy}
 ‼ control plane is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ```
@@ -922,7 +922,7 @@ There is a newer version of the control plane. See the page on
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ control plane and cli versions match
     mismatched channels: running stable-2.1.0 but retrieved edge-19.1.2
 ```
@@ -962,7 +962,9 @@ Example failure:
 
 ```bash
 $ linkerd check --proxy --namespace foo
-...
+```
+
+```text {class=disable-copy}
 × data plane namespace exists
     The "foo" namespace does not exist
 ```
@@ -974,7 +976,7 @@ namespaces.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxies are ready
     No "linkerd-proxy" containers found
 ```
@@ -990,7 +992,7 @@ in our [Getting Started](../getting-started/) guide.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane is up-to-date
     linkerd/linkerd-prometheus-74d66f86f6-6t6dh: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -999,7 +1001,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 ### √ data plane and cli versions match {#l5d-data-plane-cli-version}
 
-```bash
+```text {class=disable-copy}
 ‼ data plane and cli versions match
     linkerd/linkerd-identity-5f6c45d6d9-9hd9j: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -1010,7 +1012,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane pod labels are configured correctly
     Some labels on data plane pods should be annotations:
     * emojivoto/voting-ff4c54b8d-tv9pp
@@ -1024,7 +1026,7 @@ be annotations in order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service labels and annotations are configured correctly
     Some labels on data plane services should be annotations:
     * emojivoto/emoji-svc
@@ -1038,7 +1040,7 @@ order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service annotations are configured correctly
     Some annotations on data plane services should be labels:
     * emojivoto/emoji-svc
@@ -1051,7 +1053,7 @@ Example failure:
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × opaque ports are properly annotated
         * service emoji-svc targets the opaque port 8080 through 8080; add 8080 to its config.linkerd.io/opaque-ports annotation
     see https://linkerd.io/2/checks/#linkerd-opaque-ports-definition for hints
@@ -1075,7 +1077,7 @@ These checks are ran if Linkerd has been installed in HA mode.
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ multiple replicas of control plane pods
     not enough replicas available for [linkerd-identity]
     see https://linkerd.io/2/checks/#l5d-control-plane-replicas for hints
@@ -1103,7 +1105,7 @@ returns the healthchecks in the
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Linkerd command jaeger exists
 ```
 
@@ -1124,7 +1126,7 @@ resources are in place. If any of them are missing, you can use
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ConfigMap exists
     configmaps "linkerd-cni-config" not found
     see https://linkerd.io/2/checks/#cni-plugin-cm-exists for hints
@@ -1149,7 +1151,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRole exists
     missing ClusterRole: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-cr-exists for hints
@@ -1174,7 +1176,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRoleBinding exists
     missing ClusterRoleBinding: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-crb-exists for hints
@@ -1199,7 +1201,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ServiceAccount exists
     missing ServiceAccount: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-sa-exists for hints
@@ -1224,7 +1226,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin DaemonSet exists
     missing DaemonSet: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-ds-exists for hints
@@ -1249,7 +1251,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cni plugin pod is running on all nodes
     number ready: 2, number scheduled: 3
     see https://linkerd.io/2/checks/#cni-plugin-ready
@@ -1286,7 +1288,7 @@ possible between paired clusters.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link CRD exists
     multicluster.linkerd.io/Link CRD is missing
     see https://linkerd.io/2/checks/#l5d-multicluster-link-crd-exists for hints
@@ -1305,7 +1307,7 @@ links.multicluster.linkerd.io     2021-03-10T09:58:10Z
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link resources are valid
     failed to parse Link east
     see https://linkerd.io/2/checks/#l5d-multicluster-links-are-valid for hints
@@ -1317,7 +1319,7 @@ Make sure all the link objects are specified in the expected format.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × remote cluster access credentials are valid
     * secret [east/east-config]: could not find east-config secret
     see https://linkerd.io/2/checks/#l5d-smc-target-clusters-access for hints
@@ -1330,7 +1332,7 @@ target cluster is present as a secret correctly
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote
@@ -1341,7 +1343,7 @@ The error above indicates that your trust anchors are not compatible. In order
 to fix that you need to ensure that both your anchors contain identical sets of
 certificates.
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote: cannot parse trust anchors
@@ -1361,7 +1363,7 @@ linkerd --context=remote check
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controller has required permissions
     missing Service mirror ClusterRole linkerd-service-mirror-access-local-resources: unexpected verbs expected create,delete,get,list,update,watch, got create,delete,get,update,watch
     see https://linkerd.io/2/checks/#l5d-multicluster-source-rbac-correct for hints
@@ -1430,7 +1432,7 @@ metadata:
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controllers are running
     Service mirror controller is not present
     see https://linkerd.io/2/checks/#l5d-multicluster-service-mirror-running for hints
@@ -1450,7 +1452,7 @@ linkerd-service-mirror-7bb8ff5967-zg265   2/2       Running   0          50m
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all gateway mirrors are healthy
     Some gateway mirrors do not have endpoints:
   linkerd-gateway-gke.linkerd-multicluster mirrored from cluster [gke]
@@ -1470,7 +1472,7 @@ service in target cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all mirror services have endpoints
     Some mirror services do not have endpoints:
   voting-svc-gke.emojivoto mirrored from cluster [gke] (gateway: [linkerd-multicluster/linkerd-gateway])
@@ -1491,7 +1493,7 @@ cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼  all mirror services are part of a Link
     mirror service voting-east.emojivoto is not part of any Link
     see https://linkerd.io/2/checks/#l5d-multicluster-orphaned-services for hints
@@ -1550,7 +1552,7 @@ for a full list of configurable fields.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1578,7 +1580,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-crb-exists for hints
@@ -1624,7 +1626,7 @@ sync by updating either the CLI or linkerd-viz as necessary.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     secrets "tap-k8s-tls" not found
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1635,7 +1637,7 @@ Ensure that the `tap-k8s-tls` secret exists and contains the appropriate
 named `linkerd-tap-tls` and it should contain the `crt.pem` and `key.pem` data
 entries.
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not tap.linkerd-viz.svc
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1648,7 +1650,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ tap API server cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-webhook-cert-not-expiring-soon for hints
@@ -1663,7 +1665,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × FailedDiscoveryCheck: no response from https://10.233.31.133:443: Get https://10.233.31.133:443: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
 ```
 
@@ -1679,7 +1681,7 @@ requirements in the cluster:
 
 ### √ linkerd-viz pods are injected {#l5d-viz-pods-injection}
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz extension pods are injected
     could not find proxy container for tap-59f5595fc7-ttndp pod
     see https://linkerd.io/2/checks/#l5d-viz-pods-injection for hints
@@ -1703,7 +1705,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ viz extension pods are running {#l5d-viz-pods-running}
 
-```bash
+```text {class=disable-copy}
 × viz extension pods are running
     container linkerd-proxy in pod tap-59f5595fc7-ttndp is not ready
     see https://linkerd.io/2/checks/#l5d-viz-pods-running for hints
@@ -1727,7 +1729,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ prometheus is installed and configured correctly {#l5d-viz-prometheus}
 
-```bash
+```text {class=disable-copy}
 × prometheus is installed and configured correctly
     missing ClusterRoles: linkerd-linkerd-viz-prometheus
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1736,12 +1738,12 @@ Make sure that the `proxy-injector` is working correctly by running
 Ensure all the prometheus related resources are present and running correctly.
 
 ```bash
-❯ kubectl -n linkerd-viz get deploy,cm | grep prometheus
+$ kubectl -n linkerd-viz get deploy,cm | grep prometheus
 deployment.apps/prometheus     1/1     1            1           3m18s
 configmap/prometheus-config   1      3m18s
-❯ kubectl get clusterRoleBindings | grep prometheus
+$ kubectl get clusterRoleBindings | grep prometheus
 linkerd-linkerd-viz-prometheus                         ClusterRole/linkerd-linkerd-viz-prometheus                         3m37s
-❯ kubectl get clusterRoles | grep prometheus
+$ kubectl get clusterRoles | grep prometheus
 linkerd-linkerd-viz-prometheus                                         2021-02-26T06:03:11Zh
 ```
 
@@ -1749,7 +1751,7 @@ linkerd-linkerd-viz-prometheus                                         2021-02-2
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     Failed to get deploy for pod metrics-api-77f684f7c7-hnw8r: not running
 ```
@@ -1757,7 +1759,7 @@ Example failure:
 Verify that the metrics API pod is running correctly
 
 ```bash
-❯ kubectl -n linkerd-viz get pods
+$ kubectl -n linkerd-viz get pods
 NAME                           READY   STATUS    RESTARTS   AGE
 metrics-api-7bb8cb8489-cbq4m   2/2     Running   0          4m58s
 tap-injector-6b9bc6fc4-cgbr4   2/2     Running   0          4m56s
@@ -1771,7 +1773,7 @@ prometheus-7c5c48c466-jc27g    2/2     Running   0          4m58s
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × viz extension self-check
     No results returned
 ```
@@ -1823,7 +1825,7 @@ be safely disregarded.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxy metrics are present in Prometheus
     Data plane metrics not found for linkerd/linkerd-identity-b8c4c48c8-pflc9.
 ```
@@ -1886,7 +1888,7 @@ versions in sync by updating either the CLI or linkerd-jaeger as necessary.
 
 ### √ jaeger extension pods are injected {#l5d-jaeger-pods-injection}
 
-```bash
+```text {class=disable-copy}
 × jaeger extension pods are injected
     could not find proxy container for jaeger-6f98d5c979-scqlq pod
     see https://linkerd.io/2/checks/#l5d-jaeger-pods-injections for hints
@@ -1907,7 +1909,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ jaeger extension pods are running {#l5d-jaeger-pods-running}
 
-```bash
+```text {class=disable-copy}
 × jaeger extension pods are running
     container linkerd-proxy in pod jaeger-59f5595fc7-ttndp is not ready
     see https://linkerd.io/2/checks/#l5d-jaeger-pods-running for hints
@@ -1935,7 +1937,7 @@ comprises `linkerd-buoyant` CLI, the `buoyant-cloud-agent` Deployment, and the
 
 ### √ Linkerd extension command linkerd-buoyant exists
 
-```bash
+```text {class=disable-copy}
 ‼ Linkerd extension command linkerd-buoyant exists
     exec: "linkerd-buoyant": executable file not found in $PATH
     see https://linkerd.io/2/checks/#extensions for hints
@@ -1955,7 +1957,7 @@ curl https://buoyant.cloud/install | sh
 
 ### √ linkerd-buoyant can determine the latest version
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant can determine the latest version
     Get "https://buoyant.cloud/version.json": dial tcp: lookup buoyant.cloud: no such host
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1971,7 +1973,7 @@ $ curl https://buoyant.cloud/version.json
 
 ### √ linkerd-buoyant cli is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant cli is up-to-date
     CLI version is v0.4.3 but the latest is v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1985,7 +1987,7 @@ curl https://buoyant.cloud/install | sh
 
 ### √ buoyant-cloud Namespace exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace exists
     namespaces "buoyant-cloud" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2006,7 +2008,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud Namespace has correct labels
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace has correct labels
     missing app.kubernetes.io/part-of label
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2021,7 +2023,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent ClusterRole exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRole exists
     missing ClusterRole: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2044,7 +2046,7 @@ yes
 
 ### √ buoyant-cloud-agent ClusterRoleBinding exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRoleBinding exists
     missing ClusterRoleBinding: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2067,7 +2069,7 @@ yes
 
 ### √ buoyant-cloud-agent ServiceAccount exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ServiceAccount exists
     missing ServiceAccount: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2090,7 +2092,7 @@ yes
 
 ### √ buoyant-cloud-id Secret exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-id Secret exists
     missing Secret: buoyant-cloud-id
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2113,7 +2115,7 @@ yes
 
 ### √ buoyant-cloud-agent Deployment exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment exists
     deployments.apps "buoyant-cloud-agent" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2134,7 +2136,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running
     no running pods for buoyant-cloud-agent Deployment
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2158,7 +2160,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-agent-6b8c6888d7-htr7d buoyant-cloud
 
 ### √ buoyant-cloud-agent Deployment is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2178,7 +2180,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-agent Deployment is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-agent Deployment is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2200,7 +2202,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running a single pod
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running a single pod
     expected 1 buoyant-cloud-agent pod, found 2
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2214,7 +2216,7 @@ kubectl get po -A --selector app=buoyant-cloud-agent
 
 ### √ buoyant-cloud-metrics DaemonSet exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet exists
     deployments.apps "buoyant-cloud-metrics" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2235,7 +2237,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-metrics DaemonSet is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is running
     no running pods for buoyant-cloud-metrics DaemonSet
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2262,7 +2264,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-metrics-kt9mv buoyant-cloud-metrics
 
 ### √ buoyant-cloud-metrics DaemonSet is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2285,7 +2287,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-metrics DaemonSet is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-metrics DaemonSet is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints

--- a/linkerd.io/content/2.16/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.16/tasks/troubleshooting.md
@@ -961,7 +961,7 @@ normally.
 Example failure:
 
 ```bash
-$ linkerd check --proxy --namespace foo
+linkerd check --proxy --namespace foo
 ```
 
 ```text {class=disable-copy}

--- a/linkerd.io/content/2.17/tasks/replacing_expired_certificates.md
+++ b/linkerd.io/content/2.17/tasks/replacing_expired_certificates.md
@@ -16,7 +16,7 @@ replace the expired certificates with valid certificates.
 It might be the case that your issuer certificate is expired. If this it true
 running `linkerd check --proxy` will produce output similar to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -41,7 +41,7 @@ replace both your root and issuer certificates at the same time. If your root
 has expired `linkerd check` will indicate that by outputting an error similar
 to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -75,7 +75,7 @@ If you run `linkerd check --proxy` while pods are restarting after the trust
 bundle is updated, you will probably see warnings about pods not having the
 current trust bundle:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -107,7 +107,7 @@ These warnings will disappear as restarts complete. Once they do, you can use
 configuration up to date. After that is done, `linkerd check` should run with no
 warnings or errors:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid

--- a/linkerd.io/content/2.17/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.17/tasks/troubleshooting.md
@@ -16,7 +16,7 @@ installation.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane namespace does not already exist
     The "linkerd" namespace already exists
 ```
@@ -34,7 +34,7 @@ linkerd check --pre --linkerd-namespace linkerd-test
 The subsequent checks in this section validate whether you have permission to
 create the Kubernetes resources required for Linkerd installation, specifically:
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -47,7 +47,7 @@ These checks only run when the `--pre` flag is set This flag is intended for use
 prior to running `linkerd install`, to verify you have the correct RBAC
 permissions to install Linkerd.
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -90,7 +90,7 @@ These checks only run when the `--pre` flag is set. This flag is intended for
 use prior to running `linkerd install`, to verify you have not already installed
 the Linkerd control plane.
 
-```bash
+```text {class=disable-copy}
 √ no ClusterRoles exist
 √ no ClusterRoleBindings exist
 √ no CustomResourceDefinitions exist
@@ -113,7 +113,7 @@ linkerd check --pre --single-namespace
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     error configuring Kubernetes API client: stat badconfig: no such file or directory
 × can query the Kubernetes API
@@ -139,8 +139,8 @@ kubectl version
 
 Another example failure:
 
-```bash
-✘ can query the Kubernetes API
+```text {class=disable-copy}
+× can query the Kubernetes API
     Get REDACTED/version: x509: certificate signed by unknown authority
 ```
 
@@ -157,7 +157,7 @@ kubectl config set-cluster ${KUBE_CONTEXT} --insecure-skip-tls-verify=true \
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum Kubernetes API version
     Kubernetes is on version [1.7.16], but version [1.13.0] or more recent is required
 ```
@@ -172,7 +172,7 @@ kubectl version
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum kubectl version
     kubectl is on version [1.9.1], but version [1.13.0] or more recent is required
     see https://linkerd.io/2/checks/#kubectl-version for hints
@@ -198,7 +198,7 @@ resources have been installed.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane Namespace exists
     The "foo" namespace does not exist
     see https://linkerd.io/2/checks/#l5d-existence-ns for hints
@@ -221,7 +221,7 @@ linkerd check --linkerd-namespace linkerdtest
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-cr for hints
@@ -248,7 +248,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-crb for hints
@@ -275,7 +275,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ServiceAccounts exist
     missing ServiceAccounts: linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-sa for hints
@@ -305,7 +305,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane CustomResourceDefinitions exist
     missing CustomResourceDefinitions: serviceprofiles.linkerd.io
     see https://linkerd.io/2/checks/#l5d-existence-crd for hints
@@ -330,7 +330,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane MutatingWebhookConfigurations exist
     missing MutatingWebhookConfigurations: linkerd-proxy-injector-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-mwc for hints
@@ -354,7 +354,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ValidatingWebhookConfigurations exist
     missing ValidatingWebhookConfigurations: linkerd-sp-validator-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-vwc for hints
@@ -378,7 +378,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × proxy-init container runs as root user if docker container runtime is used
     there are nodes using the docker container runtime and proxy-init container must run as root user.
 try installing linkerd via --set proxyInit.runAsRoot=true
@@ -409,7 +409,7 @@ further details.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × 'linkerd-config' config map exists
     missing ConfigMaps: linkerd-config
     see https://linkerd.io/2/checks/#l5d-existence-linkerd-config for hints
@@ -441,7 +441,7 @@ For more information, see the Kubernetes documentation on
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × no unschedulable pods
     linkerd-prometheus-6b668f774d-j8ncr: 0/1 nodes are available: 1 Insufficient cpu.
     see https://linkerd.io/2/checks/#l5d-existence-unschedulable-pods for hints
@@ -456,13 +456,13 @@ For more information, see the Kubernetes documentation on the
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key ca.crt containing the trust anchors needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=true
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
 ```
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key crt.pem containing the issuer certificate needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=false
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
@@ -478,7 +478,7 @@ keys are `crt.pem` and `key.pem`.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are using supported crypto algorithm
     Invalid roots:
         * 165223702412626077778653586125774349756 identity.linkerd.cluster.local must use P-256 curve for public key, instead P-521 was used
@@ -492,7 +492,7 @@ algorithm.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are within their validity period
     Invalid roots:
         * 199607941798581518463476688845828639279 identity.linkerd.cluster.local not valid anymore. Expired on 2019-12-19T13:08:18Z
@@ -509,7 +509,7 @@ cluster back to a stable state.
 
 Example warnings:
 
-```bash
+```text {class=disable-copy}
 ‼ trust roots are valid for at least 60 days
     Roots expiring soon:
         * 66509928892441932260491975092256847205 identity.linkerd.cluster.local will expire on 2019-12-19T13:30:57Z
@@ -525,7 +525,7 @@ process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is using supported crypto algorithm
     issuer certificate must use P-256 curve for public key, instead P-521 was used
     see https://linkerd.io/2/checks/#5d-identity-issuer-cert-uses-supported-crypto for hints
@@ -540,7 +540,7 @@ to see how you can generate certificates that will work with Linkerd.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is within its validity period
     issuer certificate is not valid anymore. Expired on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-is-time-valid
@@ -554,7 +554,7 @@ bring your cluster back to a valid state, follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ issuer cert is valid for at least 60 days
     issuer certificate will expire on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-not-expiring-soon for hints
@@ -569,7 +569,7 @@ follow the process outlined in
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is issued by the trust root
     x509: certificate signed by unknown authority (possibly because of "x509: ECDSA verification failure" while trying to verify candidate authority certificate "identity.linkerd.cluster.local")
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-issued-by-trust-anchor for hints
@@ -594,7 +594,7 @@ linkerd upgrade \
 Once the upgrade process is over, the output of `linkerd check --proxy` should
 be:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -617,7 +617,7 @@ linkerd-identity-data-plane
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     secrets "linkerd-proxy-injector-tls" not found
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -628,7 +628,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-proxy-injector-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-proxy-injector.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -641,7 +641,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ proxy-injector cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-not-expiring-soon for hints
@@ -656,7 +656,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     secrets "linkerd-sp-validator-tls" not found
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -667,7 +667,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-sp-validator-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-sp-validator.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -680,7 +680,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ sp-validator cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-not-expiring-soon for hints
@@ -695,7 +695,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × policy-validator webhook has valid cert
     secrets "linkerd-policy-validator-tls" not found
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-valid for hints
@@ -704,7 +704,7 @@ Example failure:
 Ensure that the `linkerd-policy-validator-k8s-tls` secret exists and contains
 the appropriate `tls.crt` and `tls.key` data entries.
 
-```bash
+```text {class=disable-copy}
 × policy-validator webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-policy-validator.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-valid for hints
@@ -717,7 +717,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ policy-validator cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-not-expiring-soon for hints
@@ -734,7 +734,7 @@ can follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
@@ -753,7 +753,7 @@ the Linkerd components are restarted. While this operation is in progress the
 `check --proxy` command may output a warning, pertaining to the Linkerd
 components:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
@@ -772,7 +772,7 @@ correct certificates.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane pods are ready
     No running pods for "linkerd-sp-validator"
 ```
@@ -791,7 +791,7 @@ linkerd-proxy-injector-67f8cf65f7-4tvt5   2/2     Running   1          12m
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cluster networks can be verified
     the following nodes do not expose a podCIDR:
         node-0
@@ -813,7 +813,7 @@ distribution being used.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × cluster networks contains all node podCIDRs
     node has podCIDR(s) [10.244.0.0/24] which are not contained in the Linkerd clusterNetworks.
     Try installing linkerd via --set clusterNetworks=10.244.0.0/24
@@ -830,12 +830,12 @@ this network may not be meshed properly. To remedy this, update the
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × the Linkerd clusterNetworks [10.244.0.0/24] do not include pod default/foo (104.21.63.202)
     see https://linkerd.io/2/checks/#l5d-cluster-networks-pods for hints
 ```
 
-```bash
+```text {class=disable-copy}
 × the Linkerd clusterNetworks [10.244.0.0/24] do not include svc default/bar (10.96.217.194)
     see https://linkerd.io/2/checks/#l5d-cluster-networks-pods for hints
 ```
@@ -853,7 +853,7 @@ networks in the cluster.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can determine the latest version
     Get https://versioncheck.linkerd.io/version.json?version=edge-19.1.2&uuid=test-uuid&source=cli: context deadline exceeded
 ```
@@ -872,7 +872,7 @@ Example failures:
 
 #### unsupported version channel
 
-```bash
+```text {class=disable-copy}
 ‼ cli is up-to-date
     unsupported version channel: stable-2.14.10
 ```
@@ -883,7 +883,7 @@ As of February 2024, the Linkerd project itself only produces
 
 #### is running version X but the latest version is Y
 
-```bash
+```text {class=disable-copy}
 ‼ cli is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ```
@@ -899,7 +899,7 @@ Example failures:
 
 #### unsupported version channel
 
-```bash
+```text {class=disable-copy}
 ‼ control plane is up-to-date
     unsupported version channel: stable-2.14.10
 ```
@@ -910,7 +910,7 @@ As of February 2024, the Linkerd project itself only produces
 
 #### is running version X but the latest version is Y
 
-```bash
+```text {class=disable-copy}
 ‼ control plane is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ```
@@ -922,7 +922,7 @@ There is a newer version of the control plane. See the page on
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ control plane and cli versions match
     mismatched channels: running stable-2.1.0 but retrieved edge-19.1.2
 ```
@@ -962,7 +962,9 @@ Example failure:
 
 ```bash
 $ linkerd check --proxy --namespace foo
-...
+```
+
+```text {class=disable-copy}
 × data plane namespace exists
     The "foo" namespace does not exist
 ```
@@ -974,7 +976,7 @@ namespaces.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxies are ready
     No "linkerd-proxy" containers found
 ```
@@ -990,7 +992,7 @@ in our [Getting Started](../getting-started/) guide.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane is up-to-date
     linkerd/linkerd-prometheus-74d66f86f6-6t6dh: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -999,7 +1001,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 ### √ data plane and cli versions match {#l5d-data-plane-cli-version}
 
-```bash
+```text {class=disable-copy}
 ‼ data plane and cli versions match
     linkerd/linkerd-identity-5f6c45d6d9-9hd9j: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -1010,7 +1012,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane pod labels are configured correctly
     Some labels on data plane pods should be annotations:
     * emojivoto/voting-ff4c54b8d-tv9pp
@@ -1024,7 +1026,7 @@ be annotations in order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service labels and annotations are configured correctly
     Some labels on data plane services should be annotations:
     * emojivoto/emoji-svc
@@ -1038,7 +1040,7 @@ order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service annotations are configured correctly
     Some annotations on data plane services should be labels:
     * emojivoto/emoji-svc
@@ -1051,7 +1053,7 @@ Example failure:
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × opaque ports are properly annotated
         * service emoji-svc targets the opaque port 8080 through 8080; add 8080 to its config.linkerd.io/opaque-ports annotation
     see https://linkerd.io/2/checks/#linkerd-opaque-ports-definition for hints
@@ -1075,7 +1077,7 @@ These checks are ran if Linkerd has been installed in HA mode.
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ multiple replicas of control plane pods
     not enough replicas available for [linkerd-identity]
     see https://linkerd.io/2/checks/#l5d-control-plane-replicas for hints
@@ -1117,7 +1119,7 @@ returns the healthchecks in the
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Linkerd command jaeger exists
 ```
 
@@ -1138,7 +1140,7 @@ resources are in place. If any of them are missing, you can use
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ConfigMap exists
     configmaps "linkerd-cni-config" not found
     see https://linkerd.io/2/checks/#cni-plugin-cm-exists for hints
@@ -1163,7 +1165,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRole exists
     missing ClusterRole: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-cr-exists for hints
@@ -1188,7 +1190,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRoleBinding exists
     missing ClusterRoleBinding: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-crb-exists for hints
@@ -1213,7 +1215,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ServiceAccount exists
     missing ServiceAccount: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-sa-exists for hints
@@ -1238,7 +1240,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin DaemonSet exists
     missing DaemonSet: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-ds-exists for hints
@@ -1263,7 +1265,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cni plugin pod is running on all nodes
     number ready: 2, number scheduled: 3
     see https://linkerd.io/2/checks/#cni-plugin-ready
@@ -1300,7 +1302,7 @@ possible between paired clusters.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link CRD exists
     multicluster.linkerd.io/Link CRD is missing
     see https://linkerd.io/2/checks/#l5d-multicluster-link-crd-exists for hints
@@ -1319,7 +1321,7 @@ links.multicluster.linkerd.io     2021-03-10T09:58:10Z
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link resources are valid
     failed to parse Link east
     see https://linkerd.io/2/checks/#l5d-multicluster-links-are-valid for hints
@@ -1342,7 +1344,7 @@ to do this.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × remote cluster access credentials are valid
     * secret [east/east-config]: could not find east-config secret
     see https://linkerd.io/2/checks/#l5d-smc-target-clusters-access for hints
@@ -1355,7 +1357,7 @@ target cluster is present as a secret correctly
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote
@@ -1366,7 +1368,7 @@ The error above indicates that your trust anchors are not compatible. In order
 to fix that you need to ensure that both your anchors contain identical sets of
 certificates.
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote: cannot parse trust anchors
@@ -1386,7 +1388,7 @@ linkerd --context=remote check
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controller has required permissions
     missing Service mirror ClusterRole linkerd-service-mirror-access-local-resources: unexpected verbs expected create,delete,get,list,update,watch, got create,delete,get,update,watch
     see https://linkerd.io/2/checks/#l5d-multicluster-source-rbac-correct for hints
@@ -1455,7 +1457,7 @@ metadata:
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controllers are running
     Service mirror controller is not present
     see https://linkerd.io/2/checks/#l5d-multicluster-service-mirror-running for hints
@@ -1475,7 +1477,7 @@ linkerd-service-mirror-7bb8ff5967-zg265   2/2       Running   0          50m
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all gateway mirrors are healthy
     Some gateway mirrors do not have endpoints:
   linkerd-gateway-gke.linkerd-multicluster mirrored from cluster [gke]
@@ -1495,7 +1497,7 @@ service in target cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all mirror services have endpoints
     Some mirror services do not have endpoints:
   voting-svc-gke.emojivoto mirrored from cluster [gke] (gateway: [linkerd-multicluster/linkerd-gateway])
@@ -1516,7 +1518,7 @@ cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼  all mirror services are part of a Link
     mirror service voting-east.emojivoto is not part of any Link
     see https://linkerd.io/2/checks/#l5d-multicluster-orphaned-services for hints
@@ -1575,7 +1577,7 @@ for a full list of configurable fields.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1603,7 +1605,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-crb-exists for hints
@@ -1649,7 +1651,7 @@ sync by updating either the CLI or linkerd-viz as necessary.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     secrets "tap-k8s-tls" not found
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1660,7 +1662,7 @@ Ensure that the `tap-k8s-tls` secret exists and contains the appropriate
 named `linkerd-tap-tls` and it should contain the `crt.pem` and `key.pem` data
 entries.
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not tap.linkerd-viz.svc
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1673,7 +1675,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ tap API server cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-webhook-cert-not-expiring-soon for hints
@@ -1688,7 +1690,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × FailedDiscoveryCheck: no response from https://10.233.31.133:443: Get https://10.233.31.133:443: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
 ```
 
@@ -1704,7 +1706,7 @@ requirements in the cluster:
 
 ### √ linkerd-viz pods are injected {#l5d-viz-pods-injection}
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz extension pods are injected
     could not find proxy container for tap-59f5595fc7-ttndp pod
     see https://linkerd.io/2/checks/#l5d-viz-pods-injection for hints
@@ -1728,7 +1730,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ viz extension pods are running {#l5d-viz-pods-running}
 
-```bash
+```text {class=disable-copy}
 × viz extension pods are running
     container linkerd-proxy in pod tap-59f5595fc7-ttndp is not ready
     see https://linkerd.io/2/checks/#l5d-viz-pods-running for hints
@@ -1752,7 +1754,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ prometheus is installed and configured correctly {#l5d-viz-prometheus}
 
-```bash
+```text {class=disable-copy}
 × prometheus is installed and configured correctly
     missing ClusterRoles: linkerd-linkerd-viz-prometheus
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1761,12 +1763,12 @@ Make sure that the `proxy-injector` is working correctly by running
 Ensure all the prometheus related resources are present and running correctly.
 
 ```bash
-❯ kubectl -n linkerd-viz get deploy,cm | grep prometheus
+$ kubectl -n linkerd-viz get deploy,cm | grep prometheus
 deployment.apps/prometheus     1/1     1            1           3m18s
 configmap/prometheus-config   1      3m18s
-❯ kubectl get clusterRoleBindings | grep prometheus
+$ kubectl get clusterRoleBindings | grep prometheus
 linkerd-linkerd-viz-prometheus                         ClusterRole/linkerd-linkerd-viz-prometheus                         3m37s
-❯ kubectl get clusterRoles | grep prometheus
+$ kubectl get clusterRoles | grep prometheus
 linkerd-linkerd-viz-prometheus                                         2021-02-26T06:03:11Zh
 ```
 
@@ -1774,7 +1776,7 @@ linkerd-linkerd-viz-prometheus                                         2021-02-2
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     Failed to get deploy for pod metrics-api-77f684f7c7-hnw8r: not running
 ```
@@ -1782,7 +1784,7 @@ Example failure:
 Verify that the metrics API pod is running correctly
 
 ```bash
-❯ kubectl -n linkerd-viz get pods
+$ kubectl -n linkerd-viz get pods
 NAME                           READY   STATUS    RESTARTS   AGE
 metrics-api-7bb8cb8489-cbq4m   2/2     Running   0          4m58s
 tap-injector-6b9bc6fc4-cgbr4   2/2     Running   0          4m56s
@@ -1796,7 +1798,7 @@ prometheus-7c5c48c466-jc27g    2/2     Running   0          4m58s
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × viz extension self-check
     No results returned
 ```
@@ -1848,7 +1850,7 @@ be safely disregarded.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxy metrics are present in Prometheus
     Data plane metrics not found for linkerd/linkerd-identity-b8c4c48c8-pflc9.
 ```
@@ -1911,7 +1913,7 @@ versions in sync by updating either the CLI or linkerd-jaeger as necessary.
 
 ### √ jaeger extension pods are injected {#l5d-jaeger-pods-injection}
 
-```bash
+```text {class=disable-copy}
 × jaeger extension pods are injected
     could not find proxy container for jaeger-6f98d5c979-scqlq pod
     see https://linkerd.io/2/checks/#l5d-jaeger-pods-injections for hints
@@ -1932,7 +1934,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ jaeger extension pods are running {#l5d-jaeger-pods-running}
 
-```bash
+```text {class=disable-copy}
 × jaeger extension pods are running
     container linkerd-proxy in pod jaeger-59f5595fc7-ttndp is not ready
     see https://linkerd.io/2/checks/#l5d-jaeger-pods-running for hints
@@ -1960,7 +1962,7 @@ comprises `linkerd-buoyant` CLI, the `buoyant-cloud-agent` Deployment, and the
 
 ### √ Linkerd extension command linkerd-buoyant exists
 
-```bash
+```text {class=disable-copy}
 ‼ Linkerd extension command linkerd-buoyant exists
     exec: "linkerd-buoyant": executable file not found in $PATH
     see https://linkerd.io/2/checks/#extensions for hints
@@ -1980,7 +1982,7 @@ curl https://buoyant.cloud/install | sh
 
 ### √ linkerd-buoyant can determine the latest version
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant can determine the latest version
     Get "https://buoyant.cloud/version.json": dial tcp: lookup buoyant.cloud: no such host
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1996,7 +1998,7 @@ $ curl https://buoyant.cloud/version.json
 
 ### √ linkerd-buoyant cli is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant cli is up-to-date
     CLI version is v0.4.3 but the latest is v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2010,7 +2012,7 @@ curl https://buoyant.cloud/install | sh
 
 ### √ buoyant-cloud Namespace exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace exists
     namespaces "buoyant-cloud" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2031,7 +2033,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud Namespace has correct labels
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace has correct labels
     missing app.kubernetes.io/part-of label
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2046,7 +2048,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent ClusterRole exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRole exists
     missing ClusterRole: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2069,7 +2071,7 @@ yes
 
 ### √ buoyant-cloud-agent ClusterRoleBinding exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRoleBinding exists
     missing ClusterRoleBinding: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2092,7 +2094,7 @@ yes
 
 ### √ buoyant-cloud-agent ServiceAccount exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ServiceAccount exists
     missing ServiceAccount: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2115,7 +2117,7 @@ yes
 
 ### √ buoyant-cloud-id Secret exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-id Secret exists
     missing Secret: buoyant-cloud-id
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2138,7 +2140,7 @@ yes
 
 ### √ buoyant-cloud-agent Deployment exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment exists
     deployments.apps "buoyant-cloud-agent" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2159,7 +2161,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running
     no running pods for buoyant-cloud-agent Deployment
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2183,7 +2185,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-agent-6b8c6888d7-htr7d buoyant-cloud
 
 ### √ buoyant-cloud-agent Deployment is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2203,7 +2205,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-agent Deployment is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-agent Deployment is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2225,7 +2227,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running a single pod
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running a single pod
     expected 1 buoyant-cloud-agent pod, found 2
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2239,7 +2241,7 @@ kubectl get po -A --selector app=buoyant-cloud-agent
 
 ### √ buoyant-cloud-metrics DaemonSet exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet exists
     deployments.apps "buoyant-cloud-metrics" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2260,7 +2262,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-metrics DaemonSet is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is running
     no running pods for buoyant-cloud-metrics DaemonSet
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2287,7 +2289,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-metrics-kt9mv buoyant-cloud-metrics
 
 ### √ buoyant-cloud-metrics DaemonSet is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2310,7 +2312,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-metrics DaemonSet is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-metrics DaemonSet is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints

--- a/linkerd.io/content/2.17/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.17/tasks/troubleshooting.md
@@ -961,7 +961,7 @@ normally.
 Example failure:
 
 ```bash
-$ linkerd check --proxy --namespace foo
+linkerd check --proxy --namespace foo
 ```
 
 ```text {class=disable-copy}

--- a/linkerd.io/content/2.18/tasks/replacing_expired_certificates.md
+++ b/linkerd.io/content/2.18/tasks/replacing_expired_certificates.md
@@ -16,7 +16,7 @@ replace the expired certificates with valid certificates.
 It might be the case that your issuer certificate is expired. If this it true
 running `linkerd check --proxy` will produce output similar to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -41,7 +41,7 @@ replace both your root and issuer certificates at the same time. If your root
 has expired `linkerd check` will indicate that by outputting an error similar
 to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -75,7 +75,7 @@ If you run `linkerd check --proxy` while pods are restarting after the trust
 bundle is updated, you will probably see warnings about pods not having the
 current trust bundle:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -107,7 +107,7 @@ These warnings will disappear as restarts complete. Once they do, you can use
 configuration up to date. After that is done, `linkerd check` should run with no
 warnings or errors:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid

--- a/linkerd.io/content/2.18/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.18/tasks/troubleshooting.md
@@ -16,7 +16,7 @@ installation.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane namespace does not already exist
     The "linkerd" namespace already exists
 ```
@@ -34,7 +34,7 @@ linkerd check --pre --linkerd-namespace linkerd-test
 The subsequent checks in this section validate whether you have permission to
 create the Kubernetes resources required for Linkerd installation, specifically:
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -47,7 +47,7 @@ These checks only run when the `--pre` flag is set This flag is intended for use
 prior to running `linkerd install`, to verify you have the correct RBAC
 permissions to install Linkerd.
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -90,7 +90,7 @@ These checks only run when the `--pre` flag is set. This flag is intended for
 use prior to running `linkerd install`, to verify you have not already installed
 the Linkerd control plane.
 
-```bash
+```text {class=disable-copy}
 √ no ClusterRoles exist
 √ no ClusterRoleBindings exist
 √ no CustomResourceDefinitions exist
@@ -113,7 +113,7 @@ linkerd check --pre --single-namespace
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     error configuring Kubernetes API client: stat badconfig: no such file or directory
 × can query the Kubernetes API
@@ -139,8 +139,8 @@ kubectl version
 
 Another example failure:
 
-```bash
-✘ can query the Kubernetes API
+```text {class=disable-copy}
+× can query the Kubernetes API
     Get REDACTED/version: x509: certificate signed by unknown authority
 ```
 
@@ -157,7 +157,7 @@ kubectl config set-cluster ${KUBE_CONTEXT} --insecure-skip-tls-verify=true \
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum Kubernetes API version
     Kubernetes is on version [1.7.16], but version [1.13.0] or more recent is required
 ```
@@ -172,7 +172,7 @@ kubectl version
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum kubectl version
     kubectl is on version [1.9.1], but version [1.13.0] or more recent is required
     see https://linkerd.io/2/checks/#kubectl-version for hints
@@ -198,7 +198,7 @@ resources have been installed.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane Namespace exists
     The "foo" namespace does not exist
     see https://linkerd.io/2/checks/#l5d-existence-ns for hints
@@ -221,7 +221,7 @@ linkerd check --linkerd-namespace linkerdtest
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-cr for hints
@@ -248,7 +248,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-crb for hints
@@ -275,7 +275,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ServiceAccounts exist
     missing ServiceAccounts: linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-sa for hints
@@ -305,7 +305,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane CustomResourceDefinitions exist
     missing CustomResourceDefinitions: serviceprofiles.linkerd.io
     see https://linkerd.io/2/checks/#l5d-existence-crd for hints
@@ -330,7 +330,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane MutatingWebhookConfigurations exist
     missing MutatingWebhookConfigurations: linkerd-proxy-injector-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-mwc for hints
@@ -354,7 +354,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ValidatingWebhookConfigurations exist
     missing ValidatingWebhookConfigurations: linkerd-sp-validator-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-vwc for hints
@@ -378,7 +378,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × proxy-init container runs as root user if docker container runtime is used
     there are nodes using the docker container runtime and proxy-init container must run as root user.
 try installing linkerd via --set proxyInit.runAsRoot=true
@@ -409,7 +409,7 @@ further details.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × 'linkerd-config' config map exists
     missing ConfigMaps: linkerd-config
     see https://linkerd.io/2/checks/#l5d-existence-linkerd-config for hints
@@ -441,7 +441,7 @@ For more information, see the Kubernetes documentation on
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × no unschedulable pods
     linkerd-prometheus-6b668f774d-j8ncr: 0/1 nodes are available: 1 Insufficient cpu.
     see https://linkerd.io/2/checks/#l5d-existence-unschedulable-pods for hints
@@ -456,13 +456,13 @@ For more information, see the Kubernetes documentation on the
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key ca.crt containing the trust anchors needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=true
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
 ```
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key crt.pem containing the issuer certificate needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=false
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
@@ -478,7 +478,7 @@ keys are `crt.pem` and `key.pem`.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are using supported crypto algorithm
     Invalid roots:
         * 165223702412626077778653586125774349756 identity.linkerd.cluster.local must use P-256 curve for public key, instead P-521 was used
@@ -492,7 +492,7 @@ algorithm.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are within their validity period
     Invalid roots:
         * 199607941798581518463476688845828639279 identity.linkerd.cluster.local not valid anymore. Expired on 2019-12-19T13:08:18Z
@@ -509,7 +509,7 @@ cluster back to a stable state.
 
 Example warnings:
 
-```bash
+```text {class=disable-copy}
 ‼ trust roots are valid for at least 60 days
     Roots expiring soon:
         * 66509928892441932260491975092256847205 identity.linkerd.cluster.local will expire on 2019-12-19T13:30:57Z
@@ -525,7 +525,7 @@ process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is using supported crypto algorithm
     issuer certificate must use P-256 curve for public key, instead P-521 was used
     see https://linkerd.io/2/checks/#5d-identity-issuer-cert-uses-supported-crypto for hints
@@ -540,7 +540,7 @@ to see how you can generate certificates that will work with Linkerd.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is within its validity period
     issuer certificate is not valid anymore. Expired on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-is-time-valid
@@ -554,7 +554,7 @@ bring your cluster back to a valid state, follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ issuer cert is valid for at least 60 days
     issuer certificate will expire on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-not-expiring-soon for hints
@@ -569,7 +569,7 @@ follow the process outlined in
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is issued by the trust root
     x509: certificate signed by unknown authority (possibly because of "x509: ECDSA verification failure" while trying to verify candidate authority certificate "identity.linkerd.cluster.local")
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-issued-by-trust-anchor for hints
@@ -594,7 +594,7 @@ linkerd upgrade \
 Once the upgrade process is over, the output of `linkerd check --proxy` should
 be:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -617,7 +617,7 @@ linkerd-identity-data-plane
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     secrets "linkerd-proxy-injector-tls" not found
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -628,7 +628,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-proxy-injector-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-proxy-injector.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -641,7 +641,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ proxy-injector cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-not-expiring-soon for hints
@@ -656,7 +656,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     secrets "linkerd-sp-validator-tls" not found
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -667,7 +667,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-sp-validator-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-sp-validator.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -680,7 +680,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ sp-validator cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-not-expiring-soon for hints
@@ -695,7 +695,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × policy-validator webhook has valid cert
     secrets "linkerd-policy-validator-tls" not found
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-valid for hints
@@ -704,7 +704,7 @@ Example failure:
 Ensure that the `linkerd-policy-validator-k8s-tls` secret exists and contains
 the appropriate `tls.crt` and `tls.key` data entries.
 
-```bash
+```text {class=disable-copy}
 × policy-validator webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-policy-validator.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-valid for hints
@@ -717,7 +717,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ policy-validator cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-not-expiring-soon for hints
@@ -734,7 +734,7 @@ can follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
@@ -753,7 +753,7 @@ the Linkerd components are restarted. While this operation is in progress the
 `check --proxy` command may output a warning, pertaining to the Linkerd
 components:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
@@ -772,7 +772,7 @@ correct certificates.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane pods are ready
     No running pods for "linkerd-sp-validator"
 ```
@@ -791,7 +791,7 @@ linkerd-proxy-injector-67f8cf65f7-4tvt5   2/2     Running   1          12m
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cluster networks can be verified
     the following nodes do not expose a podCIDR:
         node-0
@@ -813,7 +813,7 @@ distribution being used.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × cluster networks contains all node podCIDRs
     node has podCIDR(s) [10.244.0.0/24] which are not contained in the Linkerd clusterNetworks.
     Try installing linkerd via --set clusterNetworks=10.244.0.0/24
@@ -830,12 +830,12 @@ this network may not be meshed properly. To remedy this, update the
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × the Linkerd clusterNetworks [10.244.0.0/24] do not include pod default/foo (104.21.63.202)
     see https://linkerd.io/2/checks/#l5d-cluster-networks-pods for hints
 ```
 
-```bash
+```text {class=disable-copy}
 × the Linkerd clusterNetworks [10.244.0.0/24] do not include svc default/bar (10.96.217.194)
     see https://linkerd.io/2/checks/#l5d-cluster-networks-pods for hints
 ```
@@ -853,7 +853,7 @@ networks in the cluster.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can determine the latest version
     Get https://versioncheck.linkerd.io/version.json?version=edge-19.1.2&uuid=test-uuid&source=cli: context deadline exceeded
 ```
@@ -872,7 +872,7 @@ Example failures:
 
 #### unsupported version channel
 
-```bash
+```text {class=disable-copy}
 ‼ cli is up-to-date
     unsupported version channel: stable-2.14.10
 ```
@@ -883,7 +883,7 @@ As of February 2024, the Linkerd project itself only produces
 
 #### is running version X but the latest version is Y
 
-```bash
+```text {class=disable-copy}
 ‼ cli is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ```
@@ -899,7 +899,7 @@ Example failures:
 
 #### unsupported version channel
 
-```bash
+```text {class=disable-copy}
 ‼ control plane is up-to-date
     unsupported version channel: stable-2.14.10
 ```
@@ -910,7 +910,7 @@ As of February 2024, the Linkerd project itself only produces
 
 #### is running version X but the latest version is Y
 
-```bash
+```text {class=disable-copy}
 ‼ control plane is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ```
@@ -922,7 +922,7 @@ There is a newer version of the control plane. See the page on
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ control plane and cli versions match
     mismatched channels: running stable-2.1.0 but retrieved edge-19.1.2
 ```
@@ -962,7 +962,9 @@ Example failure:
 
 ```bash
 $ linkerd check --proxy --namespace foo
-...
+```
+
+```text {class=disable-copy}
 × data plane namespace exists
     The "foo" namespace does not exist
 ```
@@ -974,7 +976,7 @@ namespaces.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxies are ready
     No "linkerd-proxy" containers found
 ```
@@ -990,7 +992,7 @@ in our [Getting Started](../getting-started/) guide.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane is up-to-date
     linkerd/linkerd-prometheus-74d66f86f6-6t6dh: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -999,7 +1001,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 ### √ data plane and cli versions match {#l5d-data-plane-cli-version}
 
-```bash
+```text {class=disable-copy}
 ‼ data plane and cli versions match
     linkerd/linkerd-identity-5f6c45d6d9-9hd9j: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -1010,7 +1012,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane pod labels are configured correctly
     Some labels on data plane pods should be annotations:
     * emojivoto/voting-ff4c54b8d-tv9pp
@@ -1024,7 +1026,7 @@ be annotations in order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service labels and annotations are configured correctly
     Some labels on data plane services should be annotations:
     * emojivoto/emoji-svc
@@ -1038,7 +1040,7 @@ order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service annotations are configured correctly
     Some annotations on data plane services should be labels:
     * emojivoto/emoji-svc
@@ -1051,7 +1053,7 @@ Example failure:
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × opaque ports are properly annotated
         * service emoji-svc targets the opaque port 8080 through 8080; add 8080 to its config.linkerd.io/opaque-ports annotation
     see https://linkerd.io/2/checks/#linkerd-opaque-ports-definition for hints
@@ -1075,7 +1077,7 @@ These checks are ran if Linkerd has been installed in HA mode.
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ multiple replicas of control plane pods
     not enough replicas available for [linkerd-identity]
     see https://linkerd.io/2/checks/#l5d-control-plane-replicas for hints
@@ -1117,7 +1119,7 @@ returns the healthchecks in the
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Linkerd command jaeger exists
 ```
 
@@ -1138,7 +1140,7 @@ resources are in place. If any of them are missing, you can use
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ConfigMap exists
     configmaps "linkerd-cni-config" not found
     see https://linkerd.io/2/checks/#cni-plugin-cm-exists for hints
@@ -1163,7 +1165,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRole exists
     missing ClusterRole: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-cr-exists for hints
@@ -1188,7 +1190,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRoleBinding exists
     missing ClusterRoleBinding: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-crb-exists for hints
@@ -1213,7 +1215,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ServiceAccount exists
     missing ServiceAccount: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-sa-exists for hints
@@ -1238,7 +1240,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin DaemonSet exists
     missing DaemonSet: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-ds-exists for hints
@@ -1263,7 +1265,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cni plugin pod is running on all nodes
     number ready: 2, number scheduled: 3
     see https://linkerd.io/2/checks/#cni-plugin-ready
@@ -1300,7 +1302,7 @@ possible between paired clusters.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link CRD exists
     multicluster.linkerd.io/Link CRD is missing
     see https://linkerd.io/2/checks/#l5d-multicluster-link-crd-exists for hints
@@ -1319,7 +1321,7 @@ links.multicluster.linkerd.io     2021-03-10T09:58:10Z
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link resources are valid
     failed to parse Link east
     see https://linkerd.io/2/checks/#l5d-multicluster-links-are-valid for hints
@@ -1342,7 +1344,7 @@ to do this.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × remote cluster access credentials are valid
     * secret [east/east-config]: could not find east-config secret
     see https://linkerd.io/2/checks/#l5d-smc-target-clusters-access for hints
@@ -1355,7 +1357,7 @@ target cluster is present as a secret correctly
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote
@@ -1366,7 +1368,7 @@ The error above indicates that your trust anchors are not compatible. In order
 to fix that you need to ensure that both your anchors contain identical sets of
 certificates.
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote: cannot parse trust anchors
@@ -1386,7 +1388,7 @@ linkerd --context=remote check
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controller has required permissions
     missing Service mirror ClusterRole linkerd-service-mirror-access-local-resources: unexpected verbs expected create,delete,get,list,update,watch, got create,delete,get,update,watch
     see https://linkerd.io/2/checks/#l5d-multicluster-source-rbac-correct for hints
@@ -1455,7 +1457,7 @@ metadata:
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controllers are running
     Service mirror controller is not present
     see https://linkerd.io/2/checks/#l5d-multicluster-service-mirror-running for hints
@@ -1475,7 +1477,7 @@ linkerd-service-mirror-7bb8ff5967-zg265   2/2       Running   0          50m
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 ‼ extension is managing controllers
             * using legacy service mirror controller for Link: target
     see https://linkerd.io/2/checks/#l5d-multicluster-managed-controllers for hints
@@ -1503,7 +1505,7 @@ grab the Lease object allowing them to take over service mirroring.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all gateway mirrors are healthy
     Some gateway mirrors do not have endpoints:
   linkerd-gateway-gke.linkerd-multicluster mirrored from cluster [gke]
@@ -1523,7 +1525,7 @@ service in target cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all mirror services have endpoints
     Some mirror services do not have endpoints:
   voting-svc-gke.emojivoto mirrored from cluster [gke] (gateway: [linkerd-multicluster/linkerd-gateway])
@@ -1544,7 +1546,7 @@ cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼  all mirror services are part of a Link
     mirror service voting-east.emojivoto is not part of any Link
     see https://linkerd.io/2/checks/#l5d-multicluster-orphaned-services for hints
@@ -1603,7 +1605,7 @@ for a full list of configurable fields.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1631,7 +1633,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-crb-exists for hints
@@ -1677,7 +1679,7 @@ sync by updating either the CLI or linkerd-viz as necessary.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     secrets "tap-k8s-tls" not found
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1688,7 +1690,7 @@ Ensure that the `tap-k8s-tls` secret exists and contains the appropriate
 named `linkerd-tap-tls` and it should contain the `crt.pem` and `key.pem` data
 entries.
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not tap.linkerd-viz.svc
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1701,7 +1703,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ tap API server cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-webhook-cert-not-expiring-soon for hints
@@ -1716,7 +1718,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × FailedDiscoveryCheck: no response from https://10.233.31.133:443: Get https://10.233.31.133:443: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
 ```
 
@@ -1732,7 +1734,7 @@ requirements in the cluster:
 
 ### √ linkerd-viz pods are injected {#l5d-viz-pods-injection}
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz extension pods are injected
     could not find proxy container for tap-59f5595fc7-ttndp pod
     see https://linkerd.io/2/checks/#l5d-viz-pods-injection for hints
@@ -1756,7 +1758,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ viz extension pods are running {#l5d-viz-pods-running}
 
-```bash
+```text {class=disable-copy}
 × viz extension pods are running
     container linkerd-proxy in pod tap-59f5595fc7-ttndp is not ready
     see https://linkerd.io/2/checks/#l5d-viz-pods-running for hints
@@ -1780,7 +1782,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ prometheus is installed and configured correctly {#l5d-viz-prometheus}
 
-```bash
+```text {class=disable-copy}
 × prometheus is installed and configured correctly
     missing ClusterRoles: linkerd-linkerd-viz-prometheus
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1789,12 +1791,12 @@ Make sure that the `proxy-injector` is working correctly by running
 Ensure all the prometheus related resources are present and running correctly.
 
 ```bash
-❯ kubectl -n linkerd-viz get deploy,cm | grep prometheus
+$ kubectl -n linkerd-viz get deploy,cm | grep prometheus
 deployment.apps/prometheus     1/1     1            1           3m18s
 configmap/prometheus-config   1      3m18s
-❯ kubectl get clusterRoleBindings | grep prometheus
+$ kubectl get clusterRoleBindings | grep prometheus
 linkerd-linkerd-viz-prometheus                         ClusterRole/linkerd-linkerd-viz-prometheus                         3m37s
-❯ kubectl get clusterRoles | grep prometheus
+$ kubectl get clusterRoles | grep prometheus
 linkerd-linkerd-viz-prometheus                                         2021-02-26T06:03:11Zh
 ```
 
@@ -1802,7 +1804,7 @@ linkerd-linkerd-viz-prometheus                                         2021-02-2
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     Failed to get deploy for pod metrics-api-77f684f7c7-hnw8r: not running
 ```
@@ -1810,7 +1812,7 @@ Example failure:
 Verify that the metrics API pod is running correctly
 
 ```bash
-❯ kubectl -n linkerd-viz get pods
+$ kubectl -n linkerd-viz get pods
 NAME                           READY   STATUS    RESTARTS   AGE
 metrics-api-7bb8cb8489-cbq4m   2/2     Running   0          4m58s
 tap-injector-6b9bc6fc4-cgbr4   2/2     Running   0          4m56s
@@ -1824,7 +1826,7 @@ prometheus-7c5c48c466-jc27g    2/2     Running   0          4m58s
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × viz extension self-check
     No results returned
 ```
@@ -1876,7 +1878,7 @@ be safely disregarded.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxy metrics are present in Prometheus
     Data plane metrics not found for linkerd/linkerd-identity-b8c4c48c8-pflc9.
 ```
@@ -1939,7 +1941,7 @@ versions in sync by updating either the CLI or linkerd-jaeger as necessary.
 
 ### √ jaeger extension pods are injected {#l5d-jaeger-pods-injection}
 
-```bash
+```text {class=disable-copy}
 × jaeger extension pods are injected
     could not find proxy container for jaeger-6f98d5c979-scqlq pod
     see https://linkerd.io/2/checks/#l5d-jaeger-pods-injections for hints
@@ -1960,7 +1962,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ jaeger extension pods are running {#l5d-jaeger-pods-running}
 
-```bash
+```text {class=disable-copy}
 × jaeger extension pods are running
     container linkerd-proxy in pod jaeger-59f5595fc7-ttndp is not ready
     see https://linkerd.io/2/checks/#l5d-jaeger-pods-running for hints
@@ -1988,7 +1990,7 @@ comprises `linkerd-buoyant` CLI, the `buoyant-cloud-agent` Deployment, and the
 
 ### √ Linkerd extension command linkerd-buoyant exists
 
-```bash
+```text {class=disable-copy}
 ‼ Linkerd extension command linkerd-buoyant exists
     exec: "linkerd-buoyant": executable file not found in $PATH
     see https://linkerd.io/2/checks/#extensions for hints
@@ -2008,7 +2010,7 @@ curl https://buoyant.cloud/install | sh
 
 ### √ linkerd-buoyant can determine the latest version
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant can determine the latest version
     Get "https://buoyant.cloud/version.json": dial tcp: lookup buoyant.cloud: no such host
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2024,7 +2026,7 @@ $ curl https://buoyant.cloud/version.json
 
 ### √ linkerd-buoyant cli is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant cli is up-to-date
     CLI version is v0.4.3 but the latest is v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2038,7 +2040,7 @@ curl https://buoyant.cloud/install | sh
 
 ### √ buoyant-cloud Namespace exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace exists
     namespaces "buoyant-cloud" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2059,7 +2061,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud Namespace has correct labels
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace has correct labels
     missing app.kubernetes.io/part-of label
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2074,7 +2076,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent ClusterRole exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRole exists
     missing ClusterRole: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2097,7 +2099,7 @@ yes
 
 ### √ buoyant-cloud-agent ClusterRoleBinding exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRoleBinding exists
     missing ClusterRoleBinding: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2120,7 +2122,7 @@ yes
 
 ### √ buoyant-cloud-agent ServiceAccount exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ServiceAccount exists
     missing ServiceAccount: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2143,7 +2145,7 @@ yes
 
 ### √ buoyant-cloud-id Secret exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-id Secret exists
     missing Secret: buoyant-cloud-id
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2166,7 +2168,7 @@ yes
 
 ### √ buoyant-cloud-agent Deployment exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment exists
     deployments.apps "buoyant-cloud-agent" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2187,7 +2189,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running
     no running pods for buoyant-cloud-agent Deployment
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2211,7 +2213,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-agent-6b8c6888d7-htr7d buoyant-cloud
 
 ### √ buoyant-cloud-agent Deployment is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2231,7 +2233,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-agent Deployment is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-agent Deployment is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2253,7 +2255,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running a single pod
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running a single pod
     expected 1 buoyant-cloud-agent pod, found 2
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2267,7 +2269,7 @@ kubectl get po -A --selector app=buoyant-cloud-agent
 
 ### √ buoyant-cloud-metrics DaemonSet exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet exists
     deployments.apps "buoyant-cloud-metrics" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2288,7 +2290,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-metrics DaemonSet is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is running
     no running pods for buoyant-cloud-metrics DaemonSet
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2315,7 +2317,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-metrics-kt9mv buoyant-cloud-metrics
 
 ### √ buoyant-cloud-metrics DaemonSet is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2338,7 +2340,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-metrics DaemonSet is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-metrics DaemonSet is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints

--- a/linkerd.io/content/2.18/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.18/tasks/troubleshooting.md
@@ -961,7 +961,7 @@ normally.
 Example failure:
 
 ```bash
-$ linkerd check --proxy --namespace foo
+linkerd check --proxy --namespace foo
 ```
 
 ```text {class=disable-copy}

--- a/linkerd.io/content/2.19/tasks/replacing_expired_certificates.md
+++ b/linkerd.io/content/2.19/tasks/replacing_expired_certificates.md
@@ -16,7 +16,7 @@ replace the expired certificates with valid certificates.
 It might be the case that your issuer certificate is expired. If this it true
 running `linkerd check --proxy` will produce output similar to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -41,7 +41,7 @@ replace both your root and issuer certificates at the same time. If your root
 has expired `linkerd check` will indicate that by outputting an error similar
 to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -75,7 +75,7 @@ If you run `linkerd check --proxy` while pods are restarting after the trust
 bundle is updated, you will probably see warnings about pods not having the
 current trust bundle:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -107,7 +107,7 @@ These warnings will disappear as restarts complete. Once they do, you can use
 configuration up to date. After that is done, `linkerd check` should run with no
 warnings or errors:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid

--- a/linkerd.io/content/2.19/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.19/tasks/troubleshooting.md
@@ -16,7 +16,7 @@ installation.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane namespace does not already exist
     The "linkerd" namespace already exists
 ```
@@ -34,7 +34,7 @@ linkerd check --pre --linkerd-namespace linkerd-test
 The subsequent checks in this section validate whether you have permission to
 create the Kubernetes resources required for Linkerd installation, specifically:
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -47,7 +47,7 @@ These checks only run when the `--pre` flag is set This flag is intended for use
 prior to running `linkerd install`, to verify you have the correct RBAC
 permissions to install Linkerd.
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -90,7 +90,7 @@ These checks only run when the `--pre` flag is set. This flag is intended for
 use prior to running `linkerd install`, to verify you have not already installed
 the Linkerd control plane.
 
-```bash
+```text {class=disable-copy}
 √ no ClusterRoles exist
 √ no ClusterRoleBindings exist
 √ no CustomResourceDefinitions exist
@@ -113,7 +113,7 @@ linkerd check --pre --single-namespace
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     error configuring Kubernetes API client: stat badconfig: no such file or directory
 × can query the Kubernetes API
@@ -139,8 +139,8 @@ kubectl version
 
 Another example failure:
 
-```bash
-✘ can query the Kubernetes API
+```text {class=disable-copy}
+× can query the Kubernetes API
     Get REDACTED/version: x509: certificate signed by unknown authority
 ```
 
@@ -157,7 +157,7 @@ kubectl config set-cluster ${KUBE_CONTEXT} --insecure-skip-tls-verify=true \
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum Kubernetes API version
     Kubernetes is on version [1.7.16], but version [1.13.0] or more recent is required
 ```
@@ -172,7 +172,7 @@ kubectl version
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum kubectl version
     kubectl is on version [1.9.1], but version [1.13.0] or more recent is required
     see https://linkerd.io/2/checks/#kubectl-version for hints
@@ -198,7 +198,7 @@ resources have been installed.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane Namespace exists
     The "foo" namespace does not exist
     see https://linkerd.io/2/checks/#l5d-existence-ns for hints
@@ -221,7 +221,7 @@ linkerd check --linkerd-namespace linkerdtest
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-cr for hints
@@ -248,7 +248,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-crb for hints
@@ -275,7 +275,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ServiceAccounts exist
     missing ServiceAccounts: linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-sa for hints
@@ -305,7 +305,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane CustomResourceDefinitions exist
     missing CustomResourceDefinitions: serviceprofiles.linkerd.io
     see https://linkerd.io/2/checks/#l5d-existence-crd for hints
@@ -330,7 +330,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane MutatingWebhookConfigurations exist
     missing MutatingWebhookConfigurations: linkerd-proxy-injector-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-mwc for hints
@@ -354,7 +354,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ValidatingWebhookConfigurations exist
     missing ValidatingWebhookConfigurations: linkerd-sp-validator-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-vwc for hints
@@ -378,7 +378,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × proxy-init container runs as root user if docker container runtime is used
     there are nodes using the docker container runtime and proxy-init container must run as root user.
 try installing linkerd via --set proxyInit.runAsRoot=true
@@ -409,7 +409,7 @@ further details.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × 'linkerd-config' config map exists
     missing ConfigMaps: linkerd-config
     see https://linkerd.io/2/checks/#l5d-existence-linkerd-config for hints
@@ -441,7 +441,7 @@ For more information, see the Kubernetes documentation on
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × no unschedulable pods
     linkerd-prometheus-6b668f774d-j8ncr: 0/1 nodes are available: 1 Insufficient cpu.
     see https://linkerd.io/2/checks/#l5d-existence-unschedulable-pods for hints
@@ -456,13 +456,13 @@ For more information, see the Kubernetes documentation on the
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key ca.crt containing the trust anchors needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=true
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
 ```
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key crt.pem containing the issuer certificate needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=false
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
@@ -478,7 +478,7 @@ keys are `crt.pem` and `key.pem`.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are using supported crypto algorithm
     Invalid roots:
         * 165223702412626077778653586125774349756 identity.linkerd.cluster.local must use P-256 curve for public key, instead P-521 was used
@@ -492,7 +492,7 @@ algorithm.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are within their validity period
     Invalid roots:
         * 199607941798581518463476688845828639279 identity.linkerd.cluster.local not valid anymore. Expired on 2019-12-19T13:08:18Z
@@ -509,7 +509,7 @@ cluster back to a stable state.
 
 Example warnings:
 
-```bash
+```text {class=disable-copy}
 ‼ trust roots are valid for at least 60 days
     Roots expiring soon:
         * 66509928892441932260491975092256847205 identity.linkerd.cluster.local will expire on 2019-12-19T13:30:57Z
@@ -525,7 +525,7 @@ process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is using supported crypto algorithm
     issuer certificate must use P-256 curve for public key, instead P-521 was used
     see https://linkerd.io/2/checks/#5d-identity-issuer-cert-uses-supported-crypto for hints
@@ -540,7 +540,7 @@ to see how you can generate certificates that will work with Linkerd.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is within its validity period
     issuer certificate is not valid anymore. Expired on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-is-time-valid
@@ -554,7 +554,7 @@ bring your cluster back to a valid state, follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ issuer cert is valid for at least 60 days
     issuer certificate will expire on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-not-expiring-soon for hints
@@ -569,7 +569,7 @@ follow the process outlined in
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is issued by the trust root
     x509: certificate signed by unknown authority (possibly because of "x509: ECDSA verification failure" while trying to verify candidate authority certificate "identity.linkerd.cluster.local")
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-issued-by-trust-anchor for hints
@@ -594,7 +594,7 @@ linkerd upgrade \
 Once the upgrade process is over, the output of `linkerd check --proxy` should
 be:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -617,7 +617,7 @@ linkerd-identity-data-plane
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     secrets "linkerd-proxy-injector-tls" not found
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -628,7 +628,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-proxy-injector-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-proxy-injector.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -641,7 +641,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ proxy-injector cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-not-expiring-soon for hints
@@ -656,7 +656,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     secrets "linkerd-sp-validator-tls" not found
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -667,7 +667,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-sp-validator-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-sp-validator.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -680,7 +680,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ sp-validator cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-not-expiring-soon for hints
@@ -695,7 +695,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × policy-validator webhook has valid cert
     secrets "linkerd-policy-validator-tls" not found
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-valid for hints
@@ -704,7 +704,7 @@ Example failure:
 Ensure that the `linkerd-policy-validator-k8s-tls` secret exists and contains
 the appropriate `tls.crt` and `tls.key` data entries.
 
-```bash
+```text {class=disable-copy}
 × policy-validator webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-policy-validator.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-valid for hints
@@ -717,7 +717,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ policy-validator cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-not-expiring-soon for hints
@@ -734,7 +734,7 @@ can follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
@@ -753,7 +753,7 @@ the Linkerd components are restarted. While this operation is in progress the
 `check --proxy` command may output a warning, pertaining to the Linkerd
 components:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
@@ -772,7 +772,7 @@ correct certificates.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane pods are ready
     No running pods for "linkerd-sp-validator"
 ```
@@ -791,7 +791,7 @@ linkerd-proxy-injector-67f8cf65f7-4tvt5   2/2     Running   1          12m
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cluster networks can be verified
     the following nodes do not expose a podCIDR:
         node-0
@@ -813,7 +813,7 @@ distribution being used.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × cluster networks contains all node podCIDRs
     node has podCIDR(s) [10.244.0.0/24] which are not contained in the Linkerd clusterNetworks.
     Try installing linkerd via --set clusterNetworks=10.244.0.0/24
@@ -830,12 +830,12 @@ this network may not be meshed properly. To remedy this, update the
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × the Linkerd clusterNetworks [10.244.0.0/24] do not include pod default/foo (104.21.63.202)
     see https://linkerd.io/2/checks/#l5d-cluster-networks-pods for hints
 ```
 
-```bash
+```text {class=disable-copy}
 × the Linkerd clusterNetworks [10.244.0.0/24] do not include svc default/bar (10.96.217.194)
     see https://linkerd.io/2/checks/#l5d-cluster-networks-pods for hints
 ```
@@ -853,7 +853,7 @@ networks in the cluster.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can determine the latest version
     Get https://versioncheck.linkerd.io/version.json?version=edge-19.1.2&uuid=test-uuid&source=cli: context deadline exceeded
 ```
@@ -872,7 +872,7 @@ Example failures:
 
 #### unsupported version channel
 
-```bash
+```text {class=disable-copy}
 ‼ cli is up-to-date
     unsupported version channel: stable-2.14.10
 ```
@@ -883,7 +883,7 @@ As of February 2024, the Linkerd project itself only produces
 
 #### is running version X but the latest version is Y
 
-```bash
+```text {class=disable-copy}
 ‼ cli is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ```
@@ -899,7 +899,7 @@ Example failures:
 
 #### unsupported version channel
 
-```bash
+```text {class=disable-copy}
 ‼ control plane is up-to-date
     unsupported version channel: stable-2.14.10
 ```
@@ -910,7 +910,7 @@ As of February 2024, the Linkerd project itself only produces
 
 #### is running version X but the latest version is Y
 
-```bash
+```text {class=disable-copy}
 ‼ control plane is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ```
@@ -922,7 +922,7 @@ There is a newer version of the control plane. See the page on
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ control plane and cli versions match
     mismatched channels: running stable-2.1.0 but retrieved edge-19.1.2
 ```
@@ -962,7 +962,9 @@ Example failure:
 
 ```bash
 $ linkerd check --proxy --namespace foo
-...
+```
+
+```text {class=disable-copy}
 × data plane namespace exists
     The "foo" namespace does not exist
 ```
@@ -974,7 +976,7 @@ namespaces.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxies are ready
     No "linkerd-proxy" containers found
 ```
@@ -990,7 +992,7 @@ in our [Getting Started](../getting-started/) guide.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane is up-to-date
     linkerd/linkerd-prometheus-74d66f86f6-6t6dh: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -999,7 +1001,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 ### √ data plane and cli versions match {#l5d-data-plane-cli-version}
 
-```bash
+```text {class=disable-copy}
 ‼ data plane and cli versions match
     linkerd/linkerd-identity-5f6c45d6d9-9hd9j: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -1010,7 +1012,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane pod labels are configured correctly
     Some labels on data plane pods should be annotations:
     * emojivoto/voting-ff4c54b8d-tv9pp
@@ -1024,7 +1026,7 @@ be annotations in order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service labels and annotations are configured correctly
     Some labels on data plane services should be annotations:
     * emojivoto/emoji-svc
@@ -1038,7 +1040,7 @@ order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service annotations are configured correctly
     Some annotations on data plane services should be labels:
     * emojivoto/emoji-svc
@@ -1051,7 +1053,7 @@ Example failure:
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × opaque ports are properly annotated
         * service emoji-svc targets the opaque port 8080 through 8080; add 8080 to its config.linkerd.io/opaque-ports annotation
     see https://linkerd.io/2/checks/#linkerd-opaque-ports-definition for hints
@@ -1075,7 +1077,7 @@ These checks are ran if Linkerd has been installed in HA mode.
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ multiple replicas of control plane pods
     not enough replicas available for [linkerd-identity]
     see https://linkerd.io/2/checks/#l5d-control-plane-replicas for hints
@@ -1117,7 +1119,7 @@ returns the healthchecks in the
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Linkerd command viz exists
 ```
 
@@ -1138,7 +1140,7 @@ resources are in place. If any of them are missing, you can use
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ConfigMap exists
     configmaps "linkerd-cni-config" not found
     see https://linkerd.io/2/checks/#cni-plugin-cm-exists for hints
@@ -1163,7 +1165,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRole exists
     missing ClusterRole: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-cr-exists for hints
@@ -1188,7 +1190,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRoleBinding exists
     missing ClusterRoleBinding: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-crb-exists for hints
@@ -1213,7 +1215,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ServiceAccount exists
     missing ServiceAccount: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-sa-exists for hints
@@ -1238,7 +1240,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin DaemonSet exists
     missing DaemonSet: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-ds-exists for hints
@@ -1263,7 +1265,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cni plugin pod is running on all nodes
     number ready: 2, number scheduled: 3
     see https://linkerd.io/2/checks/#cni-plugin-ready
@@ -1300,7 +1302,7 @@ possible between paired clusters.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link CRD exists
     multicluster.linkerd.io/Link CRD is missing
     see https://linkerd.io/2/checks/#l5d-multicluster-link-crd-exists for hints
@@ -1319,7 +1321,7 @@ links.multicluster.linkerd.io     2021-03-10T09:58:10Z
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link resources are valid
     failed to parse Link east
     see https://linkerd.io/2/checks/#l5d-multicluster-links-are-valid for hints
@@ -1342,7 +1344,7 @@ to do this.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × remote cluster access credentials are valid
     * secret [east/east-config]: could not find east-config secret
     see https://linkerd.io/2/checks/#l5d-smc-target-clusters-access for hints
@@ -1355,7 +1357,7 @@ target cluster is present as a secret correctly
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote
@@ -1366,7 +1368,7 @@ The error above indicates that your trust anchors are not compatible. In order
 to fix that you need to ensure that both your anchors contain identical sets of
 certificates.
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote: cannot parse trust anchors
@@ -1386,7 +1388,7 @@ linkerd --context=remote check
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controller has required permissions
     missing Service mirror ClusterRole linkerd-service-mirror-access-local-resources: unexpected verbs expected create,delete,get,list,update,watch, got create,delete,get,update,watch
     see https://linkerd.io/2/checks/#l5d-multicluster-source-rbac-correct for hints
@@ -1455,7 +1457,7 @@ metadata:
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controllers are running
     Service mirror controller is not present
     see https://linkerd.io/2/checks/#l5d-multicluster-service-mirror-running for hints
@@ -1475,7 +1477,7 @@ linkerd-service-mirror-7bb8ff5967-zg265   2/2       Running   0          50m
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 ‼ extension is managing controllers
             * using legacy service mirror controller for Link: target
     see https://linkerd.io/2/checks/#l5d-multicluster-managed-controllers for hints
@@ -1503,7 +1505,7 @@ grab the Lease object allowing them to take over service mirroring.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all gateway mirrors are healthy
     Some gateway mirrors do not have endpoints:
   linkerd-gateway-gke.linkerd-multicluster mirrored from cluster [gke]
@@ -1523,7 +1525,7 @@ service in target cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all mirror services have endpoints
     Some mirror services do not have endpoints:
   voting-svc-gke.emojivoto mirrored from cluster [gke] (gateway: [linkerd-multicluster/linkerd-gateway])
@@ -1544,7 +1546,7 @@ cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼  all mirror services are part of a Link
     mirror service voting-east.emojivoto is not part of any Link
     see https://linkerd.io/2/checks/#l5d-multicluster-orphaned-services for hints
@@ -1603,7 +1605,7 @@ for a full list of configurable fields.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1631,7 +1633,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-crb-exists for hints
@@ -1677,7 +1679,7 @@ sync by updating either the CLI or linkerd-viz as necessary.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     secrets "tap-k8s-tls" not found
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1688,7 +1690,7 @@ Ensure that the `tap-k8s-tls` secret exists and contains the appropriate
 named `linkerd-tap-tls` and it should contain the `crt.pem` and `key.pem` data
 entries.
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not tap.linkerd-viz.svc
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1701,7 +1703,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ tap API server cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-webhook-cert-not-expiring-soon for hints
@@ -1716,7 +1718,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × FailedDiscoveryCheck: no response from https://10.233.31.133:443: Get https://10.233.31.133:443: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
 ```
 
@@ -1732,7 +1734,7 @@ requirements in the cluster:
 
 ### √ linkerd-viz pods are injected {#l5d-viz-pods-injection}
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz extension pods are injected
     could not find proxy container for tap-59f5595fc7-ttndp pod
     see https://linkerd.io/2/checks/#l5d-viz-pods-injection for hints
@@ -1756,7 +1758,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ viz extension pods are running {#l5d-viz-pods-running}
 
-```bash
+```text {class=disable-copy}
 × viz extension pods are running
     container linkerd-proxy in pod tap-59f5595fc7-ttndp is not ready
     see https://linkerd.io/2/checks/#l5d-viz-pods-running for hints
@@ -1780,7 +1782,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ prometheus is installed and configured correctly {#l5d-viz-prometheus}
 
-```bash
+```text {class=disable-copy}
 × prometheus is installed and configured correctly
     missing ClusterRoles: linkerd-linkerd-viz-prometheus
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1789,12 +1791,12 @@ Make sure that the `proxy-injector` is working correctly by running
 Ensure all the prometheus related resources are present and running correctly.
 
 ```bash
-❯ kubectl -n linkerd-viz get deploy,cm | grep prometheus
+$ kubectl -n linkerd-viz get deploy,cm | grep prometheus
 deployment.apps/prometheus     1/1     1            1           3m18s
 configmap/prometheus-config   1      3m18s
-❯ kubectl get clusterRoleBindings | grep prometheus
+$ kubectl get clusterRoleBindings | grep prometheus
 linkerd-linkerd-viz-prometheus                         ClusterRole/linkerd-linkerd-viz-prometheus                         3m37s
-❯ kubectl get clusterRoles | grep prometheus
+$ kubectl get clusterRoles | grep prometheus
 linkerd-linkerd-viz-prometheus                                         2021-02-26T06:03:11Zh
 ```
 
@@ -1802,7 +1804,7 @@ linkerd-linkerd-viz-prometheus                                         2021-02-2
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     Failed to get deploy for pod metrics-api-77f684f7c7-hnw8r: not running
 ```
@@ -1810,7 +1812,7 @@ Example failure:
 Verify that the metrics API pod is running correctly
 
 ```bash
-❯ kubectl -n linkerd-viz get pods
+$ kubectl -n linkerd-viz get pods
 NAME                           READY   STATUS    RESTARTS   AGE
 metrics-api-7bb8cb8489-cbq4m   2/2     Running   0          4m58s
 tap-injector-6b9bc6fc4-cgbr4   2/2     Running   0          4m56s
@@ -1824,7 +1826,7 @@ prometheus-7c5c48c466-jc27g    2/2     Running   0          4m58s
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × viz extension self-check
     No results returned
 ```
@@ -1876,7 +1878,7 @@ be safely disregarded.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxy metrics are present in Prometheus
     Data plane metrics not found for linkerd/linkerd-identity-b8c4c48c8-pflc9.
 ```
@@ -1906,7 +1908,7 @@ comprises `linkerd-buoyant` CLI, the `buoyant-cloud-agent` Deployment, and the
 
 ### √ Linkerd extension command linkerd-buoyant exists
 
-```bash
+```text {class=disable-copy}
 ‼ Linkerd extension command linkerd-buoyant exists
     exec: "linkerd-buoyant": executable file not found in $PATH
     see https://linkerd.io/2/checks/#extensions for hints
@@ -1926,7 +1928,7 @@ curl https://buoyant.cloud/install | sh
 
 ### √ linkerd-buoyant can determine the latest version
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant can determine the latest version
     Get "https://buoyant.cloud/version.json": dial tcp: lookup buoyant.cloud: no such host
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1942,7 +1944,7 @@ $ curl https://buoyant.cloud/version.json
 
 ### √ linkerd-buoyant cli is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant cli is up-to-date
     CLI version is v0.4.3 but the latest is v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1956,7 +1958,7 @@ curl https://buoyant.cloud/install | sh
 
 ### √ buoyant-cloud Namespace exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace exists
     namespaces "buoyant-cloud" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1977,7 +1979,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud Namespace has correct labels
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace has correct labels
     missing app.kubernetes.io/part-of label
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1992,7 +1994,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent ClusterRole exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRole exists
     missing ClusterRole: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2015,7 +2017,7 @@ yes
 
 ### √ buoyant-cloud-agent ClusterRoleBinding exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRoleBinding exists
     missing ClusterRoleBinding: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2038,7 +2040,7 @@ yes
 
 ### √ buoyant-cloud-agent ServiceAccount exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ServiceAccount exists
     missing ServiceAccount: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2061,7 +2063,7 @@ yes
 
 ### √ buoyant-cloud-id Secret exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-id Secret exists
     missing Secret: buoyant-cloud-id
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2084,7 +2086,7 @@ yes
 
 ### √ buoyant-cloud-agent Deployment exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment exists
     deployments.apps "buoyant-cloud-agent" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2105,7 +2107,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running
     no running pods for buoyant-cloud-agent Deployment
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2129,7 +2131,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-agent-6b8c6888d7-htr7d buoyant-cloud
 
 ### √ buoyant-cloud-agent Deployment is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2149,7 +2151,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-agent Deployment is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-agent Deployment is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2171,7 +2173,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running a single pod
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running a single pod
     expected 1 buoyant-cloud-agent pod, found 2
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2185,7 +2187,7 @@ kubectl get po -A --selector app=buoyant-cloud-agent
 
 ### √ buoyant-cloud-metrics DaemonSet exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet exists
     deployments.apps "buoyant-cloud-metrics" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2206,7 +2208,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-metrics DaemonSet is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is running
     no running pods for buoyant-cloud-metrics DaemonSet
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2233,7 +2235,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-metrics-kt9mv buoyant-cloud-metrics
 
 ### √ buoyant-cloud-metrics DaemonSet is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2256,7 +2258,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-metrics DaemonSet is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-metrics DaemonSet is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints

--- a/linkerd.io/content/2.19/tasks/troubleshooting.md
+++ b/linkerd.io/content/2.19/tasks/troubleshooting.md
@@ -961,7 +961,7 @@ normally.
 Example failure:
 
 ```bash
-$ linkerd check --proxy --namespace foo
+linkerd check --proxy --namespace foo
 ```
 
 ```text {class=disable-copy}

--- a/linkerd.io/content/docs/tasks/replacing_expired_certificates.md
+++ b/linkerd.io/content/docs/tasks/replacing_expired_certificates.md
@@ -16,7 +16,7 @@ replace the expired certificates with valid certificates.
 It might be the case that your issuer certificate is expired. If this it true
 running `linkerd check --proxy` will produce output similar to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -41,7 +41,7 @@ replace both your root and issuer certificates at the same time. If your root
 has expired `linkerd check` will indicate that by outputting an error similar
 to:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -75,7 +75,7 @@ If you run `linkerd check --proxy` while pods are restarting after the trust
 bundle is updated, you will probably see warnings about pods not having the
 current trust bundle:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -107,7 +107,7 @@ These warnings will disappear as restarts complete. Once they do, you can use
 configuration up to date. After that is done, `linkerd check` should run with no
 warnings or errors:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid

--- a/linkerd.io/content/docs/tasks/troubleshooting.md
+++ b/linkerd.io/content/docs/tasks/troubleshooting.md
@@ -16,7 +16,7 @@ installation.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane namespace does not already exist
     The "linkerd" namespace already exists
 ```
@@ -34,7 +34,7 @@ linkerd check --pre --linkerd-namespace linkerd-test
 The subsequent checks in this section validate whether you have permission to
 create the Kubernetes resources required for Linkerd installation, specifically:
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -47,7 +47,7 @@ These checks only run when the `--pre` flag is set This flag is intended for use
 prior to running `linkerd install`, to verify you have the correct RBAC
 permissions to install Linkerd.
 
-```bash
+```text {class=disable-copy}
 √ can create Namespaces
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
@@ -90,7 +90,7 @@ These checks only run when the `--pre` flag is set. This flag is intended for
 use prior to running `linkerd install`, to verify you have not already installed
 the Linkerd control plane.
 
-```bash
+```text {class=disable-copy}
 √ no ClusterRoles exist
 √ no ClusterRoleBindings exist
 √ no CustomResourceDefinitions exist
@@ -113,7 +113,7 @@ linkerd check --pre --single-namespace
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     error configuring Kubernetes API client: stat badconfig: no such file or directory
 × can query the Kubernetes API
@@ -139,8 +139,8 @@ kubectl version
 
 Another example failure:
 
-```bash
-✘ can query the Kubernetes API
+```text {class=disable-copy}
+× can query the Kubernetes API
     Get REDACTED/version: x509: certificate signed by unknown authority
 ```
 
@@ -157,7 +157,7 @@ kubectl config set-cluster ${KUBE_CONTEXT} --insecure-skip-tls-verify=true \
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum Kubernetes API version
     Kubernetes is on version [1.7.16], but version [1.13.0] or more recent is required
 ```
@@ -172,7 +172,7 @@ kubectl version
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × is running the minimum kubectl version
     kubectl is on version [1.9.1], but version [1.13.0] or more recent is required
     see https://linkerd.io/2/checks/#kubectl-version for hints
@@ -198,7 +198,7 @@ resources have been installed.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane Namespace exists
     The "foo" namespace does not exist
     see https://linkerd.io/2/checks/#l5d-existence-ns for hints
@@ -221,7 +221,7 @@ linkerd check --linkerd-namespace linkerdtest
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-cr for hints
@@ -248,7 +248,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-crb for hints
@@ -275,7 +275,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ServiceAccounts exist
     missing ServiceAccounts: linkerd-identity
     see https://linkerd.io/2/checks/#l5d-existence-sa for hints
@@ -305,7 +305,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane CustomResourceDefinitions exist
     missing CustomResourceDefinitions: serviceprofiles.linkerd.io
     see https://linkerd.io/2/checks/#l5d-existence-crd for hints
@@ -330,7 +330,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane MutatingWebhookConfigurations exist
     missing MutatingWebhookConfigurations: linkerd-proxy-injector-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-mwc for hints
@@ -354,7 +354,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane ValidatingWebhookConfigurations exist
     missing ValidatingWebhookConfigurations: linkerd-sp-validator-webhook-config
     see https://linkerd.io/2/checks/#l5d-existence-vwc for hints
@@ -378,7 +378,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × proxy-init container runs as root user if docker container runtime is used
     there are nodes using the docker container runtime and proxy-init container must run as root user.
 try installing linkerd via --set proxyInit.runAsRoot=true
@@ -409,7 +409,7 @@ further details.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × 'linkerd-config' config map exists
     missing ConfigMaps: linkerd-config
     see https://linkerd.io/2/checks/#l5d-existence-linkerd-config for hints
@@ -441,7 +441,7 @@ For more information, see the Kubernetes documentation on
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × no unschedulable pods
     linkerd-prometheus-6b668f774d-j8ncr: 0/1 nodes are available: 1 Insufficient cpu.
     see https://linkerd.io/2/checks/#l5d-existence-unschedulable-pods for hints
@@ -456,13 +456,13 @@ For more information, see the Kubernetes documentation on the
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key ca.crt containing the trust anchors needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=true
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
 ```
 
-```bash
+```text {class=disable-copy}
 × certificate config is valid
     key crt.pem containing the issuer certificate needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=false
     see https://linkerd.io/2/checks/#l5d-identity-cert-config-valid
@@ -478,7 +478,7 @@ keys are `crt.pem` and `key.pem`.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are using supported crypto algorithm
     Invalid roots:
         * 165223702412626077778653586125774349756 identity.linkerd.cluster.local must use P-256 curve for public key, instead P-521 was used
@@ -492,7 +492,7 @@ algorithm.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × trust roots are within their validity period
     Invalid roots:
         * 199607941798581518463476688845828639279 identity.linkerd.cluster.local not valid anymore. Expired on 2019-12-19T13:08:18Z
@@ -509,7 +509,7 @@ cluster back to a stable state.
 
 Example warnings:
 
-```bash
+```text {class=disable-copy}
 ‼ trust roots are valid for at least 60 days
     Roots expiring soon:
         * 66509928892441932260491975092256847205 identity.linkerd.cluster.local will expire on 2019-12-19T13:30:57Z
@@ -525,7 +525,7 @@ process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is using supported crypto algorithm
     issuer certificate must use P-256 curve for public key, instead P-521 was used
     see https://linkerd.io/2/checks/#5d-identity-issuer-cert-uses-supported-crypto for hints
@@ -540,7 +540,7 @@ to see how you can generate certificates that will work with Linkerd.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is within its validity period
     issuer certificate is not valid anymore. Expired on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-is-time-valid
@@ -554,7 +554,7 @@ bring your cluster back to a valid state, follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ issuer cert is valid for at least 60 days
     issuer certificate will expire on 2019-12-19T13:35:49Z
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-not-expiring-soon for hints
@@ -569,7 +569,7 @@ follow the process outlined in
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × issuer cert is issued by the trust root
     x509: certificate signed by unknown authority (possibly because of "x509: ECDSA verification failure" while trying to verify candidate authority certificate "identity.linkerd.cluster.local")
     see https://linkerd.io/2/checks/#l5d-identity-issuer-cert-issued-by-trust-anchor for hints
@@ -594,7 +594,7 @@ linkerd upgrade \
 Once the upgrade process is over, the output of `linkerd check --proxy` should
 be:
 
-```bash
+```text {class=disable-copy}
 linkerd-identity
 ----------------
 √ certificate config is valid
@@ -617,7 +617,7 @@ linkerd-identity-data-plane
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     secrets "linkerd-proxy-injector-tls" not found
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -628,7 +628,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-proxy-injector-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × proxy-injector webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-proxy-injector.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-valid for hints
@@ -641,7 +641,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ proxy-injector cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-proxy-injector-webhook-cert-not-expiring-soon for hints
@@ -656,7 +656,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     secrets "linkerd-sp-validator-tls" not found
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -667,7 +667,7 @@ appropriate `tls.crt` and `tls.key` data entries. For versions before 2.9, the
 secret is named `linkerd-sp-validator-tls` and it should contain the `crt.pem`
 and `key.pem` data entries.
 
-```bash
+```text {class=disable-copy}
 × sp-validator webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-sp-validator.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-valid for hints
@@ -680,7 +680,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ sp-validator cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-sp-validator-webhook-cert-not-expiring-soon for hints
@@ -695,7 +695,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × policy-validator webhook has valid cert
     secrets "linkerd-policy-validator-tls" not found
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-valid for hints
@@ -704,7 +704,7 @@ Example failure:
 Ensure that the `linkerd-policy-validator-k8s-tls` secret exists and contains
 the appropriate `tls.crt` and `tls.key` data entries.
 
-```bash
+```text {class=disable-copy}
 × policy-validator webhook has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not linkerd-policy-validator.linkerd.svc
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-valid for hints
@@ -717,7 +717,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ policy-validator cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-policy-validator-webhook-cert-not-expiring-soon for hints
@@ -734,7 +734,7 @@ can follow the process outlined in
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * emojivoto/emoji-d8d7d9c6b-8qwfx
@@ -753,7 +753,7 @@ the Linkerd components are restarted. While this operation is in progress the
 `check --proxy` command may output a warning, pertaining to the Linkerd
 components:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane proxies certificate match CA
     Some pods do not have the current trust bundle and must be restarted:
         * linkerd/linkerd-sp-validator-75f9d96dc-rch4x
@@ -772,7 +772,7 @@ correct certificates.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × control plane pods are ready
     No running pods for "linkerd-sp-validator"
 ```
@@ -791,7 +791,7 @@ linkerd-proxy-injector-67f8cf65f7-4tvt5   2/2     Running   1          12m
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cluster networks can be verified
     the following nodes do not expose a podCIDR:
         node-0
@@ -813,7 +813,7 @@ distribution being used.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × cluster networks contains all node podCIDRs
     node has podCIDR(s) [10.244.0.0/24] which are not contained in the Linkerd clusterNetworks.
     Try installing linkerd via --set clusterNetworks=10.244.0.0/24
@@ -830,12 +830,12 @@ this network may not be meshed properly. To remedy this, update the
 
 Example failures:
 
-```bash
+```text {class=disable-copy}
 × the Linkerd clusterNetworks [10.244.0.0/24] do not include pod default/foo (104.21.63.202)
     see https://linkerd.io/2/checks/#l5d-cluster-networks-pods for hints
 ```
 
-```bash
+```text {class=disable-copy}
 × the Linkerd clusterNetworks [10.244.0.0/24] do not include svc default/bar (10.96.217.194)
     see https://linkerd.io/2/checks/#l5d-cluster-networks-pods for hints
 ```
@@ -853,7 +853,7 @@ networks in the cluster.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can determine the latest version
     Get https://versioncheck.linkerd.io/version.json?version=edge-19.1.2&uuid=test-uuid&source=cli: context deadline exceeded
 ```
@@ -872,7 +872,7 @@ Example failures:
 
 #### unsupported version channel
 
-```bash
+```text {class=disable-copy}
 ‼ cli is up-to-date
     unsupported version channel: stable-2.14.10
 ```
@@ -883,7 +883,7 @@ As of February 2024, the Linkerd project itself only produces
 
 #### is running version X but the latest version is Y
 
-```bash
+```text {class=disable-copy}
 ‼ cli is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ```
@@ -899,7 +899,7 @@ Example failures:
 
 #### unsupported version channel
 
-```bash
+```text {class=disable-copy}
 ‼ control plane is up-to-date
     unsupported version channel: stable-2.14.10
 ```
@@ -910,7 +910,7 @@ As of February 2024, the Linkerd project itself only produces
 
 #### is running version X but the latest version is Y
 
-```bash
+```text {class=disable-copy}
 ‼ control plane is up-to-date
     is running version 19.1.1 but the latest edge version is 19.1.2
 ```
@@ -922,7 +922,7 @@ There is a newer version of the control plane. See the page on
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ control plane and cli versions match
     mismatched channels: running stable-2.1.0 but retrieved edge-19.1.2
 ```
@@ -962,7 +962,9 @@ Example failure:
 
 ```bash
 $ linkerd check --proxy --namespace foo
-...
+```
+
+```text {class=disable-copy}
 × data plane namespace exists
     The "foo" namespace does not exist
 ```
@@ -974,7 +976,7 @@ namespaces.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxies are ready
     No "linkerd-proxy" containers found
 ```
@@ -990,7 +992,7 @@ in our [Getting Started](../getting-started/) guide.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane is up-to-date
     linkerd/linkerd-prometheus-74d66f86f6-6t6dh: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -999,7 +1001,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 ### √ data plane and cli versions match {#l5d-data-plane-cli-version}
 
-```bash
+```text {class=disable-copy}
 ‼ data plane and cli versions match
     linkerd/linkerd-identity-5f6c45d6d9-9hd9j: is running version 19.1.2 but the latest edge version is 19.1.3
 ```
@@ -1010,7 +1012,7 @@ See the page on [Upgrading Linkerd](upgrade/).
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane pod labels are configured correctly
     Some labels on data plane pods should be annotations:
     * emojivoto/voting-ff4c54b8d-tv9pp
@@ -1024,7 +1026,7 @@ be annotations in order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service labels and annotations are configured correctly
     Some labels on data plane services should be annotations:
     * emojivoto/emoji-svc
@@ -1038,7 +1040,7 @@ order to take effect.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ data plane service annotations are configured correctly
     Some annotations on data plane services should be labels:
     * emojivoto/emoji-svc
@@ -1051,7 +1053,7 @@ Example failure:
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × opaque ports are properly annotated
         * service emoji-svc targets the opaque port 8080 through 8080; add 8080 to its config.linkerd.io/opaque-ports annotation
     see https://linkerd.io/2/checks/#linkerd-opaque-ports-definition for hints
@@ -1075,7 +1077,7 @@ These checks are ran if Linkerd has been installed in HA mode.
 
 Example warning:
 
-```bash
+```text {class=disable-copy}
 ‼ multiple replicas of control plane pods
     not enough replicas available for [linkerd-identity]
     see https://linkerd.io/2/checks/#l5d-control-plane-replicas for hints
@@ -1117,7 +1119,7 @@ returns the healthchecks in the
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Linkerd command viz exists
 ```
 
@@ -1138,7 +1140,7 @@ resources are in place. If any of them are missing, you can use
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ConfigMap exists
     configmaps "linkerd-cni-config" not found
     see https://linkerd.io/2/checks/#cni-plugin-cm-exists for hints
@@ -1163,7 +1165,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRole exists
     missing ClusterRole: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-cr-exists for hints
@@ -1188,7 +1190,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ClusterRoleBinding exists
     missing ClusterRoleBinding: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-crb-exists for hints
@@ -1213,7 +1215,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin ServiceAccount exists
     missing ServiceAccount: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-sa-exists for hints
@@ -1238,7 +1240,7 @@ yes
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × cni plugin DaemonSet exists
     missing DaemonSet: linkerd-cni
     see https://linkerd.io/2/checks/#cni-plugin-ds-exists for hints
@@ -1263,7 +1265,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ cni plugin pod is running on all nodes
     number ready: 2, number scheduled: 3
     see https://linkerd.io/2/checks/#cni-plugin-ready
@@ -1300,7 +1302,7 @@ possible between paired clusters.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link CRD exists
     multicluster.linkerd.io/Link CRD is missing
     see https://linkerd.io/2/checks/#l5d-multicluster-link-crd-exists for hints
@@ -1319,7 +1321,7 @@ links.multicluster.linkerd.io     2021-03-10T09:58:10Z
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × Link resources are valid
     failed to parse Link east
     see https://linkerd.io/2/checks/#l5d-multicluster-links-are-valid for hints
@@ -1342,7 +1344,7 @@ to do this.
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × remote cluster access credentials are valid
     * secret [east/east-config]: could not find east-config secret
     see https://linkerd.io/2/checks/#l5d-smc-target-clusters-access for hints
@@ -1355,7 +1357,7 @@ target cluster is present as a secret correctly
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote
@@ -1366,7 +1368,7 @@ The error above indicates that your trust anchors are not compatible. In order
 to fix that you need to ensure that both your anchors contain identical sets of
 certificates.
 
-```bash
+```text {class=disable-copy}
 × clusters share trust anchors
     Problematic clusters:
         * remote: cannot parse trust anchors
@@ -1386,7 +1388,7 @@ linkerd --context=remote check
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controller has required permissions
     missing Service mirror ClusterRole linkerd-service-mirror-access-local-resources: unexpected verbs expected create,delete,get,list,update,watch, got create,delete,get,update,watch
     see https://linkerd.io/2/checks/#l5d-multicluster-source-rbac-correct for hints
@@ -1455,7 +1457,7 @@ metadata:
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 × service mirror controllers are running
     Service mirror controller is not present
     see https://linkerd.io/2/checks/#l5d-multicluster-service-mirror-running for hints
@@ -1475,7 +1477,7 @@ linkerd-service-mirror-7bb8ff5967-zg265   2/2       Running   0          50m
 
 Example error:
 
-```bash
+```text {class=disable-copy}
 ‼ extension is managing controllers
             * using legacy service mirror controller for Link: target
     see https://linkerd.io/2/checks/#l5d-multicluster-managed-controllers for hints
@@ -1503,7 +1505,7 @@ grab the Lease object allowing them to take over service mirroring.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all gateway mirrors are healthy
     Some gateway mirrors do not have endpoints:
   linkerd-gateway-gke.linkerd-multicluster mirrored from cluster [gke]
@@ -1523,7 +1525,7 @@ service in target cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼ all mirror services have endpoints
     Some mirror services do not have endpoints:
   voting-svc-gke.emojivoto mirrored from cluster [gke] (gateway: [linkerd-multicluster/linkerd-gateway])
@@ -1544,7 +1546,7 @@ cluster.
 
 Example errors:
 
-```bash
+```text {class=disable-copy}
 ‼  all mirror services are part of a Link
     mirror service voting-east.emojivoto is not part of any Link
     see https://linkerd.io/2/checks/#l5d-multicluster-orphaned-services for hints
@@ -1603,7 +1605,7 @@ for a full list of configurable fields.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoles exist
     missing ClusterRoles: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1631,7 +1633,7 @@ yes
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz ClusterRoleBindings exist
     missing ClusterRoleBindings: linkerd-linkerd-viz-metrics-api
     see https://linkerd.io/2/checks/#l5d-viz-crb-exists for hints
@@ -1677,7 +1679,7 @@ sync by updating either the CLI or linkerd-viz as necessary.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     secrets "tap-k8s-tls" not found
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1688,7 +1690,7 @@ Ensure that the `tap-k8s-tls` secret exists and contains the appropriate
 named `linkerd-tap-tls` and it should contain the `crt.pem` and `key.pem` data
 entries.
 
-```bash
+```text {class=disable-copy}
 × tap API server has valid cert
     cert is not issued by the trust anchor: x509: certificate is valid for xxxxxx, not tap.linkerd-viz.svc
     see https://linkerd.io/2/checks/#l5d-tap-cert-valid for hints
@@ -1701,7 +1703,7 @@ Here you need to make sure the certificate was issued specifically for
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 ‼ tap API server cert is valid for at least 60 days
     certificate will expire on 2020-11-07T17:00:07Z
     see https://linkerd.io/2/checks/#l5d-webhook-cert-not-expiring-soon for hints
@@ -1716,7 +1718,7 @@ can follow the process outlined in
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × FailedDiscoveryCheck: no response from https://10.233.31.133:443: Get https://10.233.31.133:443: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
 ```
 
@@ -1732,7 +1734,7 @@ requirements in the cluster:
 
 ### √ linkerd-viz pods are injected {#l5d-viz-pods-injection}
 
-```bash
+```text {class=disable-copy}
 × linkerd-viz extension pods are injected
     could not find proxy container for tap-59f5595fc7-ttndp pod
     see https://linkerd.io/2/checks/#l5d-viz-pods-injection for hints
@@ -1756,7 +1758,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ viz extension pods are running {#l5d-viz-pods-running}
 
-```bash
+```text {class=disable-copy}
 × viz extension pods are running
     container linkerd-proxy in pod tap-59f5595fc7-ttndp is not ready
     see https://linkerd.io/2/checks/#l5d-viz-pods-running for hints
@@ -1780,7 +1782,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ prometheus is installed and configured correctly {#l5d-viz-prometheus}
 
-```bash
+```text {class=disable-copy}
 × prometheus is installed and configured correctly
     missing ClusterRoles: linkerd-linkerd-viz-prometheus
     see https://linkerd.io/2/checks/#l5d-viz-cr-exists for hints
@@ -1789,12 +1791,12 @@ Make sure that the `proxy-injector` is working correctly by running
 Ensure all the prometheus related resources are present and running correctly.
 
 ```bash
-❯ kubectl -n linkerd-viz get deploy,cm | grep prometheus
+$ kubectl -n linkerd-viz get deploy,cm | grep prometheus
 deployment.apps/prometheus     1/1     1            1           3m18s
 configmap/prometheus-config   1      3m18s
-❯ kubectl get clusterRoleBindings | grep prometheus
+$ kubectl get clusterRoleBindings | grep prometheus
 linkerd-linkerd-viz-prometheus                         ClusterRole/linkerd-linkerd-viz-prometheus                         3m37s
-❯ kubectl get clusterRoles | grep prometheus
+$ kubectl get clusterRoles | grep prometheus
 linkerd-linkerd-viz-prometheus                                         2021-02-26T06:03:11Zh
 ```
 
@@ -1802,7 +1804,7 @@ linkerd-linkerd-viz-prometheus                                         2021-02-2
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × can initialize the client
     Failed to get deploy for pod metrics-api-77f684f7c7-hnw8r: not running
 ```
@@ -1810,7 +1812,7 @@ Example failure:
 Verify that the metrics API pod is running correctly
 
 ```bash
-❯ kubectl -n linkerd-viz get pods
+$ kubectl -n linkerd-viz get pods
 NAME                           READY   STATUS    RESTARTS   AGE
 metrics-api-7bb8cb8489-cbq4m   2/2     Running   0          4m58s
 tap-injector-6b9bc6fc4-cgbr4   2/2     Running   0          4m56s
@@ -1824,7 +1826,7 @@ prometheus-7c5c48c466-jc27g    2/2     Running   0          4m58s
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × viz extension self-check
     No results returned
 ```
@@ -1876,7 +1878,7 @@ be safely disregarded.
 
 Example failure:
 
-```bash
+```text {class=disable-copy}
 × data plane proxy metrics are present in Prometheus
     Data plane metrics not found for linkerd/linkerd-identity-b8c4c48c8-pflc9.
 ```
@@ -1906,7 +1908,7 @@ comprises `linkerd-buoyant` CLI, the `buoyant-cloud-agent` Deployment, and the
 
 ### √ Linkerd extension command linkerd-buoyant exists
 
-```bash
+```text {class=disable-copy}
 ‼ Linkerd extension command linkerd-buoyant exists
     exec: "linkerd-buoyant": executable file not found in $PATH
     see https://linkerd.io/2/checks/#extensions for hints
@@ -1926,7 +1928,7 @@ curl https://buoyant.cloud/install | sh
 
 ### √ linkerd-buoyant can determine the latest version
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant can determine the latest version
     Get "https://buoyant.cloud/version.json": dial tcp: lookup buoyant.cloud: no such host
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1942,7 +1944,7 @@ $ curl https://buoyant.cloud/version.json
 
 ### √ linkerd-buoyant cli is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ linkerd-buoyant cli is up-to-date
     CLI version is v0.4.3 but the latest is v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1956,7 +1958,7 @@ curl https://buoyant.cloud/install | sh
 
 ### √ buoyant-cloud Namespace exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace exists
     namespaces "buoyant-cloud" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1977,7 +1979,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud Namespace has correct labels
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud Namespace has correct labels
     missing app.kubernetes.io/part-of label
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -1992,7 +1994,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent ClusterRole exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRole exists
     missing ClusterRole: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2015,7 +2017,7 @@ yes
 
 ### √ buoyant-cloud-agent ClusterRoleBinding exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ClusterRoleBinding exists
     missing ClusterRoleBinding: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2038,7 +2040,7 @@ yes
 
 ### √ buoyant-cloud-agent ServiceAccount exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent ServiceAccount exists
     missing ServiceAccount: buoyant-cloud-agent
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2061,7 +2063,7 @@ yes
 
 ### √ buoyant-cloud-id Secret exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-id Secret exists
     missing Secret: buoyant-cloud-id
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2084,7 +2086,7 @@ yes
 
 ### √ buoyant-cloud-agent Deployment exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment exists
     deployments.apps "buoyant-cloud-agent" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2105,7 +2107,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running
     no running pods for buoyant-cloud-agent Deployment
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2129,7 +2131,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-agent-6b8c6888d7-htr7d buoyant-cloud
 
 ### √ buoyant-cloud-agent Deployment is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2149,7 +2151,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-agent Deployment is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-agent Deployment is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2171,7 +2173,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-agent Deployment is running a single pod
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-agent Deployment is running a single pod
     expected 1 buoyant-cloud-agent pod, found 2
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2185,7 +2187,7 @@ kubectl get po -A --selector app=buoyant-cloud-agent
 
 ### √ buoyant-cloud-metrics DaemonSet exists
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet exists
     deployments.apps "buoyant-cloud-metrics" not found
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2206,7 +2208,7 @@ linkerd-buoyant install | kubectl apply -f -
 
 ### √ buoyant-cloud-metrics DaemonSet is running
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is running
     no running pods for buoyant-cloud-metrics DaemonSet
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2233,7 +2235,7 @@ kubectl logs -n buoyant-cloud buoyant-cloud-metrics-kt9mv buoyant-cloud-metrics
 
 ### √ buoyant-cloud-metrics DaemonSet is injected
 
-```bash
+```text {class=disable-copy}
 × buoyant-cloud-metrics DaemonSet is injected
     could not find proxy container for buoyant-cloud-agent-6b8c6888d7-htr7d pod
     see https://linkerd.io/checks#l5d-buoyant for hints
@@ -2256,7 +2258,7 @@ Make sure that the `proxy-injector` is working correctly by running
 
 ### √ buoyant-cloud-metrics DaemonSet is up-to-date
 
-```bash
+```text {class=disable-copy}
 ‼ buoyant-cloud-metrics DaemonSet is up-to-date
     incorrect app.kubernetes.io/version label: v0.4.3, expected: v0.4.4
     see https://linkerd.io/checks#l5d-buoyant for hints

--- a/linkerd.io/content/docs/tasks/troubleshooting.md
+++ b/linkerd.io/content/docs/tasks/troubleshooting.md
@@ -961,7 +961,7 @@ normally.
 Example failure:
 
 ```bash
-$ linkerd check --proxy --namespace foo
+linkerd check --proxy --namespace foo
 ```
 
 ```text {class=disable-copy}


### PR DESCRIPTION
Currently, there are a lot of code blocks in the troubleshooting page that show examples of command output. These 
code blocks have the Bash language set, so the syntax highlighting doesn't make sense in a lot of cases. These code blocks also do not need a Copy button.

For example:
<img width="901" height="124" alt="Screenshot 2026-06-30 at 2 27 09 PM" src="https://github.com/user-attachments/assets/52df5f6c-8782-4177-8842-b0cf747d9075" />

This PR changes language of code blocks on command output examples from Bash to text, and disables the Copy button.

**Current**
https://linkerd.io/docs/tasks/troubleshooting/#kubectl-version

**Preview**
https://deploy-preview-2142--linkerdio.netlify.app/docs/tasks/troubleshooting/#kubectl-version