### PR TITLE
Add RFC 9116 security.txt to linkerd.io/static/.well-known/

### DIFF
--- a/linkerd.io/static/.well-known/security.txt
+++ b/linkerd.io/static/.well-known/security.txt
@@ -1,0 +1,6 @@
+# Linkerd security reporting — see https://github.com/linkerd/linkerd2/security/policy
+Contact: https://github.com/linkerd/linkerd2/security/advisories/new
+Expires: 2027-07-14T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://linkerd.io/.well-known/security.txt
+Policy: https://github.com/linkerd/linkerd2/security/policy


### PR DESCRIPTION
## What this does

Adds `/.well-known/security.txt` by placing it in `linkerd.io/static/.well-known/security.txt`, which Hugo copies verbatim to the published site root.

## Why

[RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) defines a standard file at `/.well-known/security.txt` so a security researcher can find where to report a vulnerability. Right now the live file is missing:

```
$ curl -sSL -o /dev/null -w '%{http_code}\n' https://linkerd.io/.well-known/security.txt
404
```

I pointed the file at the existing reporting flow rather than inventing anything:

- `Contact: https://github.com/linkerd/linkerd2/security/advisories/new` — the GitHub security advisory flow that `linkerd2`'s `SECURITY.md` asks reporters to use
- `Policy:` the linkerd2 security policy
- `Expires:` — RFC 9116 requires this field; I set it ~1 year out.

## Verifying it will serve

`linkerd.io/static/` is already served verbatim — e.g. `linkerd.io/static/images/logo-only-200h.png` is live at `https://linkerd.io/images/logo-only-200h.png` (200). So `linkerd.io/static/.well-known/security.txt` will publish at `https://linkerd.io/.well-known/security.txt`. Please double-check on a preview build.

Single file, no other changes. Commit is DCO signed-off.

---

*Disclosure: I used an AI tool to help spot this and draft the file. I verified every line myself against the live site and the linkerd2 `SECURITY.md`, and I take responsibility for the change. Happy to adjust the `Expires` date, contact, or policy link to whatever you prefer.*
