### PR TITLE
Fix broken Gateway API reference links

### DIFF
--- a/linkerd.io/content/2-edge/features/request-routing.md
+++ b/linkerd.io/content/2-edge/features/request-routing.md
@@ -14,7 +14,7 @@ This is an example of _client-side policy_, i.e. ways to dynamically configure
 Linkerd's behavior when it is sending requests from a meshed pod.
 
 Dynamic request routing is built on Kubernetes's Gateway API types, especially
-[HTTPRoute](https://gateway-api.sigs.k8s.io/api-types/httproute/).
+[HTTPRoute](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/).
 
 This feature extends Linkerd's traffic routing capabilities beyond those of
 [traffic splits](traffic-split/), which only provide percentage-based splits.

--- a/linkerd.io/content/2-edge/reference/grpcroute.md
+++ b/linkerd.io/content/2-edge/reference/grpcroute.md
@@ -15,7 +15,7 @@ part of [Linkerd's support for the Gateway API](../features/gateway-api/).
 
 The GRPCRoute resource is part of the Gateway API and is not Linkerd-specific.
 The canonical reference doc is the
-[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute//).
+[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute/).
 This page is intended as a _supplement_ to that doc, and will detail how this
 type is used by Linkerd specifically.
 

--- a/linkerd.io/content/2-edge/reference/grpcroute.md
+++ b/linkerd.io/content/2-edge/reference/grpcroute.md
@@ -15,7 +15,7 @@ part of [Linkerd's support for the Gateway API](../features/gateway-api/).
 
 The GRPCRoute resource is part of the Gateway API and is not Linkerd-specific.
 The canonical reference doc is the
-[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/api-types/grpcroute/).
+[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute//).
 This page is intended as a _supplement_ to that doc, and will detail how this
 type is used by Linkerd specifically.
 

--- a/linkerd.io/content/2-edge/reference/httproute.md
+++ b/linkerd.io/content/2-edge/reference/httproute.md
@@ -15,7 +15,7 @@ part of [Linkerd's support for the Gateway API](../features/gateway-api/).
 
 The HTTPRoute resource is part of the Gateway API and is not Linkerd-specific.
 The canonical reference doc is the
-[Gateway API HTTPRoute documentation](https://gateway-api.sigs.k8s.io/api-types/httproute/).
+[Gateway API HTTPRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/).
 This page is intended as a _supplement_ to that doc, and will detail how this
 type is used by Linkerd specifically.
 

--- a/linkerd.io/content/2-edge/reference/timeouts.md
+++ b/linkerd.io/content/2-edge/reference/timeouts.md
@@ -37,7 +37,7 @@ annotations.
   regardless of its state.
 
 If the
-[request timeout](https://gateway-api.sigs.k8s.io/api-types/httproute/#timeouts-optional)
+[request timeout](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/#timeouts-optional)
 field is set on an HTTPRoute resource, it will be used as the
 `timeout.linkerd.io/request` timeout. However, if both the field and the
 annotation are specified, the annotation will take priority.

--- a/linkerd.io/content/2.13/features/request-routing.md
+++ b/linkerd.io/content/2.13/features/request-routing.md
@@ -14,7 +14,7 @@ This is an example of _client-side policy_, i.e. ways to dynamically configure
 Linkerd's behavior when it is sending requests from a meshed pod.
 
 Dynamic request routing is built on Kubernetes's Gateway API types, especially
-[HTTPRoute](https://gateway-api.sigs.k8s.io/api-types/httproute/).
+[HTTPRoute](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/).
 
 This feature extends Linkerd's traffic routing capabilities beyond those of
 [traffic splits](traffic-split/), which only provide percentage-based splits.

--- a/linkerd.io/content/2.14/features/httproute.md
+++ b/linkerd.io/content/2.14/features/httproute.md
@@ -69,7 +69,7 @@ To get started with HTTPRoutes, you can:
 - See the [reference documentation](../reference/httproute/) for a complete
   description of the HTTPRoute resource.
 
-[HTTPRoute resource]: https://gateway-api.sigs.k8s.io/api-types/httproute/
+[HTTPRoute resource]: https://gateway-api.sigs.k8s.io/reference/api-types/httproute/
 [Gateway API]: https://gateway-api.sigs.k8s.io/
 [Service]: https://kubernetes.io/docs/concepts/services-networking/service/
 [Server]: ../reference/authorization-policy/#server

--- a/linkerd.io/content/2.14/features/request-routing.md
+++ b/linkerd.io/content/2.14/features/request-routing.md
@@ -14,7 +14,7 @@ This is an example of _client-side policy_, i.e. ways to dynamically configure
 Linkerd's behavior when it is sending requests from a meshed pod.
 
 Dynamic request routing is built on Kubernetes's Gateway API types, especially
-[HTTPRoute](https://gateway-api.sigs.k8s.io/api-types/httproute/).
+[HTTPRoute](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/).
 
 This feature extends Linkerd's traffic routing capabilities beyond those of
 [traffic splits](traffic-split/), which only provide percentage-based splits.

--- a/linkerd.io/content/2.15/features/httproute.md
+++ b/linkerd.io/content/2.15/features/httproute.md
@@ -69,7 +69,7 @@ To get started with HTTPRoutes, you can:
 - See the [reference documentation](../reference/httproute/) for a complete
   description of the HTTPRoute resource.
 
-[HTTPRoute resource]: https://gateway-api.sigs.k8s.io/api-types/httproute/
+[HTTPRoute resource]: https://gateway-api.sigs.k8s.io/reference/api-types/httproute/
 [Gateway API]: https://gateway-api.sigs.k8s.io/
 [Service]: https://kubernetes.io/docs/concepts/services-networking/service/
 [Server]: ../reference/authorization-policy/#server

--- a/linkerd.io/content/2.15/features/request-routing.md
+++ b/linkerd.io/content/2.15/features/request-routing.md
@@ -14,7 +14,7 @@ This is an example of _client-side policy_, i.e. ways to dynamically configure
 Linkerd's behavior when it is sending requests from a meshed pod.
 
 Dynamic request routing is built on Kubernetes's Gateway API types, especially
-[HTTPRoute](https://gateway-api.sigs.k8s.io/api-types/httproute/).
+[HTTPRoute](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/).
 
 This feature extends Linkerd's traffic routing capabilities beyond those of
 [traffic splits](traffic-split/), which only provide percentage-based splits.

--- a/linkerd.io/content/2.16/features/request-routing.md
+++ b/linkerd.io/content/2.16/features/request-routing.md
@@ -14,7 +14,7 @@ This is an example of _client-side policy_, i.e. ways to dynamically configure
 Linkerd's behavior when it is sending requests from a meshed pod.
 
 Dynamic request routing is built on Kubernetes's Gateway API types, especially
-[HTTPRoute](https://gateway-api.sigs.k8s.io/api-types/httproute/).
+[HTTPRoute](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/).
 
 This feature extends Linkerd's traffic routing capabilities beyond those of
 [traffic splits](traffic-split/), which only provide percentage-based splits.

--- a/linkerd.io/content/2.16/reference/grpcroute.md
+++ b/linkerd.io/content/2.16/reference/grpcroute.md
@@ -15,7 +15,7 @@ part of [Linkerd's support for the Gateway API](../features/gateway-api/).
 
 The GRPCRoute resource is part of the Gateway API and is not Linkerd-specific.
 The canonical reference doc is the
-[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute//).
+[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute/).
 This page is intended as a _supplement_ to that doc, and will detail how this
 type is used by Linkerd specifically.
 

--- a/linkerd.io/content/2.16/reference/grpcroute.md
+++ b/linkerd.io/content/2.16/reference/grpcroute.md
@@ -15,7 +15,7 @@ part of [Linkerd's support for the Gateway API](../features/gateway-api/).
 
 The GRPCRoute resource is part of the Gateway API and is not Linkerd-specific.
 The canonical reference doc is the
-[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/api-types/grpcroute/).
+[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute//).
 This page is intended as a _supplement_ to that doc, and will detail how this
 type is used by Linkerd specifically.
 

--- a/linkerd.io/content/2.16/reference/httproute.md
+++ b/linkerd.io/content/2.16/reference/httproute.md
@@ -15,7 +15,7 @@ part of [Linkerd's support for the Gateway API](../features/gateway-api/).
 
 The HTTPRoute resource is part of the Gateway API and is not Linkerd-specific.
 The canonical reference doc is the
-[Gateway API HTTPRoute documentation](https://gateway-api.sigs.k8s.io/api-types/httproute/).
+[Gateway API HTTPRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/).
 This page is intended as a _supplement_ to that doc, and will detail how this
 type is used by Linkerd specifically.
 

--- a/linkerd.io/content/2.16/reference/timeouts.md
+++ b/linkerd.io/content/2.16/reference/timeouts.md
@@ -37,7 +37,7 @@ annotations.
   regardless of its state.
 
 If the
-[request timeout](https://gateway-api.sigs.k8s.io/api-types/httproute/#timeouts-optional)
+[request timeout](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/#timeouts-optional)
 field is set on an HTTPRoute resource, it will be used as the
 `timeout.linkerd.io/request` timeout. However, if both the field and the
 annotation are specified, the annotation will take priority.

--- a/linkerd.io/content/2.17/features/request-routing.md
+++ b/linkerd.io/content/2.17/features/request-routing.md
@@ -14,7 +14,7 @@ This is an example of _client-side policy_, i.e. ways to dynamically configure
 Linkerd's behavior when it is sending requests from a meshed pod.
 
 Dynamic request routing is built on Kubernetes's Gateway API types, especially
-[HTTPRoute](https://gateway-api.sigs.k8s.io/api-types/httproute/).
+[HTTPRoute](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/).
 
 This feature extends Linkerd's traffic routing capabilities beyond those of
 [traffic splits](traffic-split/), which only provide percentage-based splits.

--- a/linkerd.io/content/2.17/reference/grpcroute.md
+++ b/linkerd.io/content/2.17/reference/grpcroute.md
@@ -15,7 +15,7 @@ part of [Linkerd's support for the Gateway API](../features/gateway-api/).
 
 The GRPCRoute resource is part of the Gateway API and is not Linkerd-specific.
 The canonical reference doc is the
-[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute//).
+[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute/).
 This page is intended as a _supplement_ to that doc, and will detail how this
 type is used by Linkerd specifically.
 

--- a/linkerd.io/content/2.17/reference/grpcroute.md
+++ b/linkerd.io/content/2.17/reference/grpcroute.md
@@ -15,7 +15,7 @@ part of [Linkerd's support for the Gateway API](../features/gateway-api/).
 
 The GRPCRoute resource is part of the Gateway API and is not Linkerd-specific.
 The canonical reference doc is the
-[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/api-types/grpcroute/).
+[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute//).
 This page is intended as a _supplement_ to that doc, and will detail how this
 type is used by Linkerd specifically.
 

--- a/linkerd.io/content/2.17/reference/httproute.md
+++ b/linkerd.io/content/2.17/reference/httproute.md
@@ -15,7 +15,7 @@ part of [Linkerd's support for the Gateway API](../features/gateway-api/).
 
 The HTTPRoute resource is part of the Gateway API and is not Linkerd-specific.
 The canonical reference doc is the
-[Gateway API HTTPRoute documentation](https://gateway-api.sigs.k8s.io/api-types/httproute/).
+[Gateway API HTTPRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/).
 This page is intended as a _supplement_ to that doc, and will detail how this
 type is used by Linkerd specifically.
 

--- a/linkerd.io/content/2.17/reference/timeouts.md
+++ b/linkerd.io/content/2.17/reference/timeouts.md
@@ -37,7 +37,7 @@ annotations.
   regardless of its state.
 
 If the
-[request timeout](https://gateway-api.sigs.k8s.io/api-types/httproute/#timeouts-optional)
+[request timeout](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/#timeouts-optional)
 field is set on an HTTPRoute resource, it will be used as the
 `timeout.linkerd.io/request` timeout. However, if both the field and the
 annotation are specified, the annotation will take priority.

--- a/linkerd.io/content/2.18/features/request-routing.md
+++ b/linkerd.io/content/2.18/features/request-routing.md
@@ -14,7 +14,7 @@ This is an example of _client-side policy_, i.e. ways to dynamically configure
 Linkerd's behavior when it is sending requests from a meshed pod.
 
 Dynamic request routing is built on Kubernetes's Gateway API types, especially
-[HTTPRoute](https://gateway-api.sigs.k8s.io/api-types/httproute/).
+[HTTPRoute](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/).
 
 This feature extends Linkerd's traffic routing capabilities beyond those of
 [traffic splits](traffic-split/), which only provide percentage-based splits.

--- a/linkerd.io/content/2.18/reference/grpcroute.md
+++ b/linkerd.io/content/2.18/reference/grpcroute.md
@@ -15,7 +15,7 @@ part of [Linkerd's support for the Gateway API](../features/gateway-api/).
 
 The GRPCRoute resource is part of the Gateway API and is not Linkerd-specific.
 The canonical reference doc is the
-[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute//).
+[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute/).
 This page is intended as a _supplement_ to that doc, and will detail how this
 type is used by Linkerd specifically.
 

--- a/linkerd.io/content/2.18/reference/grpcroute.md
+++ b/linkerd.io/content/2.18/reference/grpcroute.md
@@ -15,7 +15,7 @@ part of [Linkerd's support for the Gateway API](../features/gateway-api/).
 
 The GRPCRoute resource is part of the Gateway API and is not Linkerd-specific.
 The canonical reference doc is the
-[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/api-types/grpcroute/).
+[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute//).
 This page is intended as a _supplement_ to that doc, and will detail how this
 type is used by Linkerd specifically.
 

--- a/linkerd.io/content/2.18/reference/httproute.md
+++ b/linkerd.io/content/2.18/reference/httproute.md
@@ -15,7 +15,7 @@ part of [Linkerd's support for the Gateway API](../features/gateway-api/).
 
 The HTTPRoute resource is part of the Gateway API and is not Linkerd-specific.
 The canonical reference doc is the
-[Gateway API HTTPRoute documentation](https://gateway-api.sigs.k8s.io/api-types/httproute/).
+[Gateway API HTTPRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/).
 This page is intended as a _supplement_ to that doc, and will detail how this
 type is used by Linkerd specifically.
 

--- a/linkerd.io/content/2.18/reference/timeouts.md
+++ b/linkerd.io/content/2.18/reference/timeouts.md
@@ -37,7 +37,7 @@ annotations.
   regardless of its state.
 
 If the
-[request timeout](https://gateway-api.sigs.k8s.io/api-types/httproute/#timeouts-optional)
+[request timeout](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/#timeouts-optional)
 field is set on an HTTPRoute resource, it will be used as the
 `timeout.linkerd.io/request` timeout. However, if both the field and the
 annotation are specified, the annotation will take priority.

--- a/linkerd.io/content/2.19/features/request-routing.md
+++ b/linkerd.io/content/2.19/features/request-routing.md
@@ -14,7 +14,7 @@ This is an example of _client-side policy_, i.e. ways to dynamically configure
 Linkerd's behavior when it is sending requests from a meshed pod.
 
 Dynamic request routing is built on Kubernetes's Gateway API types, especially
-[HTTPRoute](https://gateway-api.sigs.k8s.io/api-types/httproute/).
+[HTTPRoute](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/).
 
 This feature extends Linkerd's traffic routing capabilities beyond those of
 [traffic splits](traffic-split/), which only provide percentage-based splits.

--- a/linkerd.io/content/2.19/reference/grpcroute.md
+++ b/linkerd.io/content/2.19/reference/grpcroute.md
@@ -15,7 +15,7 @@ part of [Linkerd's support for the Gateway API](../features/gateway-api/).
 
 The GRPCRoute resource is part of the Gateway API and is not Linkerd-specific.
 The canonical reference doc is the
-[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute//).
+[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute/).
 This page is intended as a _supplement_ to that doc, and will detail how this
 type is used by Linkerd specifically.
 

--- a/linkerd.io/content/2.19/reference/grpcroute.md
+++ b/linkerd.io/content/2.19/reference/grpcroute.md
@@ -15,7 +15,7 @@ part of [Linkerd's support for the Gateway API](../features/gateway-api/).
 
 The GRPCRoute resource is part of the Gateway API and is not Linkerd-specific.
 The canonical reference doc is the
-[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/api-types/grpcroute/).
+[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute//).
 This page is intended as a _supplement_ to that doc, and will detail how this
 type is used by Linkerd specifically.
 

--- a/linkerd.io/content/2.19/reference/httproute.md
+++ b/linkerd.io/content/2.19/reference/httproute.md
@@ -15,7 +15,7 @@ part of [Linkerd's support for the Gateway API](../features/gateway-api/).
 
 The HTTPRoute resource is part of the Gateway API and is not Linkerd-specific.
 The canonical reference doc is the
-[Gateway API HTTPRoute documentation](https://gateway-api.sigs.k8s.io/api-types/httproute/).
+[Gateway API HTTPRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/).
 This page is intended as a _supplement_ to that doc, and will detail how this
 type is used by Linkerd specifically.
 

--- a/linkerd.io/content/2.19/reference/timeouts.md
+++ b/linkerd.io/content/2.19/reference/timeouts.md
@@ -37,7 +37,7 @@ annotations.
   regardless of its state.
 
 If the
-[request timeout](https://gateway-api.sigs.k8s.io/api-types/httproute/#timeouts-optional)
+[request timeout](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/#timeouts-optional)
 field is set on an HTTPRoute resource, it will be used as the
 `timeout.linkerd.io/request` timeout. However, if both the field and the
 annotation are specified, the annotation will take priority.

--- a/linkerd.io/content/blog/2023/0807-edge-release-roundup/index.md
+++ b/linkerd.io/content/blog/2023/0807-edge-release-roundup/index.md
@@ -59,7 +59,7 @@ between [HTTPRoutes] and [ServiceProfiles]:
   header modifications for _requests_, and edge-23.7.3 added header
   modifications for _responses_).
 
-[HTTPRoutes]: https://gateway-api.sigs.k8s.io/api-types/httproute/
+[HTTPRoutes]: https://gateway-api.sigs.k8s.io/reference/api-types/httproute/
 [HTTPRoute standard]:
   https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRoute
 [ServiceProfiles]: /2.13/features/service-profiles/

--- a/linkerd.io/content/docs/features/request-routing.md
+++ b/linkerd.io/content/docs/features/request-routing.md
@@ -14,7 +14,7 @@ This is an example of _client-side policy_, i.e. ways to dynamically configure
 Linkerd's behavior when it is sending requests from a meshed pod.
 
 Dynamic request routing is built on Kubernetes's Gateway API types, especially
-[HTTPRoute](https://gateway-api.sigs.k8s.io/api-types/httproute/).
+[HTTPRoute](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/).
 
 This feature extends Linkerd's traffic routing capabilities beyond those of
 [traffic splits](traffic-split/), which only provide percentage-based splits.

--- a/linkerd.io/content/docs/reference/grpcroute.md
+++ b/linkerd.io/content/docs/reference/grpcroute.md
@@ -15,7 +15,7 @@ part of [Linkerd's support for the Gateway API](../features/gateway-api/).
 
 The GRPCRoute resource is part of the Gateway API and is not Linkerd-specific.
 The canonical reference doc is the
-[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute//).
+[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute/).
 This page is intended as a _supplement_ to that doc, and will detail how this
 type is used by Linkerd specifically.
 

--- a/linkerd.io/content/docs/reference/grpcroute.md
+++ b/linkerd.io/content/docs/reference/grpcroute.md
@@ -15,7 +15,7 @@ part of [Linkerd's support for the Gateway API](../features/gateway-api/).
 
 The GRPCRoute resource is part of the Gateway API and is not Linkerd-specific.
 The canonical reference doc is the
-[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/api-types/grpcroute/).
+[Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute//).
 This page is intended as a _supplement_ to that doc, and will detail how this
 type is used by Linkerd specifically.
 

--- a/linkerd.io/content/docs/reference/httproute.md
+++ b/linkerd.io/content/docs/reference/httproute.md
@@ -15,7 +15,7 @@ part of [Linkerd's support for the Gateway API](../features/gateway-api/).
 
 The HTTPRoute resource is part of the Gateway API and is not Linkerd-specific.
 The canonical reference doc is the
-[Gateway API HTTPRoute documentation](https://gateway-api.sigs.k8s.io/api-types/httproute/).
+[Gateway API HTTPRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/).
 This page is intended as a _supplement_ to that doc, and will detail how this
 type is used by Linkerd specifically.
 

--- a/linkerd.io/content/docs/reference/timeouts.md
+++ b/linkerd.io/content/docs/reference/timeouts.md
@@ -37,7 +37,7 @@ annotations.
   regardless of its state.
 
 If the
-[request timeout](https://gateway-api.sigs.k8s.io/api-types/httproute/#timeouts-optional)
+[request timeout](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/#timeouts-optional)
 field is set on an HTTPRoute resource, it will be used as the
 `timeout.linkerd.io/request` timeout. However, if both the field and the
 annotation are specified, the annotation will take priority.


### PR DESCRIPTION
Not a lot of magic here, just global search and replace -- Gateway API moved all the API type docs under `/reference/` kinda recently. 😛 

Signed-off-by: Flynn <flynn@buoyant.io>
